### PR TITLE
fix: Fix the problem that the popup layer will respond to keyboard ev…

### DIFF
--- a/components/Cascader/cascader.tsx
+++ b/components/Cascader/cascader.tsx
@@ -359,6 +359,9 @@ function Cascader<T extends OptionProps>(baseProps: CascaderProps<T>, ref) {
             props.onClear && props.onClear(!!popupVisible);
           }}
           onKeyDown={(e) => {
+            if (disabled) {
+              return;
+            }
             e.stopPropagation();
             const keyCode = e.keyCode || e.which;
             if (keyCode === Enter.code && !popupVisible) {

--- a/components/_class/select-view.tsx
+++ b/components/_class/select-view.tsx
@@ -451,7 +451,7 @@ export const SelectView = (props: SelectViewProps, ref) => {
     <div
       {...include(rest, ['onClick', 'onMouseEnter', 'onMouseLeave'])}
       ref={refWrapper}
-      tabIndex={0}
+      tabIndex={disabled ? -1 : 0}
       style={style}
       className={classNames}
       // When there is an input box, the keyboard events are handled inside the input box to avoid triggering redundant events in the Chinese input method


### PR DESCRIPTION
…ents and pop up when the `Cascader` component is disabled.

<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
- [ ] New feature
- [x] Bug fix
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change

## Background and context

<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

## Solution

<!-- Describe how the problem is fixed in detail -->

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|     Cascader      |修复 `Cascader` 组件在禁用时，弹出层会响应键盘事件并弹出的问题。|    Fix the problem that the popup layer will respond to keyboard events and pop up when the `Cascader` component is disabled.         |       close #15          |

## Checklist:

- [ ] Test suite passes (`npm run test`)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
