### PR TITLE
fix: When Typography children change (from less text to more text), they can not be folded up normally.

### DIFF
--- a/components/Typography/base.tsx
+++ b/components/Typography/base.tsx
@@ -109,6 +109,9 @@ function Base(props: BaseProps) {
   const [measuring, setMeasuring] = useState(false);
 
   const componentRef = useRef(null);
+  // Use the current attribute of useRef to obtain the latest children
+  const childrenRef = useRef(null);
+  childrenRef.current = children;
 
   const editableConfig = isObject(editable) ? editable : {};
   const mergedEditing = 'editing' in editableConfig ? editableConfig.editing : editing;
@@ -196,7 +199,7 @@ function Base(props: BaseProps) {
         componentRef.current,
         ellipsisConfig,
         renderOperations(!!ellipsisConfig.expandable),
-        children
+        childrenRef.current
       );
       setMeasuring(false);
       if (ellipsis && text) {


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
- [ ] New feature
- [x] Bug fix
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context

[Link to related open issues #37](https://github.com/arco-design/arco-design/issues/37)

## Solution

Use the current attribute of useRef to obtain the latest children

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|   Typography   |   修复Typography的children变化时(从文字少变成文字多)，无法正常收起  |  fix: When Typography children change (from less text to more text), they cannot be folded up normally.  |       [#37](https://github.com/arco-design/arco-design/issues/37)         |

## Checklist:

- [x] Test suite passes (`npm run test`)
- [x] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [x] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
