### PR TITLE
style: fix the problem that the style of the trigger-arrow does not w…

### DIFF
--- a/components/Menu/style/index.less
+++ b/components/Menu/style/index.less
@@ -391,9 +391,12 @@
       }
     }
 
-    .@{prefix}-dropdown-menu-dark ~ .@{prefix}-trigger-arrow {
-      background-color: @menu-dark-color-bg;
-      border-color: @menu-dark-color-bg;
+    .@{prefix}-dropdown-menu-dark ~ .@{prefix}-trigger-container {
+      
+      .@{prefix}-trigger-arrow {
+        background-color: @menu-dark-color-bg;
+        border-color: @menu-dark-color-bg;
+      }
     }
   }
 }

--- a/components/Menu/style/index.less
+++ b/components/Menu/style/index.less
@@ -391,7 +391,7 @@
       }
     }
 
-    .@{prefix}-dropdown-menu-dark ~ .@{prefix}-trigger-container {
+    .@{prefix}-dropdown-menu-dark ~ .@{prefix}-trigger-arrow-container {
       
       .@{prefix}-trigger-arrow {
         background-color: @menu-dark-color-bg;


### PR DESCRIPTION
## Types of changes

<!-- What types of changes does this PR introduce -->
- [ ] New feature
- [x] Bug fix
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context
the style of the trigger-arrow does not work under the black theme of the menu component

## Solution
solved this problem by update style file of menu.

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
| Menu | 修复Menu组件使用深色模式时点击更多菜单按钮弹出的气泡箭头颜色错误问题 | fix the problem that the style of the trigger-arrow does not work under the black theme of the menu component | #78 |

## Checklist:

- [x] Test suite passes (`npm run test`)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)