### PR TITLE
fix: avatar group shows +x when maxCount equals 0

### DIFF
--- a/components/Avatar/group.tsx
+++ b/components/Avatar/group.tsx
@@ -1,4 +1,5 @@
 import React, { useContext, forwardRef, PropsWithChildren } from 'react';
+import { isNumber } from '../_util/is';
 import cs from '../_util/classNames';
 import { ConfigContext } from '../ConfigProvider';
 import Avatar from './avatar';
@@ -40,7 +41,7 @@ function Group(baseProps: PropsWithChildren<AvatarGroupProps>, ref) {
   const avatarCount = childrenArr.length;
   let avatarsToRender = childrenArr;
 
-  if (maxCount && avatarCount > maxCount) {
+  if (isNumber(maxCount) && maxCount >= 0 && avatarCount > maxCount) {
     const avatarsInPopover = childrenArr.slice(maxCount);
     avatarsToRender = childrenArr.slice(0, maxCount);
     avatarsToRender.push(


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
- [ ] New feature
- [x] Bug fix
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context

<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->
closes #88 

## Solution

<!-- Describe how the problem is fixed in detail -->

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|Avatar|修复 `Avatar` 组件设置 `maxCount = 0` 时头像全部展示的问题。|Fix the bug that the `Avatar` component still show all avatars when set `maxCount = 0`.|close #88|

## Checklist:

- [x] Test suite passes (`npm run test`)
- [x] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [x] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
