### PR TITLE
fix:  className(menu-item-tooltip)  is overwritten when the tooltipPr…

### DIFF
--- a/components/Menu/item.tsx
+++ b/components/Menu/item.tsx
@@ -121,8 +121,11 @@ function Item(props: MenuItemProps, ref) {
       trigger="hover"
       content={<span>{children}</span>}
       position="right"
-      triggerProps={{ className: `${prefixCls}-item-tooltip` }}
-      {...tooltipProps}
+      triggerProps={{
+        className: `${prefixCls}-item-tooltip`,
+        ...(tooltipProps?.triggerProps || {}),
+      }}
+      {...omit(tooltipProps, ['triggerProps'])}
     >
       {itemElement}
     </Tooltip>


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
- [ ] New feature
- [x] Bug fix
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context
menu在pop模式，菜单收起状态下，传入包含 trrigerProps的tooltipProps属性时，只有一层的菜单项内的a标签样式错误  #98
<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

## Solution
保留内置类名，同时接受新属性
<!-- Describe how the problem is fixed in detail -->

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|     Menu      |    `Menu` 传入的 `tooltipProps` 包含 `triggerProps` 时，会覆盖原有的类名 `menu-item-tooltip`   | When the `tooltipProps` passed by `Menu` contains `triggerProps`, the original class name `menu-item-tooltip` will be overwrite  |          #98      |

## Checklist:

- [x] Test suite passes (`npm run test`)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
