### PR TITLE
docs: Modify the nested Form.Item example to make the error message more user-friendly.

### DIFF
--- a/components/Form/__demo__/shouldUpdate.md
+++ b/components/Form/__demo__/shouldUpdate.md
@@ -39,17 +39,21 @@ function Demo() {
           console.log(values);
         }}
       >
-        <Form.Item label="User" required>
-          <Grid.Row style={{flexWrap: 'nowrap'}}>
-            <Form.Item field="name" noStyle={{showErrorTip: true}} rules={[{ required: true, message: 'name is required' }]}>
-              <Input placeholder="please enter you username" />
-            </Form.Item>
-            <Form.Item field="age" noStyle={{showErrorTip: true}} rules={[{ required: true, message: 'age is required' }]}>
-              <Input placeholder="please enter your age" style={{marginLeft: 8}} />
-            </Form.Item>
+        <Form.Item label='User' required style={{ marginBottom: 0 }}>
+          <Grid.Row gutter={8}>
+            <Grid.Col span={12}>
+              <Form.Item field='name' rules={[{ required: true, message: 'name is required' }]}>
+                <Input placeholder='please enter you username' />
+              </Form.Item>
+            </Grid.Col>
+            <Grid.Col span={12}>
+              <Form.Item field='age' rules={[{ required: true, message: 'age is required' }]}>
+                <Input placeholder='please enter your age' />
+              </Form.Item>
+            </Grid.Col>
           </Grid.Row>
         </Form.Item>
-       <Form.Item label="Gender" required>
+        <Form.Item label="Gender" required>
           <Grid.Row align="center">
             <Form.Item field="gender" noStyle={{showErrorTip: true}} rules={[{ required: true, message: 'name is required' }]}>
               <Select options={['male', 'female', 'other']} placeholder="please enter you gender" style={{ flex: 1 }}/>


### PR DESCRIPTION
The current [example of nested Form.Item](https://arco.design/react/components/form#%E5%B5%8C%E5%A5%97%E6%8E%A7%E4%BB%B6) uses `noStyle={{showErrorTip: true}}` and `Grid.Row` to achieve the effect of two fields in one line, but with `noStyle={{showErrorTip: true}}` when both fields have errors, the errors are elevated to the parent `Form.Item`. It leads to a stacking of error messages that is not user-friendly. `Grid.Row` with a normal `Form.Item` can achieve the same effect, and the error message will appear under the corresponding `Form.

A sample of the modified version can be found at https://codepen.io/ignorancew/pen/vYJdrXw?editors=001.