### PR TITLE
feat: add a ellispsis in flex scene demo

### DIFF
--- a/components/Typography/__demo__/ellipsis-controlled.md
+++ b/components/Typography/__demo__/ellipsis-controlled.md
@@ -39,10 +39,10 @@ const Demo = () => {
           wrapperCol={{ span: 18 }}
           size="small"
         >
-          <Form.Item label="超出省略" field="ellipsis">
+          <Form.Item label="超出省略" field="ellipsis" triggerPropName="checked">
             <Switch />
           </Form.Item>
-          <Form.Item label="展开/折叠" field="expandable">
+          <Form.Item label="展开/折叠" field="expandable" triggerPropName="checked">
             <Switch />
           </Form.Item>
           <Form.Item label="省略号" field="ellipsisStr" initialValue={defaultConfig.ellipsisStr}>
@@ -79,11 +79,11 @@ const Demo = () => {
       </Space>
 
       <div>
-        <Typography.Text
+        <Typography.Paragraph
           ellipsis={ellipsis ? { rows: rows, expandable, suffix, ellipsisStr } : undefined}
         >
           {text}
-        </Typography.Text>
+        </Typography.Paragraph>
       </div>
     </>
   );

--- a/components/Typography/__demo__/ellipsis.md
+++ b/components/Typography/__demo__/ellipsis.md
@@ -9,13 +9,22 @@ title:
 
 在空间不足时省略多行文本内容。
 
+**注意**：父元素 `flex` 模式下， 省略的 `Typography` 的 `resize` 场景会收到影响，可以添加 `width: 100%` 使 `Typography` 充满整个父元素。
+
 ## en-US
 
 Omit multiple lines of text when there is insufficient space.
 
+**Note**: In the parent element `flex` mode, the omitted `Typography`'s `resize` scene will be affected. You can add `width: 100%` to make the `Typography` fill the entire parent element.
+
+
 ```js
 import { useState } from 'react';
-import { Typography, Switch } from '@arco-design/web-react';
+import { Typography, Switch, Tag } from '@arco-design/web-react';
+
+const mockText = 'A design is a plan or specification for the construction of an object or system or for the implementation of an activity or process, or the result of that plan or specification in the form of a prototype, product or process. The verb to design expresses the process of developing a design. The verb to design expresses the process of developing a design. A design is a plan or specification for the construction of an object or system or for the implementation of an activity or process, or the result of that plan or specification in the form of a prototype, product or process. The verb to design expresses the process of developing a design. The verb to design expresses the process of developing a design.'
+
+const mockTitle = ' A design is a plan or specification for the construction of an object or system or for the implementation of an activity or process.'
 
 const Demo = () => {
   const [ellipsis, setEllipsis] = useState(true);
@@ -26,69 +35,30 @@ const Demo = () => {
         onChange={() => {
           setEllipsis(!ellipsis);
         }}
-      ></Switch>
+      />
       <div>
         <Typography.Title heading={4} ellipsis={ellipsis}>
-          A design is a plan or specification for the construction of an object or system or for the
-          implementation of an activity or process.
+          {mockTitle}
         </Typography.Title>
-        <Typography.Paragraph ellipsis={ellipsis ? { rows: 2, showTooltip: true } : undefined}>
-          A design is a plan or specification for the construction of an object or system or for the
-          implementation of an activity or process, or the result of that plan or specification in
-          the form of a prototype, product or process. The verb to design expresses the process of
-          developing a design. The verb to design expresses the process of developing a design.A
-          design is a plan or specification for the construction of an object or system or for the
-          implementation of an activity or process, or the result of that plan or specification in
-          the form of a prototype, product or process. The verb to design expresses the process of
-          developing a design. The verb to design expresses the process of developing a design.
+        <Typography.Paragraph ellipsis={ellipsis ? { rows: 2, showTooltip: true, expandable: true } : undefined}>
+          {mockText}
         </Typography.Paragraph>
-        <Typography.Paragraph
-          ellipsis={
-            ellipsis
-              ? {
-                  suffix: '(Arco Design)',
-                  rows: 2,
-                  expandable: true,
-                  expandNodes: ['Less', 'More'],
-                  showTooltip: {
-                    type: 'popover',
-                    props: {
-                      style: { maxWidth: 500 },
-                    },
-                  },
-                }
-              : undefined
-          }
-        >
-          A design is a plan or specification for the construction of an object or system or for the
-          implementation of an activity or process, or the result of that plan or specification in
-          the form of a prototype, product or process. The verb to design expresses the process of
-          developing a design. The verb to design expresses the process of developing a design. A
-          design is a plan or specification for the construction of an object or system or for the
-          implementation of an activity or process, or the result of that plan or specification in
-          the form of a prototype, product or process. The verb to design expresses the process of
-          developing a design. The verb to design expresses the process of developing a design. 
-        </Typography.Paragraph>
-        <Typography.Paragraph
-          ellipsis={
-            ellipsis
-              ? {
-                  suffix: '(Arco Design)',
-                  rows: 2,
-                  expandable: true,
-                }
-              : undefined
-          }
-        >
-          A design is a plan or specification for the construction of an object or system or for the
-          implementation of an activity or process, or the result of that plan or specification in
-          the form of a prototype, product or process. The verb to design expresses the process of
-          developing a design. The verb to design expresses the process of developing a design. A
-          design is a plan or specification for the construction of an object or system or for the
-          implementation of an activity or process, or the result of that plan or specification in
-          the form of a prototype, product or process. The verb to design expresses the process of
-          developing a design. The verb to design expresses the process of developing a design. 
-        </Typography.Paragraph>
+      </div>
+
+      <div>
+        <Typography.Title style={{ width: '240px' }} heading={4}>
+          Ellipsis in flex scene
+        </Typography.Title>
+        <div style={{ display: 'flex' }}>
+          <Typography.Paragraph ellipsis={ellipsis} style={{ width: '100%' }}>
+            (width: 100%) {mockTitle}
+          </Typography.Paragraph>
+        </div>
+        <div style={{ display: 'flex' }}>
+          <Typography.Paragraph ellipsis={ellipsis}>
+            (width: normal) {mockTitle}
+          </Typography.Paragraph>
+        </div>
       </div>
     </>
   );

--- a/components/Typography/__test__/__snapshots__/demo.test.ts.snap
+++ b/components/Typography/__test__/__snapshots__/demo.test.ts.snap
@@ -145,22 +145,39 @@ Array [
     <h4
       class="arco-typography"
     >
-      A design is a plan or specification for the construction of an object or system or for the implementation of an activity or process.
+       A design is a plan or specification for the construction of an object or system or for the implementation of an activity or process.
     </h4>
     <div
       class="arco-typography"
     >
-      A design is a plan or specification for the construction of an object or system or for the implementation of an activity or process, or the result of that plan or specification in the form of a prototype, product or process. The verb to design expresses the process of developing a design. The verb to design expresses the process of developing a design.A design is a plan or specification for the construction of an object or system or for the implementation of an activity or process, or the result of that plan or specification in the form of a prototype, product or process. The verb to design expresses the process of developing a design. The verb to design expresses the process of developing a design.
+      A design is a plan or specification for the construction of an object or system or for the implementation of an activity or process, or the result of that plan or specification in the form of a prototype, product or process. The verb to design expresses the process of developing a design. The verb to design expresses the process of developing a design. A design is a plan or specification for the construction of an object or system or for the implementation of an activity or process, or the result of that plan or specification in the form of a prototype, product or process. The verb to design expresses the process of developing a design. The verb to design expresses the process of developing a design.
+    </div>
+  </div>,
+  <div>
+    <h4
+      class="arco-typography"
+      style="width:240px"
+    >
+      Ellipsis in flex scene
+    </h4>
+    <div
+      style="display:flex"
+    >
+      <div
+        class="arco-typography"
+        style="width:100%"
+      >
+        (width: 100%)  A design is a plan or specification for the construction of an object or system or for the implementation of an activity or process.
+      </div>
     </div>
     <div
-      class="arco-typography"
+      style="display:flex"
     >
-      A design is a plan or specification for the construction of an object or system or for the implementation of an activity or process, or the result of that plan or specification in the form of a prototype, product or process. The verb to design expresses the process of developing a design. The verb to design expresses the process of developing a design. A design is a plan or specification for the construction of an object or system or for the implementation of an activity or process, or the result of that plan or specification in the form of a prototype, product or process. The verb to design expresses the process of developing a design. The verb to design expresses the process of developing a design.(Arco Design)
-    </div>
-    <div
-      class="arco-typography"
-    >
-      A design is a plan or specification for the construction of an object or system or for the implementation of an activity or process, or the result of that plan or specification in the form of a prototype, product or process. The verb to design expresses the process of developing a design. The verb to design expresses the process of developing a design. A design is a plan or specification for the construction of an object or system or for the implementation of an activity or process, or the result of that plan or specification in the form of a prototype, product or process. The verb to design expresses the process of developing a design. The verb to design expresses the process of developing a design.(Arco Design)
+      <div
+        class="arco-typography"
+      >
+        (width: normal)  A design is a plan or specification for the construction of an object or system or for the implementation of an activity or process.
+      </div>
     </div>
   </div>,
 ]
@@ -479,13 +496,13 @@ Array [
     </div>
   </div>,
   <div>
-    <span
+    <div
       class="arco-typography"
     >
       A design is a plan or specification for the construction of an object or system or for the
 implementation of an activity or process. A design is a plan or specification for the
 construction of an object or system or for the implementation of an activity or process. 
-    </span>
+    </div>
   </div>,
 ]
 `;


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
- [ ] New feature
- [ ] Bug fix
- [x] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context
Flex will affect the width of the child element, causing the child element to not occupy all the space

## Solution
Manually add the style `width: 100%`, add a flex scene to the demo on the `Typography` component.

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
