### PR TITLE
Menu add property ellipsis

### DIFF
--- a/components/Menu/README.en-US.md
+++ b/components/Menu/README.en-US.md
@@ -24,6 +24,7 @@ A component to organize, arrange, and display a list of options.
 |collapse|Whether to collapse the menu horizontally|`boolean`|`-`|-|
 |accordion|Whether to render as Accordion|`boolean`|`-`|-|
 |selectable|Whether is the menu item selectable|`boolean`|`true`|-|
+|ellipsis|Whether the horizontal menu automatically collapses when it overflows|`boolean`|`true`|2.24.0|
 |autoScrollIntoView|Whether to automatically scroll the selected item to the visible area|`boolean`|`-`|-|
 |hasCollapseButton|Whether built-in folding button|`boolean`|`-`|-|
 |defaultSelectedKeys|The initially selected menu item's key array|`string[]`|`-`|-|

--- a/components/Menu/README.zh-CN.md
+++ b/components/Menu/README.zh-CN.md
@@ -24,6 +24,7 @@
 |collapse|是否水平折叠收起菜单|`boolean`|`-`|-|
 |accordion|开启手风琴效果|`boolean`|`-`|-|
 |selectable|菜单选项是否可选|`boolean`|`true`|-|
+|ellipsis|水平菜单是否自动溢出省略|`boolean`|`true`|2.24.0|
 |autoScrollIntoView|是否自动滚动选中项目到可见区域|`boolean`|`-`|-|
 |hasCollapseButton|是否内置折叠按钮|`boolean`|`-`|-|
 |defaultSelectedKeys|初始选中的菜单项 key 数组|`string[]`|`-`|-|

--- a/components/Menu/index.tsx
+++ b/components/Menu/index.tsx
@@ -22,6 +22,7 @@ const DEFAULT_THEME: MenuProps['theme'] = 'light';
 const defaultProps: MenuProps = {
   mode: 'vertical',
   selectable: true,
+  ellipsis: true,
 };
 
 function Menu(baseProps: MenuProps, ref) {
@@ -41,6 +42,7 @@ function Menu(baseProps: MenuProps, ref) {
     selectable,
     triggerProps,
     tooltipProps,
+    ellipsis,
     accordion,
     autoOpen,
     autoScrollIntoView,
@@ -115,7 +117,11 @@ function Menu(baseProps: MenuProps, ref) {
     return (
       <>
         <div className={`${prefixCls}-inner`}>
-          {mode === 'horizontal' ? <OverflowWrap>{childrenList}</OverflowWrap> : childrenList}
+          {mode === 'horizontal' && ellipsis !== false ? (
+            <OverflowWrap>{childrenList}</OverflowWrap>
+          ) : (
+            childrenList
+          )}
         </div>
 
         {mergedHasCollapseButton && (

--- a/components/Menu/interface.tsx
+++ b/components/Menu/interface.tsx
@@ -62,6 +62,13 @@ export interface MenuProps {
    */
   selectable?: boolean;
   /**
+   * @zh 水平菜单是否自动溢出省略
+   * @en Whether the horizontal menu automatically collapses when it overflows
+   * @defaultValue true
+   * @version 2.24.0
+   */
+  ellipsis?: boolean;
+  /**
    * @zh 是否自动滚动选中项目到可见区域
    * @en Whether to automatically scroll the selected item to the visible area
    */

--- a/components/Menu/overflow-wrap.tsx
+++ b/components/Menu/overflow-wrap.tsx
@@ -49,6 +49,10 @@ const OverflowWrap = (props: OverflowWrapProps) => {
   }, [children]);
 
   function computeLastVisibleIndex() {
+    if (!refUl.current) {
+      return;
+    }
+
     const ulElement = refUl.current;
     const maxWidth = getNodeWidth(ulElement) - OVERFLOW_THRESHOLD;
     const childNodeList = [].slice.call(ulElement.children);

--- a/components/Menu/style/index.less
+++ b/components/Menu/style/index.less
@@ -256,6 +256,7 @@
     .@{menu-prefix-cls}-pop {
       display: inline-block;
       vertical-align: middle;
+      flex-shrink: 0;
 
       &:not(:first-child) {
         margin-left: @menu-horizontal-item-gap;
@@ -392,7 +393,6 @@
     }
 
     .@{prefix}-dropdown-menu-dark ~ .@{prefix}-trigger-arrow-container {
-      
       .@{prefix}-trigger-arrow {
         background-color: @menu-dark-color-bg;
         border-color: @menu-dark-color-bg;


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
- [x] New feature
- [x] Bug fix
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context

Allow user to forbid horizontal Menu auto-wrap when items overflow.

<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

## Solution

Add  a new property `ellipsis`.

<!-- Describe how the problem is fixed in detail -->

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
| Menu | `Menu` 新增 `ellipsis` 属性以支持禁用水平菜单的菜单项自动折叠功能  |  `Menu` adds property `ellipsis` to forbid the automatic folding of menu items |  #60   |
| Menu | 修复 `Menu` 因为读取 `null` 的属性导致报错的 bug | Fix the bug that `Menu` caused an error because of reading an property of `null` | #101  |

## Checklist:

- [x] Test suite passes (`npm run test`)
- [x] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
