### PR TITLE
fix: The site page title compatible mobile media

### DIFF
--- a/site/src/style/page.less
+++ b/site/src/style/page.less
@@ -191,3 +191,9 @@
   box-sizing: border-box;
   padding-top: 200px;
 }
+
+@media screen and (max-width: 768px) {
+  .ac-nav-intro {
+    padding-right: 0;
+  }
+}


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
- [x] Bug fix
- [x] Coding style change

## Other information
When browsing on mobile device, the heading of docs that has 'ac-nav-intro' class is messy. 
![a49321be8085cf8120ec1757d5f640c](https://user-images.githubusercontent.com/33826386/140873782-db4d29ae-c577-4ef0-bdb9-9d5d3e19b055.jpg)

## Device
- iPhone 11 iOS15.0.1
- Safari