### PR TITLE
chore: storybook webpack config support to find the dependencies of t…

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -27,6 +27,7 @@ module.exports = {
     config.resolve.alias['@self/icon'] = path.resolve(__dirname, '../icon');
     config.resolve.alias['@self'] = path.resolve(__dirname, '../es');
 
+    config.resolve.modules = ['node_modules', path.resolve(__dirname, '../site/node_modules')];
     // 解决 webpack 编译警告
     config.module.rules[0].use[0].options.plugins.push([
       '@babel/plugin-proposal-private-property-in-object',


### PR DESCRIPTION
…he site folder

<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
- [ ] New feature
- [x] Bug fix
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [x] Others 

## Background and context
If the dependencies that are not in the root node_modules, the storybook compilation will report an error when `run demo`

## Solution
Modify the webpack configuration file of storybook to support getting dependencies from the site folder