### PR TITLE
fix: Menu.SubMenu's property priority is wrong

### DIFF
--- a/components/Menu/__test__/index.test.tsx
+++ b/components/Menu/__test__/index.test.tsx
@@ -335,4 +335,28 @@ describe('Menu', () => {
     component.update();
     expect(component.find('.arco-menu-item.arco-menu-active')).toHaveLength(0);
   });
+
+  it('SubMenu properties are passed in correctly', () => {
+    const component = mount(
+      <Menu
+        mode="vertical"
+        theme="dark"
+        style={{ width: 200 }}
+        defaultOpenKeys={['submenu', 'sub_submenu_1', 'sub_submenu_2']}
+      >
+        <SubMenu title="submenu" key="submenu" popup={false}>
+          <Menu.Item key="1">1</Menu.Item>
+          <SubMenu title="sub_submenu_1" key="sub_submenu_1">
+            <Menu.Item key="2">2</Menu.Item>
+          </SubMenu>
+          <SubMenu title="sub_submenu_2" key="sub_submenu_2" popup>
+            <Menu.Item key="3">3</Menu.Item>
+          </SubMenu>
+        </SubMenu>
+      </Menu>
+    );
+
+    expect(component.find('.arco-menu-item-inner')).toHaveLength(2);
+    expect(component.find('.arco-menu-pop-header').text()).toBe('sub_submenu_2');
+  });
 });

--- a/components/Menu/item-group.tsx
+++ b/components/Menu/item-group.tsx
@@ -6,14 +6,11 @@ import MenuContext from './context';
 import MenuIndent from './indent';
 
 function ItemGroup(props: MenuItemGroupProps, ref) {
-  const { children, title, level, className, style, _key } = props;
+  const { children, title, level, className, style } = props;
   const { prefixCls, levelIndent } = useContext(MenuContext);
 
   const childrenLevel = level === 1 ? level + 1 : level;
-  const childrenList = processChildren(children, {
-    _key,
-    level: childrenLevel,
-  });
+  const childrenList = processChildren(children, { level: childrenLevel });
 
   return (
     <div ref={ref} className={cs(`${prefixCls}-group`, className)} style={style}>

--- a/components/Menu/item.tsx
+++ b/components/Menu/item.tsx
@@ -8,6 +8,7 @@ import MenuContext from './context';
 import MenuIndent from './indent';
 import omit from '../_util/omit';
 import { useHotkeyHandler } from './hotkey';
+import { PROPS_NEED_TO_BE_PASSED_IN_SUBMENU } from './util';
 
 function Item(props: MenuItemProps, ref) {
   const {
@@ -92,7 +93,7 @@ function Item(props: MenuItemProps, ref) {
           clearHotkeyInfo();
         }
       }}
-      {...omit(rest, ['key', '_key', 'selectable', 'popup'])}
+      {...omit(rest, ['key', '_key'].concat(PROPS_NEED_TO_BE_PASSED_IN_SUBMENU))}
     >
       {needTextIndent && !collapse ? (
         <>

--- a/components/Menu/sub-menu/inline.tsx
+++ b/components/Menu/sub-menu/inline.tsx
@@ -4,10 +4,11 @@ import cs from '../../_util/classNames';
 import useStateWithPromise from '../../_util/hooks/useStateWithPromise';
 import { MenuSubMenuProps } from '../interface';
 import IconDown from '../../../icon/react-icon/IconDown';
-import { processChildren, isChildrenSelected } from '../util';
+import { processChildren, isChildrenSelected, PROPS_NEED_TO_BE_PASSED_IN_SUBMENU } from '../util';
 import MenuContext from '../context';
 import MenuIndent from '../indent';
 import { useHotkeyHandler } from '../hotkey';
+import pick from '../../_util/pick';
 
 const SubMenuInline = (props: MenuSubMenuProps & { forwardedRef }) => {
   const { _key, children, style, className, title, level, forwardedRef, ...rest } = props;
@@ -38,14 +39,12 @@ const SubMenuInline = (props: MenuSubMenuProps & { forwardedRef }) => {
     };
   }, []);
 
-  // 注意：此处 rest 中的属性会被 cloneElement 传递给 Menu.Item
-  // 当 SubMenuInline 增加了新的属性时，需要将其从 Menu.item 传递给 div 的属性中 omit
+  // Should omit these properties in Menu.Item
   const childrenList = processChildren(children, {
-    ...rest,
+    ...pick(rest, PROPS_NEED_TO_BE_PASSED_IN_SUBMENU),
     level: level + 1,
   });
 
-  // 根据level偏移
   const header = (
     <div
       className={cs(`${baseClassName}-header`, {

--- a/components/Menu/util.ts
+++ b/components/Menu/util.ts
@@ -9,7 +9,9 @@ export type MenuInfo = {
   disabled?: boolean;
 };
 
-// 将 MenuGroup 展开，得到仅含 MenuItem 和 SubMenu 的数组
+export const PROPS_NEED_TO_BE_PASSED_IN_SUBMENU = ['popup', 'triggerProps', 'selectable'];
+
+// Expand MenuGroup to get an array only contains MenuItem and SubMenu
 const flatMenuGroup = (children): ReactElement[] => {
   let validMenuItems = [];
 
@@ -105,6 +107,8 @@ export const processChildren = (
       ? item
       : React.cloneElement(item, {
           ...props,
+          // Properties of the component itself have higher priority
+          ...item.props,
           _key: item.key || `$menu-${index}`,
         });
   });

--- a/components/Progress/interface.ts
+++ b/components/Progress/interface.ts
@@ -36,9 +36,9 @@ export interface ProgressProps {
    */
   color?: string | { [key: string]: string };
   /**
- * @zh 剩余进度条颜色。
- * @en The rest of progress bar color.
- */
+   * @zh 剩余进度条颜色。
+   * @en The rest of progress bar color.
+   */
   trailColor?: string;
   /**
    * @zh 是否展示文本

--- a/components/Progress/line-progess.tsx
+++ b/components/Progress/line-progess.tsx
@@ -39,7 +39,7 @@ function LineProgress(props) {
     showText,
     bufferColor,
     formatText,
-    trailColor
+    trailColor,
   } = props;
 
   const strokeWidth = props.strokeWidth || defaultStrokeWidth[size];


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
- [ ] New feature
- [x] Bug fix
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context

`Menu.SubMenu`'s own properties should have the highest priority which should not be inherited from its parent.

<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

## Solution

Change `{ ...parentProps }` to `{ ...parentProps, ...selfProps }`.

## How is the change tested?

Add a new test case for it.

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
| Menu |  `Menu.SubMenu` 组件修复嵌套使用时，内层 `SubMenu` 属性被父 `SubMenu` 覆盖的 bug。    |   `Menu.SubMenu` component fixes the bug that the inner `SubMenu` property is overridden by the parent `SubMenu` when used in nesting.     |                |

## Checklist:

- [x] Test suite passes (`npm run test`)
- [x] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [x] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
