### PR TITLE
enhancement: Select allow user to define popup's max height in css files

### DIFF
--- a/components/Select/option.tsx
+++ b/components/Select/option.tsx
@@ -72,7 +72,11 @@ function Option(props: OptionProps, ref) {
     );
   }
 
-  return <li {...optionLabelProps}>{children}</li>;
+  return (
+    <li ref={ref} {...optionLabelProps}>
+      {children}
+    </li>
+  );
 }
 
 const OptionComponent = React.forwardRef<unknown, OptionProps>(Option);

--- a/components/Select/select.tsx
+++ b/components/Select/select.tsx
@@ -438,7 +438,7 @@ function Select(baseProps: SelectProps, ref) {
         className={cs(`${prefixCls}-popup-inner`, dropdownMenuClassName)}
         ref={refWrapper}
         data={childrenList}
-        height={200}
+        height={null}
         isStaticItemHeight={!hasOptGroup}
         measureLongestItem={needMeasureLongestItem}
         itemKey={(child) => child.props._key}


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
- [ ] New feature
- [x] Bug fix
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context

Users can not define Select's popup max height in css files.

<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

## Solution

Remove the inline style `max-height: 200px` in Select's popup container.

<!-- Describe how the problem is fixed in detail -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
| Select | `Select` 修复用户无法在 CSS 文件中覆盖弹窗高度的问题。     |    `Select` fixes the problem that users cannot cover the height of the pop-up window in the CSS file.    |                |
| Select | `Select` 修复单选时虚拟列表定位异常的 bug。 | `Select` Fix the problem of abnormal positioning of virtual list in single mode. | |
## Checklist:

- [x] Test suite passes (`npm run test`)
- [x] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [x] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
