### PR TITLE
fix: Trigger prevents mouse events before entered

### DIFF
--- a/components/Trigger/index.tsx
+++ b/components/Trigger/index.tsx
@@ -890,7 +890,7 @@ class Trigger extends PureComponent<TriggerProps, TriggerState> {
         mountOnEnter
         onEnter={(e) => {
           e.style.display = 'initial';
-          e.style.pointerEvents = 'auto';
+          e.style.pointerEvents = 'none';
           if (classNames === 'slideDynamicOrigin') {
             // 下拉菜单
             e.style.transform = this.getTransformTranslate();
@@ -902,7 +902,8 @@ class Trigger extends PureComponent<TriggerProps, TriggerState> {
             e.style.transform = '';
           }
         }}
-        onEntered={() => {
+        onEntered={(e) => {
+          e.style.pointerEvents = 'auto';
           this.forceUpdate();
         }}
         onExit={(e) => {


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
- [ ] New feature
- [x] Bug fix
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context

<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

## Solution

<!-- Describe how the problem is fixed in detail -->

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|      Trigger     |    修复 `Trigger` 组件在弹出层出现动画结束前错误触发弹出层鼠标事件的 bug。           |   Fixed a bug where the 'Trigger' component incorrectly triggered the pop-up mouse event before the animation ended.            |        close #126         |

## Checklist:

- [ ] Test suite passes (`npm run test`)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
