### PR TITLE
style: MenuItem hide text after icon when Menu is collapsed

### DIFF
--- a/components/Menu/style/index.less
+++ b/components/Menu/style/index.less
@@ -331,6 +331,15 @@
     .@{menu-prefix-cls}-icon-suffix {
       display: none;
     }
+
+    // Hide text after icon when menu is collapsed
+    @style-item-text: {
+      .@{prefix}-icon {
+        margin-right: 100%;
+      }
+    };
+
+    .applyStyleToItem(@style-item-text);
   }
 
   // 折叠按钮


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation change
- [ ] Coding style change
- [x] Component style change
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context

Hide the text after icon when Menu is collapsed.

<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
| Menu | `Menu` 组件折叠时隐藏菜单项图标后的文字，避免出现 `...` 。  |  Hide the text behind the menu item icon when the `Menu` component is collapsed to avoid display `...`. |                |

## Checklist:

- [ ] Test suite passes (`npm run test`)
- [x] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [x] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
