### PR TITLE
style: Table virtualized scroll bar style

### DIFF
--- a/components/Table/interface.tsx
+++ b/components/Table/interface.tsx
@@ -644,6 +644,7 @@ export interface TbodyProps<T = any> {
   stickyClassNames?: string[];
   getRowKey?: GetRowKeyType<T>;
   placeholder?: ReactNode;
+  saveVirtualWrapperRef?: (ref: HTMLDivElement) => void;
 }
 
 export interface TfootProps<T = any> {

--- a/components/Table/table.tsx
+++ b/components/Table/table.tsx
@@ -456,8 +456,10 @@ function Table<T extends unknown>(baseProps: TableProps<T>, ref: React.Ref<Table
     setFixedColumnClassNames();
     const root = getRootDomElement();
     if (root && (hasFixedColumn || (scroll && scroll.x))) {
-      const tableViewWidth = (root.querySelector(`.${prefixCls}-content-inner`) as HTMLElement)
-        .clientWidth;
+      const ele =
+        root.querySelector(`.${prefixCls}-body`) ||
+        root.querySelector(`.${prefixCls}-content-inner`);
+      const tableViewWidth = ele.clientWidth;
       setTableViewWidth(tableViewWidth);
     }
   }
@@ -646,7 +648,10 @@ function Table<T extends unknown>(baseProps: TableProps<T>, ref: React.Ref<Table
     // 根据 Tbody 决定 Thead 是否显示纵向滚动条
     // TODO: Remove
     setTimeout(() => {
-      const scrollBarWidth = getScrollBarWidth(refTableBody.current);
+      const scrollWrapper = virtualized
+        ? (refTableBody.current.children[0] as HTMLDivElement)
+        : refTableBody.current;
+      const scrollBarWidth = getScrollBarWidth(scrollWrapper);
       if (scrollBarWidth) {
         scrollbarChanged.current = true;
         wrapper.style.overflowY = 'scroll';
@@ -728,6 +733,11 @@ function Table<T extends unknown>(baseProps: TableProps<T>, ref: React.Ref<Table
       stickyOffsets={stickyOffsets}
       stickyClassNames={stickyClassNames}
       getRowKey={getRowKey}
+      saveVirtualWrapperRef={(ref: HTMLDivElement) => {
+        if (virtualized) {
+          refTableBody.current = ref;
+        }
+      }}
     />
   );
 

--- a/components/Table/tbody/index.tsx
+++ b/components/Table/tbody/index.tsx
@@ -24,6 +24,7 @@ function TBody<T>(props: TbodyProps<T>) {
     tableViewWidth,
     virtualized,
     getRowKey,
+    saveVirtualWrapperRef,
   } = props;
 
   const { ComponentTbody } = useComponent(components);
@@ -117,12 +118,12 @@ function TBody<T>(props: TbodyProps<T>) {
   );
 
   if (virtualized) {
-    if (data.length > 0) {
-      return (
-        <div className={`${prefixCls}-body`}>
+    return (
+      <div className={`${prefixCls}-body`} ref={(ref) => saveVirtualWrapperRef(ref)}>
+        {data.length > 0 ? (
           <VirtualList
             data={data}
-            height={scrollStyleY.maxHeight as number}
+            height={scrollStyleY.maxHeight}
             isStaticItemHeight={false}
             style={{ ...scrollStyleX, minWidth: '100%' }}
           >
@@ -130,14 +131,11 @@ function TBody<T>(props: TbodyProps<T>) {
               <Tr<T> {...trProps} key={getRowKey(child)} record={child} index={index} level={0} />
             )}
           </VirtualList>
-        </div>
-      );
-    }
-    return (
-      <div className={`${prefixCls}-body`}>
-        <table>
-          <tbody>{noDataTr}</tbody>
-        </table>
+        ) : (
+          <table>
+            <tbody>{noDataTr}</tbody>
+          </table>
+        )}
       </div>
     );
   }


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation change
- [ ] Coding style change
- [x] Component style change
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context

<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

## Solution

<!-- Describe how the problem is fixed in detail -->

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
| Table  | 修复 `Table` 组件在开启 `virtualized` 之后，当滚动条始终显示时表头出现错位的样式问题。  | Fix the style problem that the header of the `Table` component is misplaced when the scroll bar is always displayed after the `virtualized` is turned on.  | Close: https://github.com/arco-design/arco-design/issues/34 |

## Checklist:

- [x] Test suite passes (`npm run test`)
- [x] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [x] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
