### PR TITLE
fix(slider): slider wrong update value with two input case

### DIFF
--- a/components/Slider/index.tsx
+++ b/components/Slider/index.tsx
@@ -103,7 +103,7 @@ function Slider(baseProps: SliderProps, ref) {
     return range ? [beginVal, endVal] : endVal;
   }
 
-  function onChange(val) {
+  function updateValue(val) {
     let [newBeginVal, newEndVal] = val;
     newBeginVal = getLegalValue(newBeginVal);
     newEndVal = getLegalValue(newEndVal);
@@ -111,6 +111,11 @@ function Slider(baseProps: SliderProps, ref) {
     lastVal.current = [newBeginVal, newEndVal];
     const emitParams = getEmitParams([newBeginVal, newEndVal]);
     setValue(emitParams);
+    return emitParams;
+  }
+
+  function onChange(val) {
+    const emitParams = updateValue(val);
     if (isFunction(props.onChange)) {
       props.onChange(emitParams);
     }

--- a/components/Slider/input.tsx
+++ b/components/Slider/input.tsx
@@ -1,6 +1,6 @@
-import React, { memo } from 'react';
-import cs from '../_util/classNames';
+import React, { memo, useEffect, useState } from 'react';
 import InputNumber from '../InputNumber';
+import cs from '../_util/classNames';
 
 interface InputProps {
   min?: number;
@@ -10,7 +10,7 @@ interface InputProps {
   range?: boolean;
   disabled?: boolean;
   prefixCls?: string;
-  onChange: (val: number[]) => void;
+  onChange?: (val: number[]) => void;
 }
 
 const Input = function(props: InputProps) {
@@ -22,21 +22,31 @@ const Input = function(props: InputProps) {
     disabled,
     hideControl: true,
   };
-  const sortValue = [...value].sort((a, b) => a - b);
+  const [innerValue, setInnerValue] = useState(value);
+  useEffect(() => {
+    setInnerValue(value);
+  }, [value]);
 
-  function handleChange(val) {
-    onChange(val);
-  }
+  const handleChange = (val: number[]) => {
+    onChange?.(val);
+  };
+
+  const handleBlur = () => {
+    setInnerValue([...value].sort((a, b) => a - b));
+  };
 
   return (
-    <div className={cs(`${prefixCls}-input`, { [`${prefixCls}-input-group`]: range })}>
+    <div
+      className={cs(`${prefixCls}-input`, { [`${prefixCls}-input-group`]: range })}
+      onBlur={handleBlur}
+    >
       {range && [
         <InputNumber
-          value={sortValue[0]}
+          value={innerValue[0]}
           key={0}
           {...inputProps}
           onChange={(val) => {
-            handleChange([val, sortValue[1]]);
+            handleChange([val, innerValue[1]]);
           }}
         />,
         <div key={1} className={`${prefixCls}-input-range`}>
@@ -45,10 +55,10 @@ const Input = function(props: InputProps) {
       ]}
       <InputNumber
         key={2}
-        value={sortValue[1]}
+        value={innerValue[1]}
         {...inputProps}
         onChange={(val) => {
-          handleChange([sortValue[0], val]);
+          handleChange([innerValue[0], val]);
         }}
       />
     </div>


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
- [x] Bug fix

## Background and context

CLOSE #198 

<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

## Solution

- change value on input blur instead of on input change


https://user-images.githubusercontent.com/27187946/142857686-fbd34fc0-3d5d-4e32-8b23-441929027a4e.mp4

- if initial value is `[0, 0]`, there is a bug using input to change slider

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

add unit test if needed

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|      Slider     |     Bug fix          |      Bug fix         |        #198         |

## Checklist:

- [x] Test suite passes (`npm run test`)
- [x] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [x] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
