### PR TITLE
enhancement: AutoComplete onPressEnter add a new parameter activeOption

### DIFF
--- a/components/AutoComplete/index.tsx
+++ b/components/AutoComplete/index.tsx
@@ -3,7 +3,7 @@ import cs from '../_util/classNames';
 import Input from '../Input';
 import { ConfigContext } from '../ConfigProvider';
 import useMergeValue from '../_util/hooks/useMergeValue';
-import Select from '../Select/select';
+import Select, { SelectHandle } from '../Select/select';
 import { OptionInfo, SelectProps } from '../Select/interface';
 import { isSelectOption, isSelectOptGroup } from '../Select/utils';
 import { Enter, Esc } from '../_util/keycode';
@@ -63,7 +63,7 @@ function AutoComplete(baseProps: AutoCompleteProps, ref) {
   const [isFocused, setIsFocused] = useState(false);
 
   const refInput = useRef(null);
-  const refSelect = useRef(null);
+  const refSelect = useRef<SelectHandle>(null);
 
   const prefixCls = getPrefixCls('autocomplete');
   const filterOption =
@@ -139,9 +139,17 @@ function AutoComplete(baseProps: AutoCompleteProps, ref) {
     onKeyDown: (event) => {
       const keyCode = event.keyCode || event.which;
       refSelect.current && refSelect.current.hotkeyHandler(event);
-      if (keyCode === Enter.code) {
-        onPressEnter && onPressEnter(event);
+
+      if (keyCode === Enter.code && onPressEnter) {
+        let activeOption;
+        if (refSelect.current) {
+          activeOption = refSelect.current.getOptionInfoByValue(
+            refSelect.current.activeOptionValue
+          );
+        }
+        onPressEnter(event, activeOption);
       }
+
       if (keyCode === Esc.code) {
         refInput.current && refInput.current.blur && refInput.current.blur();
       }

--- a/components/AutoComplete/interface.ts
+++ b/components/AutoComplete/interface.ts
@@ -94,8 +94,9 @@ export interface AutoCompleteProps extends PartialSelectProps {
   /**
    * @zh 按下回车键的回调
    * @en Callback when Enter is pressed
+   * @version `activeOption` in 2.25.1
    */
-  onPressEnter?: (event) => void;
+  onPressEnter?: (event, activeOption?: OptionInfo) => void;
   /**
    * @zh 聚焦时的回调
    * @en Callback when component gets focus


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [x] Performance improvement
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context

<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

## Solution

Add a new parameter of `onPressEnter` callback.

<!-- Describe how the problem is fixed in detail -->

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
| AutoComplete |  `AutoComplete` 组件 `onPressEnter` 回调新增 `activeOption` 参数以区分回车键按下时下拉列表是否存在激活的选项。 | `AutoComplete`'s property `onPressEnter` adds the `activeOption` parameter to distinguish whether there is an active option in the drop-down list when the Enter key is pressed. | #197  |

## Checklist:

- [x] Test suite passes (`npm run test`)
- [x] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [x] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
