### PR TITLE
fix: the timing of tree onExpandEnd trigger

### DIFF
--- a/components/Tree/animation.tsx
+++ b/components/Tree/animation.tsx
@@ -84,6 +84,14 @@ const TreeAnimation = (props: PropsWithChildren<NodeProps>) => {
   let realHeight = treeContext.virtualListProps?.height;
   realHeight = isNumber(realHeight) ? realHeight : 0;
 
+  useEffect(() => {
+    // node set loadingMore but has no child nodes.
+    // Animation will not be triggered and needs to be removed manually
+    if (currentExpandKeys.indexOf(props._key) > -1 && filtedData.length === 0) {
+      treeContext.onExpandEnd(props._key);
+    }
+  }, [filtedData, currentExpandKeys]);
+
   return (
     <CSSTransition
       in={currentExpandKeys.indexOf(props._key) > -1 && filtedData.length > 0}
@@ -99,7 +107,6 @@ const TreeAnimation = (props: PropsWithChildren<NodeProps>) => {
       }}
       onEntering={(e) => {
         const scrollHeight = e.scrollHeight;
-
         e.style.height = expanded ? `${Math.min(realHeight || scrollHeight, scrollHeight)}px` : 0;
       }}
       onEntered={(e) => {


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
- [ ] New feature
- [x] Bug fix
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context

<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

## Solution

<!-- Describe how the problem is fixed in detail -->

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
| Tree | 修复 `Tree` 组件在展开后没有子节点场景下，无法再收起的bug  | Fix the bug that the `Tree` component can no longer be collapsed when there is no child node after expansion |  #222  |

## Checklist:

- [x] Test suite passes (`npm run test`)
- [x] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [x] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
