### PR TITLE
fix: fix Avatar Component img load fail

### DIFF
--- a/components/Avatar/__demo__/basic.md
+++ b/components/Avatar/__demo__/basic.md
@@ -7,11 +7,11 @@ title:
 
 ## zh-CN
 
-头像的基础使用。如果头像是文字的话，会自动调节字体大小，来适应头像框。
+头像的基础使用。如果头像是文字的话，会自动调节字体大小，来适应头像框。如果图片加载失败会自动获取图片的`alt`属性作为头像。
 
 ## en-US
 
-Basic usage. If the avatar content is text, the font size will be automatically adjusted to fit the content in the avatar.
+Basic usage. If the avatar content is text, the font size will be automatically adjusted to fit the content in the avatar. If the img fails to load, the `alt` property of the img is automatically taken as the avatar.
 
 ```js
 import { Avatar, Typography, Space } from '@arco-design/web-react';
@@ -29,6 +29,9 @@ ReactDOM.render(
     <Avatar style={{ backgroundColor: '#00d0b6' }}>Design</Avatar>
     <Avatar>
       <img alt="avatar" src="//p1-arco.byteimg.com/tos-cn-i-uwbnlip3yd/3ee5f13fb09879ecb5185e440cef6eb9.png~tplv-uwbnlip3yd-webp.webp" />
+    </Avatar>
+    <Avatar>
+      <img alt="Avatar" src="//p1-arco.byteimg.com/404.webp" />
     </Avatar>
   </Space>,
   CONTAINER

--- a/components/_util/hooks/useImage.ts
+++ b/components/_util/hooks/useImage.ts
@@ -1,0 +1,44 @@
+import { useEffect, useState } from 'react';
+
+export enum IMG_LOAD_STATUS {
+  LOADING = 'loading',
+  SUCCESS = 'success',
+  FAILED = 'failed',
+}
+
+const defaultState: {
+  src: undefined | string;
+  status: IMG_LOAD_STATUS;
+} = { src: undefined, status: IMG_LOAD_STATUS.LOADING };
+
+export default function useImage(url: string, crossOrigin?: string) {
+  const [image, setImage] = useState<typeof defaultState>(defaultState);
+  const [imageRul, setImageRul] = useState<string>('');
+
+  useEffect(() => {
+    setImageRul(url);
+  }, [url]);
+
+  useEffect(() => {
+    if (!imageRul) return;
+    const img = document.createElement('img');
+    const onLoad = () => setImage({ src: img.src, status: IMG_LOAD_STATUS.SUCCESS });
+    const onError = () => setImage({ src: undefined, status: IMG_LOAD_STATUS.FAILED });
+
+    img.addEventListener('load', onLoad);
+    img.addEventListener('error', onError);
+    if (crossOrigin) img.crossOrigin = crossOrigin;
+    img.src = imageRul;
+
+    return () => {
+      img.removeEventListener('load', onLoad);
+      img.removeEventListener('error', onError);
+      setImage(defaultState);
+    };
+  }, [imageRul, crossOrigin]);
+
+  return {
+    ...image,
+    setImageRul,
+  };
+}


### PR DESCRIPTION
Style issues after failed avatar picture loading

https://codesandbox.io/s/unruffled-feather-gd6x1?file=/src/App.js

修改后:
![image](https://user-images.githubusercontent.com/32266005/143833818-0b0296fb-86e4-4fe3-95be-4ef8ab338d67.png)


<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
- [ ] New feature
- [x] Bug fix
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context

<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

## Solution

<!-- Describe how the problem is fixed in detail -->

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|           |               |               |                |

## Checklist:

- [ ] Test suite passes (`npm run test`)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
