### PR TITLE
fix: upload directory excute beforeUpload

### DIFF
--- a/components/Progress/style/index.less
+++ b/components/Progress/style/index.less
@@ -153,9 +153,12 @@
   }
 
   &-is-warning {
-    .@{progress-prefix-cls}-line-inner,
-    .@{progress-prefix-cls}-steps-item-active {
+    .@{progress-prefix-cls}-line-inner {
       background-color: @progress-line-color-inner-bg_warning;
+    }
+
+    .@{progress-prefix-cls}-steps-item-active {
+      background-color: @progress-steps-color-item-bg_warning;
     }
 
     .@{progress-prefix-cls}-line-text .@{prefix}-icon,
@@ -165,9 +168,12 @@
   }
 
   &-is-success {
-    .@{progress-prefix-cls}-line-inner,
-    .@{progress-prefix-cls}-steps-item-active {
+    .@{progress-prefix-cls}-line-inne {
       background-color: @progress-line-color-inner-bg_success;
+    }
+
+    .@{progress-prefix-cls}-steps-item-active {
+      background-color: @progress-steps-color-item-bg_success;
     }
 
     .@{progress-prefix-cls}-line-text .@{prefix}-icon,
@@ -177,9 +183,13 @@
   }
 
   &-is-error {
-    .@{progress-prefix-cls}-line-inner,
-    .@{progress-prefix-cls}-steps-item-active {
+    .@{progress-prefix-cls}-line-inner {
       background-color: @progress-line-color-inner-bg_error;
+    }
+
+
+    .@{progress-prefix-cls}-steps-item-active {
+      background-color: @progress-steps-color-item-bg_error;
     }
 
     .@{progress-prefix-cls}-line-text .@{prefix}-icon,

--- a/components/Progress/style/token.less
+++ b/components/Progress/style/token.less
@@ -47,8 +47,9 @@
 @progress-steps-margin-steps-item-right_small: 3px;
 @progress-steps-color-item-bg: var(--color-fill-3);
 @progress-steps-color-item-bg_normal: @color-primary-6;
-@progress-steps-color-item-bg_success: @color-success-6;
-@progress-steps-color-item-bg_error: @color-danger-6;
+@progress-steps-color-item-bg_success: @progress-line-color-inner-bg_success;
+@progress-steps-color-item-bg_error: @progress-line-color-inner-bg_error;
+@progress-steps-color-item-bg_warning: @progress-line-color-inner-bg_warning;
 @progress-steps-margin-text-left: @spacing-4;
 
 @progress-line-color-inner-bg_warning: @color-warning-6;
@@ -56,4 +57,3 @@
 @progress-circle-size-mini-color-mask-stroke_warning: var(--color-warning-light-3);
 @progress-circle-color-path-stroke_warning: @color-warning-6;
 @progress-circle-color-icon_warning: @color-warning-6;
-@progress-steps-color-item-bg_warning: @color-warning-6;

--- a/components/Upload/trigger-node.tsx
+++ b/components/Upload/trigger-node.tsx
@@ -54,6 +54,8 @@ const getFiles = (fileList, accept) => {
 };
 
 const loopDirectory = (items: DataTransferItemList, accept, callback) => {
+  const files = [];
+
   const _loopDirectory = (item) => {
     if (item.isFile) {
       item.file((file) => {
@@ -61,7 +63,7 @@ const loopDirectory = (items: DataTransferItemList, accept, callback) => {
           Object.defineProperty(file, 'webkitRelativePath', {
             value: item.fullPath.replace(/^\//, ''),
           });
-          callback(file);
+          files.push(file);
         }
       });
     } else if (item.isDirectory) {
@@ -78,6 +80,8 @@ const loopDirectory = (items: DataTransferItemList, accept, callback) => {
     .forEach(
       (item: DataTransferItem) => item.webkitGetAsEntry && _loopDirectory(item.webkitGetAsEntry())
     );
+  // https://github.com/arco-design/arco-design/issues/242
+  callback(files);
 };
 
 const TriggerNode = (props: PropsWithChildren<TriggerProps>) => {

--- a/components/Upload/upload.tsx
+++ b/components/Upload/upload.tsx
@@ -15,7 +15,7 @@ import { ConfigContext } from '../ConfigProvider';
 import omit from '../_util/omit';
 import useMergeProps from '../_util/hooks/useMergeProps';
 
-const processFile = function (fileList?: UploadItem[]): { [key: string]: UploadItem } {
+const processFile = function(fileList?: UploadItem[]): { [key: string]: UploadItem } {
   const res = {};
   if (!isArray(fileList)) {
     return res;

--- a/components/Upload/uploader.tsx
+++ b/components/Upload/uploader.tsx
@@ -213,7 +213,7 @@ class Uploader extends React.Component<UploaderProps, UploaderState> {
           type="file"
           accept={accept}
           multiple={multiple}
-          {...(directory ? { webkitdirectory: 'webkitdirectory', directory: 'directory' } : {})}
+          {...(directory ? { webkitdirectory: 'webkitdirectory' } : {})}
           onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
             const files = e.target.files;
             if (files) {


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
- [ ] New feature
- [x] Bug fix
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context

<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

## Solution

<!-- Describe how the problem is fixed in detail -->

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|   Upload       |        修复 `Upload` 组件上传文件夹时，`beforeUpload` 的第二个参数未获取到本次上传的全部文件的 bug。       | Fix the bug that when the `Upload` component uploads a folder, the second parameter of `beforeUpload` does not get all the files uploaded this time.              |         close #242        |

## Checklist:

- [ ] Test suite passes (`npm run test`)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
