### PR TITLE
fix: Select callback's parameter enhancement when labelInValue is true

### DIFF
--- a/components/Select/README.en-US.md
+++ b/components/Select/README.en-US.md
@@ -14,14 +14,14 @@ When users need to select one or more from a group of similar data, they can use
 
 |Property|Description|Type|DefaultValue|Version|
 |---|---|---|---|---|
-|defaultValue|To set default value|`string \| string[] \| number \| number[]`|`-`|-|
-|value|To set value|`string \| string[] \| number \| number[]`|`-`|-|
+|defaultValue|To set default value|`string \| string[] \| number \| number[] \| LabeledValue \| LabeledValue[]`|`-`|-|
+|value|To set value|`string \| string[] \| number \| number[] \| LabeledValue \| LabeledValue[]`|`-`|-|
 |inputValue|To set input value|`string`|`-`|-|
 |mode|Set mode of Select(**`tags` recommends using `mode: multiple; allowCreate: true` instead, this mode will be removed in the next major version**)|`'multiple' \| 'tags'`|`-`|-|
 |options|Select options|`(\| string\| number\| { label: ReactNode \| string; value: string \| number; disabled?: boolean; extra?: any })[]`|`-`|`extra` in 2.2.0|
 |labelInValue|Whether to embed label in value, turn the format of value from string to `{ value: string, label: ReactNode }`|`boolean`|`-`|-|
 |filterOption|If it's true, filter options by input value. If it's a function, filter options base on the function.|`boolean \| ((inputValue: string, option: ReactElement) => boolean)`|`true`|-|
-|renderFormat|Customize the content that will be displayed in the Select.If the `Option` corresponding to `value` does not exist, the first parameter will be `null`|`(option: OptionInfo \| null, value: string \| number) => ReactNode`|`-`|-|
+|renderFormat|Customize the content that will be displayed in the Select.If the `Option` corresponding to `value` does not exist, the first parameter will be `null`|`(option: OptionInfo \| null, value: string \| number \| LabeledValue) => ReactNode`|`-`|-|
 |defaultActiveFirstOption|Whether to highlight the first option by default|`boolean`|`true`|-|
 |unmountOnExit|Whether to destroy the DOM when hiding|`boolean`|`true`|-|
 |defaultPopupVisible|Whether to show dropdown by default.|`boolean`|`-`|2.14.0|
@@ -37,7 +37,7 @@ When users need to select one or more from a group of similar data, they can use
 |dropdownMenuClassName|The className of dropdown menu.|`string \| string[]`|`-`|-|
 |virtualListProps|Pass properties used by VirtualList.|`AvailableVirtualListProps`|`-`|2.1.0|
 |onChange|Callback when select an option or input value change.|`(value, option: OptionInfo \| OptionInfo[]) => void`|`-`|-|
-|onDeselect|Called when a option is deselected.Only called for `multiple` mode.|`(value: OptionProps['value'], option: OptionInfo) => void`|`-`|-|
+|onDeselect|Called when a option is deselected.Only called for `multiple` mode.|`(value: string \| number \| LabeledValue, option: OptionInfo) => void`|`-`|-|
 |onClear|Called when clear|`(visible: boolean) => void`|`-`|-|
 |onSearch|Callback when input changed|`(value: string, reason: InputValueChangeReason) => void`|`-`|-|
 |onFocus|Callback when get focus|`(e) => void`|`-`|-|

--- a/components/Select/README.zh-CN.md
+++ b/components/Select/README.zh-CN.md
@@ -14,14 +14,14 @@
 
 |参数名|描述|类型|默认值|版本|
 |---|---|---|---|---|
-|defaultValue|选择框的默认值|`string \| string[] \| number \| number[]`|`-`|-|
-|value|选择器的值（受控模式）|`string \| string[] \| number \| number[]`|`-`|-|
+|defaultValue|选择框的默认值|`string \| string[] \| number \| number[] \| LabeledValue \| LabeledValue[]`|`-`|-|
+|value|选择器的值（受控模式）|`string \| string[] \| number \| number[] \| LabeledValue \| LabeledValue[]`|`-`|-|
 |inputValue|输入框的值（受控模式）|`string`|`-`|-|
 |mode|是否开启多选模式或标签模式 (**`tags` 推荐使用 `mode: multiple; allowCreate: true` 替代，下一大版本将移除此模式**)|`'multiple' \| 'tags'`|`-`|-|
 |options|指定可选项|`(\| string\| number\| { label: ReactNode \| string; value: string \| number; disabled?: boolean; extra?: any })[]`|`-`|`extra` in 2.2.0|
 |labelInValue|设置 `onChange` 回调中 `value` 的格式。默认是string，设置为true时候，value格式为： { label: string, value: string }|`boolean`|`-`|-|
 |filterOption|是否根据输入的值筛选数据。如果传入函数的话，接收 `inputValue` 和 `option` 两个参数，当option符合筛选条件时，返回 `true`，反之返回 `false`。|`boolean \| ((inputValue: string, option: ReactElement) => boolean)`|`true`|-|
-|renderFormat|定制回显内容。返回值将会显示在下拉框内。若 `value` 对应的 `Option` 不存在，则第一个参数是 null|`(option: OptionInfo \| null, value: string \| number) => ReactNode`|`-`|-|
+|renderFormat|定制回显内容。返回值将会显示在下拉框内。若 `value` 对应的 `Option` 不存在，则第一个参数是 null|`(option: OptionInfo \| null, value: string \| number \| LabeledValue) => ReactNode`|`-`|-|
 |defaultActiveFirstOption|是否默认高亮第一个选项|`boolean`|`true`|-|
 |unmountOnExit|是否在隐藏的时候销毁 DOM 结构|`boolean`|`true`|-|
 |defaultPopupVisible|下拉框是否默认打开。|`boolean`|`-`|2.14.0|
@@ -37,7 +37,7 @@
 |dropdownMenuClassName|下拉列表的类。|`string \| string[]`|`-`|-|
 |virtualListProps|传递虚拟滚动属性。|`AvailableVirtualListProps`|`-`|2.1.0|
 |onChange|点击选择框的回调|`(value, option: OptionInfo \| OptionInfo[]) => void`|`-`|-|
-|onDeselect|取消选中的时候触发的回调，(只在 `multiple` 模式下触发)。|`(value: OptionProps['value'], option: OptionInfo) => void`|`-`|-|
+|onDeselect|取消选中的时候触发的回调，(只在 `multiple` 模式下触发)。|`(value: string \| number \| LabeledValue, option: OptionInfo) => void`|`-`|-|
 |onClear|点击清除时触发，参数是当前下拉框的展开状态。|`(visible: boolean) => void`|`-`|-|
 |onSearch|搜索时的回调|`(value: string, reason: InputValueChangeReason) => void`|`-`|-|
 |onFocus|获得焦点时的回调|`(e) => void`|`-`|-|

--- a/components/Select/interface.tsx
+++ b/components/Select/interface.tsx
@@ -19,6 +19,13 @@ export interface OptionInfo extends PropsWithChildren<OptionProps> {
   _origin: 'children' | 'options' | 'userCreatedOptions' | 'userCreatingOption';
 }
 
+export type LabeledValue = {
+  value: string | number;
+  label: ReactNode;
+};
+
+export type SelectInnerStateValue = string | number | string[] | number[];
+
 /**
  * @title Select
  */
@@ -27,12 +34,12 @@ export interface SelectProps extends SelectViewCommonProps {
    * @zh 选择框的默认值
    * @en To set default value
    */
-  defaultValue?: string | string[] | number | number[];
+  defaultValue?: string | string[] | number | number[] | LabeledValue | LabeledValue[];
   /**
    * @zh 选择器的值（受控模式）
    * @en To set value
    */
-  value?: string | string[] | number | number[];
+  value?: string | string[] | number | number[] | LabeledValue | LabeledValue[];
   /**
    * @zh 输入框的值（受控模式）
    * @en To set input value
@@ -71,7 +78,7 @@ export interface SelectProps extends SelectViewCommonProps {
    * Customize the content that will be displayed in the Select.
    * If the `Option` corresponding to `value` does not exist, the first parameter will be `null`
    */
-  renderFormat?: (option: OptionInfo | null, value: string | number) => ReactNode;
+  renderFormat?: (option: OptionInfo | null, value: string | number | LabeledValue) => ReactNode;
   /**
    * @zh 是否默认高亮第一个选项
    * @en Whether to highlight the first option by default
@@ -157,7 +164,7 @@ export interface SelectProps extends SelectViewCommonProps {
    * @zh 取消选中的时候触发的回调，(只在 `multiple` 模式下触发)。
    * @en Called when a option is deselected.Only called for `multiple` mode.
    */
-  onDeselect?: (value: OptionProps['value'], option: OptionInfo) => void;
+  onDeselect?: (value: string | number | LabeledValue, option: OptionInfo) => void;
   /**
    * @zh 点击清除时触发，参数是当前下拉框的展开状态。
    * @en Called when clear

--- a/components/Select/utils.tsx
+++ b/components/Select/utils.tsx
@@ -1,7 +1,13 @@
 import React, { ReactElement } from 'react';
 import get from 'lodash/get';
 import Option from './option';
-import { OptionInfo, OptionProps, OptionsType, SelectProps } from './interface';
+import {
+  SelectInnerStateValue,
+  OptionInfo,
+  OptionProps,
+  OptionsType,
+  SelectProps,
+} from './interface';
 import { isArray, isString, isNumber, isObject } from '../_util/is';
 import getHighlightText from '../_util/getHighlightText';
 
@@ -16,7 +22,7 @@ function isEmptyValue(value, isMultiple: boolean) {
   return isMultiple ? !isArray(value) || !value.length : value === undefined;
 }
 
-function getValidValue(value, isMultiple: boolean, labelInValue: boolean): SelectProps['value'] {
+function getValidValue(value, isMultiple: boolean, labelInValue: boolean): SelectInnerStateValue {
   // Compatible when labelInValue is set, value is passed in the object
   if (labelInValue) {
     if (isMultiple) {


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
- [ ] New feature
- [x] Bug fix
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context

`renderFormat` callback's parameter `value` should be an object when `labelInValue` is `true`.

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
| Select | `Select` 组件修复 `renderFormat` 回调在设置 `labelInValue` 时，其参数未返回对象的 bug。 |  `Select` fixes the bug that the parameter of the `renderFormat` callback does not return an object when the `labelInValue` is `true`.   |                |

## Checklist:

- [x] Test suite passes (`npm run test`)
- [x] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [x] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
