### PR TITLE
fix: typography 折叠判断镜像dom的setAttribute style 错误

### DIFF
--- a/components/Typography/utils.tsx
+++ b/components/Typography/utils.tsx
@@ -42,13 +42,14 @@ export function measure(
 
   const extraStyle = {
     height: 'auto',
-    minHeight: 'auto',
-    maxHeight: 'auto',
+    'min-height': 'auto',
+    'max-height': 'auto',
     left: '0',
     top: '-99999999px',
     // top:'100px',
-    zIndex: '-200',
-    whiteSpace: 'normal',
+    'z-index': '-200',
+    'white-space': 'normal',
+    'text-overflow': 'clip',
     overflow: 'auto',
   };
   const styleString = styleToString(originStyle, extraStyle);


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
- [ ] New feature
- [x] Bug fix
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context

## Solution

<!-- Describe how the problem is fixed in detail -->

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
| Typography | 修复 `Typography`组件设置`showTooltip`后不生效的bug。  |  Fix the bug that the `Typography` component does not take effect after setting `showTooltip`.  | Close #248  |

## Checklist:

- [x] Test suite passes (`npm run test`)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
