### PR TITLE
Revert "fix: 事件绑定在icon上，hover时候点击边缘位置时，无法清空value。应绑定在icon外层的icon-hover的上"

### DIFF
--- a/components/Input/input-element.tsx
+++ b/components/Input/input-element.tsx
@@ -152,22 +152,21 @@ const InputComponent = React.forwardRef<RefInputType, InputComponentProps>(
           <>
             <input ref={refInput} {...inputProps} />
             {!disabled && allowClear && value ? (
-              <IconHover
-                className={`${prefixCls}-clear-icon`}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  if (refInput.current && refInput.current.focus) {
-                    refInput.current.focus();
-                  }
-                  onValueChange && onValueChange('', e);
-                  onClear && onClear();
-                }}
-                // keep focus status
-                onMouseDown={(e) => {
-                  e.preventDefault();
-                }}
-              >
-                <IconClose />
+              <IconHover className={`${prefixCls}-clear-icon`}>
+                <IconClose
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    if (refInput.current && refInput.current.focus) {
+                      refInput.current.focus();
+                    }
+                    onValueChange && onValueChange('', e);
+                    onClear && onClear();
+                  }}
+                  // keep focus status
+                  onMouseDown={(e) => {
+                    e.preventDefault();
+                  }}
+                />
               </IconHover>
             ) : null}
           </>


### PR DESCRIPTION
Reverts arco-design/arco-design#250