### PR TITLE
fix: Typography locale config effect ellipsis , multiple children

### DIFF
--- a/components/Typography/base.tsx
+++ b/components/Typography/base.tsx
@@ -87,7 +87,8 @@ function Base(props: BaseProps) {
     copyable,
     ...rest
   } = props;
-  const { getPrefixCls } = useContext(ConfigContext);
+  const configContext = useContext(ConfigContext);
+  const { getPrefixCls } = configContext;
   const prefixCls = getPrefixCls('typography');
 
   const rafId = useRef();
@@ -135,6 +136,8 @@ function Base(props: BaseProps) {
           expanding={expanding}
           isEllipsis={isEllipsis}
           forceShowExpand={forceShowExpand}
+          // 如果是镜像dom的话，渲染在最外层，无法从context中拿到最新config
+          currentContext={configContext}
         />
       </>
     );

--- a/components/Typography/edit-content.tsx
+++ b/components/Typography/edit-content.tsx
@@ -2,12 +2,13 @@ import React, { useEffect, useRef } from 'react';
 import cs from '../_util/classNames';
 import { EditContentProps } from './interface';
 import Input from '../Input';
+import mergedToString from '../_util/mergedToString';
 
 export default function EditContent(props: EditContentProps) {
   const { prefixCls, children, setEditing, editableConfig } = props;
   const className = cs(`${prefixCls}-typography`, `${prefixCls}-edit-content`);
 
-  const str = String(children);
+  const str = mergedToString(children);
 
   const input = useRef(null);
 

--- a/components/Typography/interface.tsx
+++ b/components/Typography/interface.tsx
@@ -44,6 +44,7 @@ export interface OperationsProps extends Omit<React.HTMLAttributes<HTMLElement>,
   onClickExpand?: () => void;
   setEditing?: (editing: boolean) => void;
   forceShowExpand?: boolean;
+  currentContext: Record<string, any>;
 }
 
 export interface CommonProps extends OperationsProps {

--- a/components/Typography/operations.tsx
+++ b/components/Typography/operations.tsx
@@ -1,16 +1,14 @@
-import React, { useState, useRef, useEffect, useContext, PropsWithChildren } from 'react';
+import React, { useState, useRef, useEffect, PropsWithChildren } from 'react';
 import Tooltip from '../Tooltip';
-import { ConfigContext } from '../ConfigProvider';
 import { isObject, isArray } from '../_util/is';
 import copy from '../_util/clipboard';
 import IconCopy from '../../icon/react-icon/IconCopy';
 import IconCheckCircleFill from '../../icon/react-icon/IconCheckCircleFill';
 import IconEdit from '../../icon/react-icon/IconEdit';
 import { OperationsProps } from './interface';
+import mergedToString from '../_util/mergedToString';
 
 export default function Operations(props: PropsWithChildren<OperationsProps>) {
-  const { getPrefixCls, locale } = useContext(ConfigContext);
-  const prefixCls = getPrefixCls('typography');
   const {
     children,
     copyable,
@@ -21,7 +19,12 @@ export default function Operations(props: PropsWithChildren<OperationsProps>) {
     setEditing,
     onClickExpand,
     forceShowExpand,
+    currentContext = {},
   } = props;
+
+  const { getPrefixCls, locale } = currentContext;
+
+  const prefixCls = getPrefixCls('typography');
 
   const [isCopied, setCopied] = useState(false);
   const copyTimer = useRef(null);
@@ -43,7 +46,7 @@ export default function Operations(props: PropsWithChildren<OperationsProps>) {
 
   function onClickCopy() {
     if (isCopied) return;
-    const text = copyConfig.text !== undefined ? copyConfig.text : String(children);
+    const text = copyConfig.text !== undefined ? copyConfig.text : mergedToString(children);
     copy(text);
     setCopied(true);
     copyConfig.onCopy && copyConfig.onCopy(text);

--- a/components/Typography/utils.tsx
+++ b/components/Typography/utils.tsx
@@ -47,6 +47,7 @@ export function measure(
     left: '0',
     top: '-99999999px',
     // top:'100px',
+    position: 'fixed',
     'z-index': '-200',
     'white-space': 'normal',
     'text-overflow': 'clip',

--- a/stories/components/Typography.jsx
+++ b/stories/components/Typography.jsx
@@ -1,98 +1,21 @@
 import React from 'react';
-import { Typography, Table } from '@self';
+import { Typography, ConfigProvider } from '@self';
+import enUS from '@self/locale/en-US';
 
-const columns = [
-  {
-    title: 'Name',
-    dataIndex: 'name',
-  },
-  {
-    title: 'Salary',
-    dataIndex: 'salary',
-  },
+const mockText =
+  'A design is a plan or specification for the construction of an object or system or for the implementation of an activity or process, or the result of that plan or specification in the form of a prototype, product or process. The verb to design expresses the process of developing a design. The verb to design expresses the process of developing a design. A design is a plan or specification for the construction of an object or system or for the implementation of an activity or process, or the result of that plan or specification in the form of a prototype, product or process. The verb to design expresses the process of developing a design. The verb to design expresses the process of developing a design.';
 
-  {
-    title: 'typographyEllipsis',
-    dataIndex: 'typographyEllipsis',
-    width: 150,
-    render(x) {
-      return (
-        <Typography.Paragraph ellipsis={{ showTooltip: true }} style={{ margin: 0 }}>
-          {x}
-        </Typography.Paragraph>
-      );
-    },
-  },
-  {
-    title: 'typographyCssEllipsisFalse',
-    dataIndex: 'typographyCssEllipsisFalse',
-    width: 200,
-    render(x) {
-      return (
-        <Typography.Paragraph
-          ellipsis={{ showTooltip: true, cssEllipsis: false }}
-          style={{ margin: 0 }}
-        >
-          {x}
-        </Typography.Paragraph>
-      );
-    },
-  },
-  {
-    title: 'cssEllipsis',
-    dataIndex: 'cssEllipsis',
-    width: 200,
-    render(x) {
-      return (
-        <div style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-          {x}
-        </div>
-      );
-    },
-  },
-];
-
-const data = [
-  {
-    key: '1',
-    name: 'Jane Doe',
-    salary: 23000,
-    typographyEllipsis: `ellipsis={{ showTooltip: true, cssEllipsis: true }}`,
-    typographyCssEllipsisFalse: `ellipsis={{ showTooltip: true, cssEllipsis: false }}`,
-    cssEllipsis: `style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}`,
-  },
-];
-
+const num = 0.123232;
 function App() {
   return (
     <div>
-      <Typography.Paragraph
-        style={{ fontSize: 10, width: 90, fontWeight: 500, backgroundColor: 'red' }}
-        ellipsis={{ showTooltip: true }}
-        editable={true}
-      >
-        color-border-...
-      </Typography.Paragraph>
-      <Typography.Paragraph
-        style={{ fontSize: 10, width: 90, fontWeight: 500, backgroundColor: 'red' }}
-        ellipsis={{ showTooltip: true }}
-        copybale={true}
-      >
-        color-border-...
-      </Typography.Paragraph>
-
-      <Typography.Paragraph
-        style={{ fontSize: 10, width: 90, fontWeight: 500, backgroundColor: 'red' }}
-        ellipsis={{ showTooltip: true }}
-      >
-        <div style={{ marginTop: '20px' }}>
-          <h3>use tableLayoutFixed</h3>
-          <Table columns={columns} data={data} style={{ width: 900 }} tableLayoutFixed />
-
-          <h3>not use use tableLayoutFixed</h3>
-          <Table columns={columns} data={data} style={{ width: 900 }} />
-        </div>
-      </Typography.Paragraph>
+      <ConfigProvider locale={enUS}>
+        <Typography.Paragraph ellipsis={{ rows: 2, showTooltip: true, expandable: true }}>
+          {mockText}
+        </Typography.Paragraph>
+      </ConfigProvider>
+      <Typography.Text copyable>{(num * 100).toFixed(2)} %</Typography.Text>
+      <Typography.Paragraph editable>{(num * 100).toFixed(2)} %</Typography.Paragraph>
     </div>
   );
 }


### PR DESCRIPTION
…tiple children while add ,

<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
- [ ] New feature
- [x] Bug fix
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context

<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

## Solution

<!-- Describe how the problem is fixed in detail -->

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|  Typography  | 修复 `Typography` 在国际化场景下折叠计算结果出错的 bug。  | Fix the bug that the calculation result of `Typography` is incorrectly when ellipsised in the international scene |   Close  #287   |
|  Typography  | 修复 `Typography` 对包裹多个动态字符串并 `copyable` 时，复制结果出错的 bug。 |Fix the bug that the copy result is wrong when `Typography` wraps multiple dynamic strings and `copyable` |                |

## Checklist:
 
- [x] Test suite passes (`npm run test`)
- [x] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [x] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
