### PR TITLE
fix: slider onAfterChange value not update

### DIFF
--- a/components/Slider/index.tsx
+++ b/components/Slider/index.tsx
@@ -14,6 +14,7 @@ import useMergeValue from '../_util/hooks/useMergeValue';
 import { off, on } from '../_util/dom';
 import useLegalValue from './hooks/useLegalValue';
 import useMergeProps from '../_util/hooks/useMergeProps';
+import useUpdate from '../_util/hooks/useUpdate';
 
 function isSameOrder(firstNums: number[], secondNums) {
   const diff1 = firstNums[0] - firstNums[1];
@@ -65,10 +66,17 @@ function Slider(baseProps: SliderProps, ref) {
     defaultValue: props.defaultValue,
     value: props.value,
   });
+
   // 计算合法值
   const curVal = getLegalRangeValue(value);
   const lastVal = useRef<number[]>(curVal);
   let [beginVal, endVal] = curVal;
+
+  // value变化后 更新lastVal
+  useUpdate(() => {
+    lastVal.current = getLegalRangeValue(value);
+  }, [value, getLegalRangeValue]);
+
   if (!isSameOrder(curVal, lastVal.current)) {
     // 保持顺序
     [beginVal, endVal] = [endVal, beginVal];

--- a/components/Typography/interface.tsx
+++ b/components/Typography/interface.tsx
@@ -47,7 +47,7 @@ export interface OperationsProps extends Omit<React.HTMLAttributes<HTMLElement>,
   currentContext: Record<string, any>;
 }
 
-export interface CommonProps extends OperationsProps {
+export interface CommonProps extends Omit<OperationsProps, 'currentContext'> {
   style?: CSSProperties;
   className?: string | string[];
   children?: ReactNode;


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
- [ ] New feature
- [x] Bug fix
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context

<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

## Solution

<!-- Describe how the problem is fixed in detail -->

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
| Slider  |  修复 `Slider` 组件的 `onAfterChange` 参数没有被更新的 bug。 | Fix the bug that the `onAfterChange` parameter of the `Slider` component is not updated.  |    Close  #291     |

## Checklist:

- [x] Test suite passes (`npm run test`)
- [x] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [x] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
