### PR TITLE
style: fix InputTag style in FormItem with validateStatus

### DIFF
--- a/components/Form/style/status.less
+++ b/components/Form/style/status.less
@@ -1,4 +1,4 @@
-// copy from select
+// Copied from Select
 .select-color (@prefixCls, @status) {
   .@{prefixCls}:not(.@{prefixCls}-disabled) {
     .@{prefixCls}-view {
@@ -37,6 +37,25 @@
   .@{prefix}-picker-focused:not(.@{prefix}-picker-disabled) {
     &,
     &:hover {
+      border-color: ~'@{form-color-border_@{status}_focus}';
+      background-color: ~'@{form-color-bg_@{status}_focus}';
+      box-shadow: 0 0 0 ~'@{form-size-shadow_@{status}_focus}' ~'@{form-color-shadow_@{status}_focus}';
+    }
+  }
+}
+
+// Copied from InputTag
+.input-tag-color(@status) {
+  .@{prefix}-input-tag {
+    background-color: ~'@{form-color-bg_@{status}}';
+    border-color: ~'@{form-color-border_@{status}}';
+
+    &:hover {
+      border-color: ~'@{form-color-border_@{status}_hover}';
+      background-color: ~'@{form-color-bg_@{status}_hover}';
+    }
+
+    &.@{prefix}-input-tag-focus when not (@status = disabled) {
       border-color: ~'@{form-color-border_@{status}_focus}';
       background-color: ~'@{form-color-bg_@{status}_focus}';
       box-shadow: 0 0 0 ~'@{form-size-shadow_@{status}_focus}' ~'@{form-color-shadow_@{status}_focus}';
@@ -107,6 +126,9 @@
 
       /** Datepicker **/
       .picker(@status);
+
+      /** InputTag **/
+      .input-tag-color(@status);
     }
   }
 
@@ -184,6 +206,15 @@
     .@{prefix}-picker-clear-icon {
       margin-right: 0;
       margin-left: 0;
+    }
+  }
+
+  // InputTag
+  .@{prefix}-input-tag {
+    padding-right: 23px;
+
+    &-suffix {
+      padding-right: 0;
     }
   }
 }


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation change
- [ ] Coding style change
- [x] Component style change
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
| Form  |  修复在带有 `validateStatus` 的 `Form.Item` 中，`InputTag` 没有校验样式的问题。 |  Fix the problem that there is no validated style when `InputTag` is used in `Form.Item` with `validateStatus`.  |                |

## Checklist:

- [x] Test suite passes (`npm run test`)
- [x] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [x] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
