### PR TITLE
fix: progress css classname mistakenly renamed

### DIFF
--- a/components/Progress/style/index.less
+++ b/components/Progress/style/index.less
@@ -168,7 +168,7 @@
   }
 
   &-is-success {
-    .@{progress-prefix-cls}-line-inne {
+    .@{progress-prefix-cls}-line-inner {
       background-color: @progress-line-color-inner-bg_success;
     }
 


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
- [ ] New feature
- [x] Bug fix
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context

class name was mistakenly changed in commit `74ddf06b51379770b8c70e644c4fc397177efe9e`
leading to `success` status of `<Progress />` not displaying correctly
fixes [https://github.com/arco-design/arco-design/issues/343](url)

## Solution

restore the original class name

## How is the change tested?

setting `status="success"` displays the right green colour again

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|           |               |               |                |

## Checklist:

- [x] Test suite passes (`npm run test`)
- [x] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [x] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
