### PR TITLE
fix: TimePicker control mode set to undefined, next time not trigger …

### DIFF
--- a/components/TimePicker/__test__/index.test.tsx
+++ b/components/TimePicker/__test__/index.test.tsx
@@ -188,4 +188,25 @@ describe('TimePicker', () => {
     expect(getInputValue(component, 0)).toBe('01:00:00');
     expect(onChange.mock.calls).toHaveLength(1);
   });
+
+  // https://github.com/arco-design/arco-design/issues/358
+  it('set to undefined and onChange correctly', () => {
+    const onChange = jest.fn();
+    const component = mount(
+      <TimePicker value={dayjs('00:00:00', 'HH:mm:ss')} disableConfirm onChange={onChange} />
+    );
+
+    expect(getInputValue(component, 0)).toBe('00:00:00');
+
+    component.setProps({ value: undefined });
+
+    expect(getInputValue(component, 0)).toBe('');
+
+    component.find('.arco-picker').simulate('click');
+
+    getCells(component, 0).at(0).simulate('click');
+
+    expect(onChange.mock.calls).toHaveLength(1);
+    expect(onChange.mock.calls[0][0]).toBe('00:00:00');
+  });
 });

--- a/components/TimePicker/picker.tsx
+++ b/components/TimePicker/picker.tsx
@@ -141,14 +141,14 @@ const Picker = (baseProps: InnerPickerProps) => {
   }
 
   function onHandleChange(vs: Dayjs | Dayjs[]) {
-    if (isArray(vs) && isDayjsArrayChange(value as Dayjs[], vs)) {
+    if (isArray(vs) && isDayjsArrayChange(mergedValue as Dayjs[], vs)) {
       onChange &&
         onChange(
           vs.map((t) => t.format(format)),
           vs
         );
     }
-    if (isDayjs(vs) && isDayjsChange(value as Dayjs, vs)) {
+    if (isDayjs(vs) && isDayjsChange(mergedValue as Dayjs, vs)) {
       onChange && onChange(vs.format(format), vs);
     }
   }


### PR DESCRIPTION
…onChange

<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
- [ ] New feature
- [x] Bug fix
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context

<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

## Solution

<!-- Describe how the problem is fixed in detail -->

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|TimePicker | 修复 `TimePicker` 组件在受控设置为 `undefined` 时，下次 onChange 回调不正确的 bug。 | Fix the bug that the next time the onChange callback is incorrect when the `TimePicker` component is set to `undefined` under the control mode.  |  Close: https://github.com/arco-design/arco-design/issues/358 |

## Checklist:

- [x] Test suite passes (`npm run test`)
- [x] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [x] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
