### PR TITLE
fix: Select allowCreate may change disabled options by user input

### DIFF
--- a/components/Select/__test__/index.test.tsx
+++ b/components/Select/__test__/index.test.tsx
@@ -325,4 +325,19 @@ describe('Select', () => {
 
     expect(wrapper.find('.arco-tag')).toHaveLength(2);
   });
+
+  it('User creating option will not affect original options', () => {
+    const value = 'Hello';
+    wrapper = mountSelect(
+      <Select
+        allowCreate
+        popupVisible
+        mode="multiple"
+        inputValue={value}
+        defaultValue={[value]}
+        options={[{ value, label: value, disabled: true }]}
+      />
+    );
+    expect(wrapper.find('.arco-select-option-disabled')).toHaveLength(1);
+  });
 });

--- a/components/Select/select.tsx
+++ b/components/Select/select.tsx
@@ -122,7 +122,9 @@ function Select(baseProps: SelectProps, ref) {
         ? triggerProps.popupVisible
         : undefined,
   });
-  // tag模式下，由用户输入而扩展到Options中的值
+  // allowCreate 时，用户正在创建的选项值
+  const [userCreatingOption, setUserCreatingOption] = useState<string>(null);
+  // allowCreate 时，由用户输入而扩展到选项中的值
   const [userCreatedOptions, setUserCreatedOptions] = useState<string[]>([]);
   // 具有选中态或者 hover 态的 option 的 value
   const [valueActive, setValueActive] = useState<OptionProps['value']>(
@@ -144,10 +146,10 @@ function Select(baseProps: SelectProps, ref) {
         prefixCls,
         inputValue,
         userCreatedOptions,
-        userCreatingOption: allowCreate ? inputValue : '',
+        userCreatingOption,
       }
     );
-  }, [children, options, filterOption, inputValue, userCreatedOptions]);
+  }, [children, options, filterOption, inputValue, userCreatingOption, userCreatedOptions]);
 
   // ref
   const refWrapper = useRef(null);
@@ -263,6 +265,14 @@ function Select(baseProps: SelectProps, ref) {
       }
     }
   }, [value]);
+
+  // allowCreate 时，根据输入内容动态修改下拉框选项
+  useEffect(() => {
+    if (allowCreate) {
+      // 避免正在输入的内容覆盖已有的选项
+      setUserCreatingOption(optionInfoMap.has(inputValue) ? null : inputValue);
+    }
+  }, [inputValue]);
 
   // 在 inputValue 变化时，适时触发 onSearch
   useEffect(() => {


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
- [ ] New feature
- [x] Bug fix
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context

<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
| Select | `Select` 修复允许创建选项时，被禁用的选项可以被通过用户输入的方式被选中的 bug。  |  `Select` fixes the bug that disabled options can be selected by user input when `allowCreate = true`. |   Close #370    |

## Checklist:

- [ ] Test suite passes (`npm run test`)
- [x] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [x] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
