### PR TITLE
fix: Slider should render the DOM in the same order as UI display

### DIFF
--- a/components/Divider/style/index.less
+++ b/components/Divider/style/index.less
@@ -22,10 +22,9 @@
       &::after {
         content: '';
         height: 0;
-        border-bottom-width: @divider-size;
-        border-bottom-style: @divider-line-style;
-        border-bottom-color: inherit;
         flex: 1;
+        border-bottom: @divider-size @divider-line-style;
+        border-bottom-color: inherit;
       }
     }
 

--- a/components/Slider/README.en-US.md
+++ b/components/Slider/README.en-US.md
@@ -24,7 +24,7 @@ A Slider component for displaying current value and intervals in range.
 |range|Whether to allow range selection|`boolean \| { draggableBar: boolean }`|`-`|2.14.0|
 |step|Slide the value of one step|`number`|`1`|-|
 |showTicks|Whether to display step tick marks|`boolean`|`-`|-|
-|marks|The labels on the render ruler. `marks` is an Object, it's `key` is an integer within [min, max].|`object`|`-`|-|
+|marks|The labels on the render ruler. `marks` is an Object, it's `key` is an integer within [min, max].|`Record<number, ReactNode>`|`-`|-|
 |onlyMarkValue|Whether only the mark value can be selected|`boolean`|`-`|-|
 |defaultValue|To set default value|`number \| number[]`|`-`|-|
 |value|To set value|`number \| number[]`|`-`|-|

--- a/components/Slider/README.zh-CN.md
+++ b/components/Slider/README.zh-CN.md
@@ -24,7 +24,7 @@
 |range|是否是范围选择|`boolean \| { draggableBar: boolean }`|`-`|2.14.0|
 |step|步长|`number`|`1`|-|
 |showTicks|是否显示步长刻度线|`boolean`|`-`|-|
-|marks|标签。是一个对象。key 为在[min, max]内的整数。|`object`|`-`|-|
+|marks|标签。是一个对象。key 为在[min, max]内的整数。|`Record<number, ReactNode>`|`-`|-|
 |onlyMarkValue|只能选择标签值，此时step将会被忽略|`boolean`|`-`|-|
 |defaultValue|默认值|`number \| number[]`|`-`|-|
 |value|值|`number \| number[]`|`-`|-|

--- a/components/Slider/__test__/index.test.tsx
+++ b/components/Slider/__test__/index.test.tsx
@@ -100,20 +100,24 @@ describe('Slider ', () => {
       <Slider
         marks={{
           0: '0',
-          10: '10',
+          0.5: '0.5',
           30: '30',
           60: '60',
           100: '100',
+          ['a' as any]: 'a',
         }}
       />
     );
     expect(component.find('.arco-slider').hasClass('arco-slider-with-marks')).toBe(true);
     expect(component.find('.arco-slider-dot').length).toBe(5);
     expect(component.find('.arco-slider-marks-text').length).toBe(5);
+    expect(component.find('.arco-slider-marks-text').at(1).text()).toBe('0.5');
+
     component.find('.arco-slider-dot').at(2).simulate('mousedown');
     expect(
       component.find('.arco-slider-button').last().getDOMNode().getAttribute('style')
     ).toContain('left: 30%');
+
     component.find('.arco-slider-marks-text').at(4).simulate('mousedown');
     expect(
       component.find('.arco-slider-button').last().getDOMNode().getAttribute('style')

--- a/components/Slider/index.tsx
+++ b/components/Slider/index.tsx
@@ -5,7 +5,7 @@ import Marks from './marks';
 import Dots from './dots';
 import Input from './input';
 import Ticks from './ticks';
-import { isFunction, isObject } from '../_util/is';
+import { isFunction, isNumber, isObject } from '../_util/is';
 import { formatPercent, getOffset } from './utils';
 import cs from '../_util/classNames';
 import { ConfigContext } from '../ConfigProvider';
@@ -86,7 +86,11 @@ function Slider(baseProps: SliderProps, ref) {
   const endOffset = getOffset(endVal, [min, max]);
   // 标签数组
   const markList = useMemo(
-    () => Object.keys(marks || {}).map((key) => ({ key, content: marks[key] })),
+    () =>
+      Object.keys(marks || {})
+        .filter((key) => isNumber(+key))
+        .sort((a, b) => (+a > +b ? 1 : -1))
+        .map((key) => ({ key, content: marks[key] })),
     [marks]
   );
   // 是否显示输入框

--- a/components/Slider/interface.tsx
+++ b/components/Slider/interface.tsx
@@ -80,7 +80,7 @@ export interface SliderProps {
    * @zh 标签。是一个对象。key 为在[min, max]内的整数。
    * @en The labels on the render ruler. `marks` is an Object, it's `key` is an integer within [min, max].
    */
-  marks?: object;
+  marks?: Record<number, ReactNode>;
   /**
    * @zh 只能选择标签值，此时step将会被忽略
    * @en Whether only the mark value can be selected


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
- [ ] New feature
- [x] Bug fix
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context

The DOM rendering order of the Mark node of `Slider` may be inconsistent with the UI cause style like `:first-child` not works as expect.

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
| Slider | 修复 `Slider` 的 Mark 节点在 DOM 中的渲染顺序可能与 UI 不一致的问题。 | Fix the problem that the DOM rendering order of the Mark node of `Slider` may be inconsistent with the UI. |                |

## Checklist:

- [ ] Test suite passes (`npm run test`)
- [x] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [x] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
