### PR TITLE
fix: Table filter control mode set filteredValue to undefined to reset

### DIFF
--- a/components/Table/__test__/filter.test.tsx
+++ b/components/Table/__test__/filter.test.tsx
@@ -125,4 +125,35 @@ describe('Table Filter', () => {
     expect(component.find('.arco-pagination-item')).toHaveLength(4);
     expect(component.find('.arco-pagination-item-active').text()).toBe('1');
   });
+
+  it('filter in control mode', async () => {
+    const component = mount(
+      <Table
+        columns={columnsFilter.map((col) => {
+          const newCol = { ...col };
+          if (newCol.dataIndex === 'sex') {
+            delete newCol.defaultFilters;
+            newCol.filteredValue = ['male'];
+          }
+          return newCol;
+        })}
+        data={data}
+      />
+    );
+
+    expect(component.find('tbody tr')).toHaveLength(3);
+
+    component.setProps({
+      columns: columnsFilter.map((col) => {
+        const newCol = { ...col };
+        if (newCol.dataIndex === 'sex') {
+          delete newCol.defaultFilters;
+          newCol.filteredValue = undefined;
+        }
+        return newCol;
+      }),
+    });
+
+    expect(component.find('tbody tr')).toHaveLength(5);
+  });
 });

--- a/components/Table/table.tsx
+++ b/components/Table/table.tsx
@@ -166,7 +166,7 @@ function Table<T extends unknown>(baseProps: TableProps<T>, ref: React.Ref<Table
   }
 
   const controlledFilter = useMemo(() => {
-    // 允许 filteredValue 设置为 null，表示不筛选
+    // 允许 filteredValue 设置为 undefined 表示不筛选
     const flattenFilteredValueColumns = flattenColumns.filter(
       (column) => 'filteredValue' in column
     );
@@ -175,10 +175,7 @@ function Table<T extends unknown>(baseProps: TableProps<T>, ref: React.Ref<Table
     if (flattenFilteredValueColumns.length) {
       flattenFilteredValueColumns.forEach((column, index) => {
         const innerDataIndex = column.dataIndex === undefined ? index : column.dataIndex;
-        if (
-          (column.filteredValue || column.filteredValue === null) &&
-          innerDataIndex !== undefined
-        ) {
+        if (innerDataIndex !== undefined) {
           newFilters[innerDataIndex] = column.filteredValue;
         }
       });
@@ -202,10 +199,7 @@ function Table<T extends unknown>(baseProps: TableProps<T>, ref: React.Ref<Table
 
   const innerSorter = controlledSorter || sorter || {};
   const innerFilters = useMemo<FilterType<T>>(() => {
-    return {
-      ...filters,
-      ...controlledFilter,
-    };
+    return Object.keys(controlledFilter).length ? controlledFilter : filters;
   }, [filters, controlledFilter]);
 
   /** ----------- Sorter ----------- */


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
- [x] New feature
- [ ] Bug fix
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context

<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

## Solution

<!-- Describe how the problem is fixed in detail -->

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
| Table | 修复 `Table` 组件筛选在受控模式下，`filteredValue` 设置为 `undefined` 不能重置的 bug。 | Fix the bug that the filter of the `Table` component cannot be reset when the `filteredValue` is set to `undefined` in the controlled mode.  | Close: https://github.com/arco-design/arco-design/issues/369|

## Checklist:

- [x] Test suite passes (`npm run test`)
- [x] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [x] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
