### PR TITLE
fix: Menu in Dropdown can not set width by style.width

### DIFF
--- a/components/Menu/index.tsx
+++ b/components/Menu/index.tsx
@@ -145,7 +145,7 @@ function Menu(baseProps: MenuProps, ref) {
   };
 
   const usedStyle = { ...style };
-  if (mergedCollapse) {
+  if (mergedCollapse && !inDropdown) {
     delete usedStyle.width;
   }
 


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
- [ ] New feature
- [x] Bug fix
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
| Dropdown |  修复 `Dropdown` 中的 `Menu` 无法通过 `style` 设置宽度的问题。 | Fix the bug that the width of `Menu` in `Dropdown` cannot be set by `style`.   | Close #393  |

## Checklist:

- [ ] Test suite passes (`npm run test`)
- [x] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [x] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
