### PR TITLE
feat: Transfer supports passing InputProps to showSearch

### DIFF
--- a/components/Transfer/README.en-US.md
+++ b/components/Transfer/README.en-US.md
@@ -29,7 +29,7 @@ A two-column multi-select component that moves elements from one column to anoth
 |oneWay|Whether to allow only one-way movement|`boolean`|`-`|-|
 |simple|Whether to automatically move an item when it is selected|`\| boolean\| {retainSelectedItems?: boolean;}`|`-`|`retainSelectedItems` in '2.21.0'|
 |draggable|Whether the items in the list can be dragged|`boolean`|`-`|-|
-|showSearch|Whether to display the search box in columns|`boolean`|`-`|-|
+|showSearch|Whether to display the search box in columns|`boolean \| InputProps`|`-`|-|
 |showFooter|Whether to display the reset-button in columns|`boolean \| ReactNode`|`-`|ReactNode in `2.11.0`|
 |pagination|Whether to divide into pages, you can also pass in the configuration of `Pagination`|`boolean \| PaginationProps`|`-`|-|
 |listStyle|The additional css style of columns|`CSSProperties`|`-`|-|

--- a/components/Transfer/README.zh-CN.md
+++ b/components/Transfer/README.zh-CN.md
@@ -29,7 +29,7 @@
 |oneWay|单向|`boolean`|`-`|-|
 |simple|简单模式|`\| boolean\| {retainSelectedItems?: boolean;}`|`-`|`retainSelectedItems` in '2.21.0'|
 |draggable|列表内条目是否可拖拽|`boolean`|`-`|-|
-|showSearch|左右两栏是否显示搜索框|`boolean`|`-`|-|
+|showSearch|左右两栏是否显示搜索框|`boolean \| InputProps`|`-`|-|
 |showFooter|左右两栏是否显示底部重置按钮|`boolean \| ReactNode`|`-`|ReactNode in `2.11.0`|
 |pagination|是否使用翻页，也可传入 `Pagination` 的配置|`boolean \| PaginationProps`|`-`|-|
 |listStyle|左右两栏框的样式|`CSSProperties`|`-`|-|

--- a/components/Transfer/index.tsx
+++ b/components/Transfer/index.tsx
@@ -14,8 +14,10 @@ const defaultProps: TransferProps = {
   titleTexts: ['Source', 'Target'],
   defaultSelectedKeys: [],
   defaultTargetKeys: [],
-  filterOption: (inputValue, item) => item.value.indexOf(inputValue) !== -1,
   dataSource: [],
+  filterOption: (inputValue, item) => {
+    return typeof item?.value === 'string' && item.value.indexOf(inputValue) !== -1;
+  },
 };
 
 function Transfer(baseProps: TransferProps, ref) {

--- a/components/Transfer/interface.tsx
+++ b/components/Transfer/interface.tsx
@@ -1,5 +1,6 @@
 import { CSSProperties, DragEvent, ReactNode } from 'react';
 import { PaginationProps } from '../Pagination/pagination';
+import { InputProps } from '../Input';
 
 export type TransferItem = {
   key: string;
@@ -16,6 +17,7 @@ type TransferListTitle =
       countSelected: number;
       clear: () => void;
       checkbox: ReactNode;
+      searchInput: ReactNode;
     }) => ReactNode);
 
 /**
@@ -102,7 +104,7 @@ export interface TransferProps {
    * @zh 左右两栏是否显示搜索框
    * @en Whether to display the search box in columns
    */
-  showSearch?: boolean;
+  showSearch?: boolean | InputProps;
   /**
    * @zh 左右两栏是否显示底部重置按钮
    * @en Whether to display the reset-button in columns

--- a/components/Transfer/list.tsx
+++ b/components/Transfer/list.tsx
@@ -10,6 +10,7 @@ import IconSearch from '../../icon/react-icon/IconSearch';
 import IconDelete from '../../icon/react-icon/IconDelete';
 import IconHover from '../_class/icon-hover';
 import { ConfigContext } from '../ConfigProvider';
+import { isObject } from '../_util/is';
 
 export const TransferList = (props: TransferListProps, ref) => {
   const {
@@ -65,6 +66,21 @@ export const TransferList = (props: TransferListProps, ref) => {
     handleSelect(checked ? keys.concat(selectedDisabledKeys) : [...selectedDisabledKeys]);
   const clearItems = () => handleRemove(validKeys);
 
+  const searchInput = (
+    <Input
+      size="small"
+      disabled={disabled}
+      placeholder={searchPlaceholder}
+      suffix={<IconSearch />}
+      {...(isObject(showSearch) ? showSearch : {})}
+      onChange={(value, event) => {
+        setFilterText(value);
+        onSearch && onSearch(value);
+        isObject(showSearch) && showSearch.onChange && showSearch.onChange(value, event);
+      }}
+    />
+  );
+
   const renderHeader = () => {
     const checkboxProps: Partial<CheckboxProps<any>> = {
       disabled,
@@ -79,6 +95,7 @@ export const TransferList = (props: TransferListProps, ref) => {
         countSelected: selectedKeys.length,
         clear: clearItems,
         checkbox: <Checkbox {...checkboxProps} />,
+        searchInput,
       });
     }
 
@@ -187,20 +204,7 @@ export const TransferList = (props: TransferListProps, ref) => {
     <div ref={ref} className={cs(baseClassName, className)} style={style}>
       <div className={`${baseClassName}-header`}>{renderHeader()}</div>
 
-      {showSearch && (
-        <div className={`${baseClassName}-search`}>
-          <Input
-            size="small"
-            disabled={disabled}
-            placeholder={searchPlaceholder}
-            suffix={<IconSearch />}
-            onChange={(value) => {
-              setFilterText(value);
-              onSearch && onSearch(value);
-            }}
-          />
-        </div>
-      )}
+      {showSearch && <div className={`${baseClassName}-search`}>{searchInput}</div>}
 
       {renderListBody()}
     </div>


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
- [x] New feature
- [ ] Bug fix
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
| Transfer | `Transfer` 支持为 `showSearch` 属性传入 `InputProps`，支持将搜索框渲染至标题区域。 | `Transfer` supports passing `InputProps` to `showSearch`. |  Close #383  |

## Checklist:

- [ ] Test suite passes (`npm run test`)
- [x] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [x] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
