### PR TITLE
fix: Carousel's first page switch animation is abnormal when currentIndex is set to non-zero

### DIFF
--- a/components/Carousel/index.tsx
+++ b/components/Carousel/index.tsx
@@ -77,8 +77,10 @@ function Carousel(baseProps: CarouselProps, ref) {
   const refSliderWrapper = useRef(null);
   const refAnimationTimer = useRef(null);
 
-  const [index, setIndex] = useState(0);
-  const [previousIndex, setPreviousIndex] = useState<number>(null);
+  const [index, setIndex] = useState(
+    typeof currentIndex === 'number' ? getValidIndex(currentIndex) : 0
+  );
+  const [previousIndex, setPreviousIndex] = useState<number>(index);
   const [isPause, setIsPause] = useState(false);
   const [isAnimating, setIsAnimating] = useState(false);
   const [slideDirection, setSlideDirection] = useState<'positive' | 'negative'>(null);


### PR DESCRIPTION

<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
- [ ] New feature
- [x] Bug fix
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
| Carousel | 修复 `Carousel` 当 `currentIndex` 设置为非 0 时，首次翻页动画异常的问题。 |  Fix the bug that Carousel's first page switch animation is abnormal when `currentIndex` is set to non-zero.  |  Close #404   |

## Checklist:

- [ ] Test suite passes (`npm run test`)
- [x] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [x] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
