### PR TITLE
make children of Select.Option optional 

### DIFF
--- a/components/Select/interface.tsx
+++ b/components/Select/interface.tsx
@@ -13,7 +13,7 @@ export type InputValueChangeReason =
   | 'tokenSeparator';
 
 export interface OptionInfo extends PropsWithChildren<OptionProps> {
-  child: ReactElement;
+  child?: ReactElement;
   _valid: boolean;
   _index: number;
   _origin: 'children' | 'options' | 'userCreatedOptions' | 'userCreatingOption';
@@ -216,7 +216,7 @@ export interface OptionProps
   extends Omit<HTMLAttributes<HTMLLIElement>, 'className' | 'onMouseEnter' | 'onMouseLeave'> {
   _key?: any;
   style?: CSSProperties;
-  children: ReactNode;
+  children?: ReactNode;
   prefixCls?: string;
   className?: string | string[];
   wrapperClassName?: string | string[];

--- a/components/Select/option.tsx
+++ b/components/Select/option.tsx
@@ -67,14 +67,14 @@ function Option(props: OptionProps, ref) {
           disabled={disabled}
           onChange={optionLabelProps.onClick}
         />
-        <span {...optionLabelProps}>{children}</span>
+        <span {...optionLabelProps}>{children??value}</span>
       </li>
     );
   }
 
   return (
     <li ref={ref} {...optionLabelProps}>
-      {children}
+      {children??value}
     </li>
   );
 }


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [x] Performance improvement
- [ ] Test cases
- [ ] Continuous integration
- [x] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context

See #418 

## Solution

make children optional in Select.Option


## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|Select.Option| 支持无 Children |  allow no children        |   #418     |

## Checklist:

- [x] Test suite passes ( CI )
- [x] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [x] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

