### PR TITLE
fix: The ellipsis calculation of typography in the zoom scene is wrong

### DIFF
--- a/components/Typography/__test__/index.test.tsx
+++ b/components/Typography/__test__/index.test.tsx
@@ -38,13 +38,10 @@ jest.mock('resize-observer-polyfill', () => ({
 const LINE_STR_COUNT = 20;
 
 const _getComputedStyle = window.getComputedStyle;
-const _getHtmlOffsetHeight = Object.getOwnPropertyDescriptor(
-  HTMLElement.prototype,
-  'offsetHeight'
-).get;
+const _getHtmlScrollHeight = Object.getOwnPropertyDescriptor(Element.prototype, 'scrollHeight').get;
 describe('Typography', () => {
   beforeAll(() => {
-    Object.defineProperty(HTMLElement.prototype, 'offsetHeight', {
+    Object.defineProperty(Element.prototype, 'scrollHeight', {
       get() {
         const html = this.innerHTML;
         const text = html.replace(/<[^>]*>/g, '');
@@ -61,8 +58,8 @@ describe('Typography', () => {
   });
 
   afterAll(() => {
-    Object.defineProperty(HTMLElement.prototype, 'offsetHeight', {
-      get: _getHtmlOffsetHeight,
+    Object.defineProperty(Element.prototype, 'scrollHeight', {
+      get: _getHtmlScrollHeight,
     });
     window.getComputedStyle = _getComputedStyle;
   });

--- a/components/Typography/utils.tsx
+++ b/components/Typography/utils.tsx
@@ -85,7 +85,7 @@ export function measure(
   }
 
   function inRange() {
-    return mirrorElement.offsetHeight <= maxHeight;
+    return mirrorElement.scrollHeight <= maxHeight;
   }
 
   if (inRange()) {

--- a/stories/components/Typography.jsx
+++ b/stories/components/Typography.jsx
@@ -1,23 +1,101 @@
 import React from 'react';
-import { Typography, ConfigProvider } from '@self';
-import enUS from '@self/locale/en-US';
+import { Typography, Table, Popover } from '@self';
+const { Text } = Typography;
 
-const mockText =
-  'A design is a plan or specification for the construction of an object or system or for the implementation of an activity or process, or the result of that plan or specification in the form of a prototype, product or process. The verb to design expresses the process of developing a design. The verb to design expresses the process of developing a design. A design is a plan or specification for the construction of an object or system or for the implementation of an activity or process, or the result of that plan or specification in the form of a prototype, product or process. The verb to design expresses the process of developing a design. The verb to design expresses the process of developing a design.';
+// 空间不足时，省略文本的内容，中间用…（省略号）来省略
+// 并且可以选择使用 popover 来展示完整文案
+// 比如 some-long-string 可省略为 some-long… 或者 some…string
+const EllipsisText = (props) => {
+  const { content: str, options } = props;
+  const {
+    auto = true, // 全自动模式，仅支持在字符串尾部省略
+    max = 10, // 短于这个长度的 string，不省略，展示全部
+    head = 8, // 省略的 string 头部展示的 characters 的数量
+    tail = 0, // 省略的 string 尾部展示的 characters 的数量
+    ellipsisConfig, // ellipsis 配置
+    className, // 文字的 classes
+    style = { margin: 'auto' }, // 文字的 style
+  } = options ?? {};
 
-const num = 0.123232;
-function App() {
+  const DEFAULT_ELLIPSIS_CONFIG = {
+    rows: 1,
+    expandable: false,
+    ellipsisStr: '…',
+    showTooltip: {
+      type: 'popover',
+    },
+  };
+
+  const finalEllipsisConfig = {
+    ...DEFAULT_ELLIPSIS_CONFIG,
+    ...(ellipsisConfig ?? {}),
+  };
+
+  if (auto) {
+    return (
+      <Text ellipsis={finalEllipsisConfig} className={className} style={style}>
+        {str}
+      </Text>
+    );
+  }
+
+  // 自定义省略字符，可以把'…'放在字符串开头、中间或尾部
+  const len = str.length;
+  const shouldNotEllipsify = head + tail >= max || len <= max;
+
+  // 根据规则省略文本，返回一个新的 string
+  const getEllipsifiedText = () => str.substring(0, head) + '…' + str.substring(len - tail, len);
+
   return (
-    <div>
-      <ConfigProvider locale={enUS}>
-        <Typography.Paragraph ellipsis={{ rows: 2, showTooltip: true, expandable: true }}>
-          {mockText}
-        </Typography.Paragraph>
-      </ConfigProvider>
-      <Typography.Text copyable>{(num * 100).toFixed(2)} %</Typography.Text>
-      <Typography.Paragraph editable>{(num * 100).toFixed(2)} %</Typography.Paragraph>
-    </div>
+    <Popover content={str} disabled={shouldNotEllipsify}>
+      <Text className={className} style={style}>
+        {shouldNotEllipsify ? str : getEllipsifiedText()}
+      </Text>
+    </Popover>
   );
+};
+
+const columns = [
+  {
+    title: 'Name',
+    dataIndex: 'name',
+    render(x) {
+      return <EllipsisText content={x} />;
+    },
+  },
+  {
+    title: 'Salary',
+    dataIndex: 'salary',
+  },
+  {
+    title: 'Address',
+    dataIndex: 'address',
+  },
+  {
+    title: 'Email',
+    dataIndex: 'email',
+  },
+];
+
+const data = [
+  {
+    key: '1',
+    name: 'Jane DoeJane DoeJane',
+    salary: 23000,
+    address: '32 Park Road, London',
+    email: 'jane.doe@example.com',
+  },
+  {
+    key: '5',
+    name: 'William Smith',
+    salary: 27000,
+    address: '62 Park Road, London',
+    email: 'william.smith@example.com',
+  },
+];
+
+function App() {
+  return <Table columns={columns} data={data} />;
 }
 
 export default App;


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
- [ ] New feature
- [x] Bug fix
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context

<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

## Solution

<!-- Describe how the problem is fixed in detail -->

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
| Typography  | 修复 `Typography` 组件在浏览器缩放场景下折叠出错的bug  |  Fixed the bug that the `Typography` component was folded incorrectly in the browser zoom scene.  |    |

## Checklist:

- [x] Test suite passes (`npm run test`)
- [x] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [x] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
