### PR TITLE
fix: image preview index

### DIFF
--- a/components/Image/image-preview.tsx
+++ b/components/Image/image-preview.tsx
@@ -65,11 +65,9 @@ function Preview(props: ImagePreviewProps, ref) {
     escToExit = true,
   } = props;
 
-  const { previewGroup, previewUrlMap, currentId, setCurrentId, infinite } =
+  const { previewGroup, previewUrlMap, currentIndex, setCurrentIndex, infinite } =
     useContext(PreviewGroupContext);
-  const mergedSrc = previewGroup ? previewUrlMap.get(currentId) : src;
-  const previewUrlIdList = Array.from(previewUrlMap.keys());
-  const currentIndex = previewUrlIdList.indexOf(currentId);
+  const mergedSrc = previewGroup ? previewUrlMap.get(currentIndex) : src;
 
   const [visible, setVisible] = useMergeValue(false, {
     defaultValue: defaultVisible,
@@ -133,14 +131,13 @@ function Preview(props: ImagePreviewProps, ref) {
 
   // Jump to image at the specified index
   function jumpTo(index: number) {
-    const previewListLen = previewUrlIdList.length;
+    const previewListLen = previewUrlMap.size;
     if (infinite) {
       index %= previewListLen;
       if (index < 0) index = previewListLen - Math.abs(index);
     }
     if (index !== currentIndex && index >= 0 && index <= previewListLen - 1) {
-      const nextId = previewUrlIdList[index];
-      setCurrentId(nextId);
+      setCurrentIndex(index);
     }
   }
 
@@ -464,7 +461,7 @@ function Preview(props: ImagePreviewProps, ref) {
                 )}
                 {previewGroup && (
                   <ImagePreviewArrow
-                    previewCount={previewUrlIdList.length}
+                    previewCount={previewUrlMap.size}
                     current={currentIndex}
                     infinite={infinite}
                     onPrev={onPrev}

--- a/components/Image/image.tsx
+++ b/components/Image/image.tsx
@@ -11,11 +11,13 @@ import useShowFooter from './utils/hooks/useShowFooter';
 import useImageStatus from './utils/hooks/useImageStatus';
 import useMergeValue from '../_util/hooks/useMergeValue';
 import omit from '../_util/omit';
+import { isNumber } from '../_util/is';
 import { PreviewGroupContext } from './previewGroupContext';
 import { isServerRendering } from '../_util/dom';
 import useMergeProps from '../_util/hooks/useMergeProps';
 
-type ImagePropsType = ImageProps & Omit<ImgHTMLAttributes<HTMLImageElement>, 'className'>;
+type ImagePropsType = ImageProps &
+  Omit<ImgHTMLAttributes<HTMLImageElement>, 'className'> & { _index?: number };
 
 let uuid = 0;
 
@@ -45,6 +47,7 @@ function Image(baseProps: ImagePropsType, ref: LegacyRef<HTMLDivElement>) {
     previewProps = {} as ImagePreviewProps,
     alt,
     onClick,
+    _index,
     ...restProps
   } = props;
 
@@ -52,10 +55,15 @@ function Image(baseProps: ImagePropsType, ref: LegacyRef<HTMLDivElement>) {
     previewGroup,
     setVisible: setGroupPreviewVisible,
     registerPreviewUrl,
-    setCurrentId,
+    setCurrentIndex,
   } = useContext(PreviewGroupContext);
   const previewSrc = previewProps.src || src;
-  const id = useMemo(() => uuid++, []);
+  const id = useMemo(() => {
+    if (isNumber(_index)) {
+      uuid = _index;
+    }
+    return uuid;
+  }, []);
 
   const [showFooter] = useShowFooter({ title, description, actions });
   const { isLoading, isError, isLoaded, setStatus } = useImageStatus('beforeLoad');
@@ -97,7 +105,7 @@ function Image(baseProps: ImagePropsType, ref: LegacyRef<HTMLDivElement>) {
 
   function onImgClick(e) {
     if (preview && previewGroup) {
-      setCurrentId(id);
+      setCurrentIndex(id);
       setGroupPreviewVisible(true);
     } else if (preview) {
       togglePreviewVisible(true);

--- a/components/Image/previewGroupContext.ts
+++ b/components/Image/previewGroupContext.ts
@@ -19,8 +19,8 @@ export interface PreviewGroupContextProps {
   previewGroup: boolean;
   previewUrlMap: Map<number, string>;
   infinite?: boolean;
-  currentId: number;
-  setCurrentId: (current: number) => void;
+  currentIndex: number;
+  setCurrentIndex: (current: number) => void;
   setPreviewUrlMap: (map: PreviewUrlMap) => void;
   registerPreviewUrl: RegisterPreviewUrl;
   visible: boolean;
@@ -31,8 +31,8 @@ export const PreviewGroupContext = createContext<PreviewGroupContextProps>({
   previewGroup: false,
   previewUrlMap: new Map(),
   infinite: true,
-  currentId: 0,
-  setCurrentId: () => null,
+  currentIndex: 0,
+  setCurrentIndex: () => null,
   setPreviewUrlMap: () => null,
   registerPreviewUrl: () => null,
   visible: false,

--- a/stories/components/Image.jsx
+++ b/stories/components/Image.jsx
@@ -1,27 +1,45 @@
 import React, { useState } from 'react';
-import { Image, Space, ConfigProvider } from '@self';
+import { Image, Space, Button } from '@self';
 
 function Demo() {
-  const srcList = [
+  const newSrc =
+    '//p1-arco.byteimg.com/tos-cn-i-uwbnlip3yd/8361eeb82904210b4f55fab888fe8416.png~tplv-uwbnlip3yd-webp.webp';
+  const [srcList, setSrcList] = useState([
     '//p1-arco.byteimg.com/tos-cn-i-uwbnlip3yd/a8c8cdb109cb051163646151a4a5083b.png~tplv-uwbnlip3yd-webp.webp',
     '//p1-arco.byteimg.com/tos-cn-i-uwbnlip3yd/e278888093bef8910e829486fb45dd69.png~tplv-uwbnlip3yd-webp.webp',
-  ];
+    '//p1-arco.byteimg.com/tos-cn-i-uwbnlip3yd/3ee5f13fb09879ecb5185e440cef6eb9.png~tplv-uwbnlip3yd-webp.webp',
+  ]);
+
+  const replaceSrc = () => {
+    setSrcList([srcList[0], newSrc, srcList[2]]);
+  };
 
   return (
-    <ConfigProvider prefixCls="demo">
-      <div>
-        <Space direction="vertical">
-          <Image.PreviewGroup infinite={true}>
+    <div>
+      <Space direction="vertical">
+        <Image.PreviewGroup infinite>
+          <Image src={newSrc} width={230} />
+          <div>
             <Space>
               {srcList.map((src, index) => (
-                <Image key={index} src={src} width={200} />
+                <Image key={src} src={src} width={200} />
               ))}
             </Space>
-          </Image.PreviewGroup>
-        </Space>
-      </div>
-    </ConfigProvider>
+          </div>
+          <div style={{ marginTop: '20px' }}>
+            <Space>
+              {[...srcList].reverse().map((src, index) => (
+                <Image key={src} src={src} width={180} />
+              ))}
+            </Space>
+          </div>
+          <Image src={srcList[1]} width={220} />
+        </Image.PreviewGroup>
+      </Space>
+      <Button type="primary" onClick={replaceSrc}>
+        Replace
+      </Button>
+    </div>
   );
 }
-
 export default Demo;


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
- [ ] New feature
- [x] Bug fix
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context

<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

## Solution

<!-- Describe how the problem is fixed in detail -->

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
| Image |  修复 `Image.PreviewGroup` 在子节点的 `src` 更新后预览顺序出错的bug。  |  Fix the bug that the preview order of Image.PreviewGroup is wrong after the src of the child node is updated.   |  Close: #375   |

## Checklist:

- [x] Test suite passes (`npm run test`)
- [x] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [x] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
