### PR TITLE
fix: Select renderFormat should return parameter value with valid lab…

### DIFF
--- a/components/Select/__test__/index.test.tsx
+++ b/components/Select/__test__/index.test.tsx
@@ -6,6 +6,7 @@ import componentConfigTest from '../../../tests/componentConfigTest';
 import Button from '../../Button';
 import Select from '../select';
 import { Enter } from '../../_util/keycode';
+import { LabeledValue } from '../interface';
 
 mountTest(Select);
 componentConfigTest(Select, 'Select');
@@ -324,6 +325,35 @@ describe('Select', () => {
     );
 
     expect(wrapper.find('.arco-tag')).toHaveLength(2);
+
+    wrapper = mountSelect(
+      <Select
+        placeholder="Please select"
+        labelInValue
+        value={{ value: 1, label: 'One' }}
+        renderFormat={(_, labeledValue) => {
+          const { label, value } = labeledValue as LabeledValue;
+          return label || value;
+        }}
+      />
+    );
+
+    expect(wrapper.find('.arco-select-view-value').at(0).text()).toBe('One');
+
+    wrapper = mountSelect(
+      <Select
+        placeholder="Please select"
+        labelInValue
+        mode="multiple"
+        defaultValue={[{ value: 1, label: 'One' }]}
+        renderFormat={(_, labeledValue) => {
+          const { label, value } = labeledValue as LabeledValue;
+          return label || value;
+        }}
+      />
+    );
+
+    expect(wrapper.find('.arco-input-tag-tag-content').at(0).text()).toBe('One');
   });
 
   it('User creating option will not affect original options', () => {


### PR DESCRIPTION
…el if props.value is already set

<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [x] Performance improvement
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
| Select |  `Select` 组件优化 `labelInValue` 时通过对象形式指定了初始值时的渲染表现。  |   `Select` optimizes the rendering behavior of `labelInValue` when the initial value is specified as an object.     |   Close: #442   |

## Checklist:

- [ ] Test suite passes (`npm run test`)
- [x] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [x] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
