### PR TITLE
fix: InputTag prevent enter key to submit form

### DIFF
--- a/components/InputTag/input-tag.tsx
+++ b/components/InputTag/input-tag.tsx
@@ -346,6 +346,7 @@ function InputTag(baseProps: InputTagProps<string | ObjectValueType>, ref) {
                   delay: () => refDelay.current,
                 }}
                 onPressEnter={async (e) => {
+                  inputValue && e.preventDefault();
                   onPressEnter && onPressEnter(e);
                   await tryAddInputValueToTag();
                 }}


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [x] Performance improvement
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|  InputTag  | `InputTag` 阻止回车时提交表单。 | `InputTag` prevents form submission on `Enter` pressed. |   Close: #469      |

## Checklist:

- [ ] Test suite passes (`npm run test`)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
