### PR TITLE
fix(Timeline): add missing values in type definition

### DIFF
--- a/components/Timeline/interface.ts
+++ b/components/Timeline/interface.ts
@@ -18,11 +18,11 @@ export interface TimelineProps {
    */
   direction?: 'horizontal' | 'vertical';
   /**
-   * @zh 时间轴的展示类型：时间轴在左侧，时间轴在右侧, 交替出现。
+   * @zh 时间轴的展示类型：时间轴在左侧/右侧(垂直方向)、上方/下方（水平方向），或交替出现。
    * @en The display mode of Timeline
-   * @defaultValue left
+   * @defaultValue left(vertical) | top(horizontal)
    */
-  mode?: 'left' | 'right' | 'alternate';
+  mode?: 'left' | 'right' | 'top' | 'bottom' | 'alternate' ;
   /**
    * @zh 是否展示幽灵节点，设置为 true 时候只展示幽灵节点。传入ReactNode时，会作为节点内容展示。
    * @en Whether to display ghost nodes. When set to true, only ghost nodes are displayed. When passed to ReactNode, it will be displayed as node content


### PR DESCRIPTION
## Types of changes

<!-- What types of changes does this PR introduce -->
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Test cases
- [ ] Continuous integration
- [x] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context

### 问题
Solves Type Error (Timeline): mode type definition missing "top" and "bottom".
Reproduce: https://codesandbox.io/s/sweet-bhaskara-wezit?file=/src/App.tsx
![image](https://user-images.githubusercontent.com/8275280/150715248-63e1e0bb-625c-4ae5-a3f6-3f1c0fdd552b.png)

### 修复步骤
1. 经过测试，确定 'top' 和 'bottom' 都是mode属性的有效值，因此在mode的类型定义中中增加了这两项：

```typescript
mode?: 'left' | 'right' | 'top' | 'bottom' | 'alternate' ;
```

2. 根据 `components/Timeline/item.tsx` 的[实现](https://github.com/arco-design/arco-design/blob/279aa9abdd4323357562243af6f4a53f4a508db9/components/Timeline/item.tsx#L63)，推断了在 `direction === 'horizontal'`的情况下，mode的默认值是 'top'。因此在jsdoc中补充了这一点：
```typescript
@defaultValue left(vertical) | top(horizontal)
```


## Solution

Added "top" and "bottom" into type definition of "mode"

## How is the change tested?

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
| Timeline  |  修复了 Timeline 组件 mode 类型定义缺少 "top" 和 "bottom" 值的问题    |  fix type definition of Timeline, where mode lacks "top" and "bottom" as possible values |                |

## Checklist:

- [x] Test suite passes (`npm run test`)
- [x] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [x] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

