### PR TITLE
fix(image): fix the problem that onload not be triggered when load form cache

### DIFF
--- a/components/Image/image-preview.tsx
+++ b/components/Image/image-preview.tsx
@@ -68,6 +68,7 @@ function Preview(props: ImagePreviewProps, ref) {
   const { previewGroup, previewUrlMap, currentIndex, setCurrentIndex, infinite } =
     useContext(PreviewGroupContext);
   const mergedSrc = previewGroup ? previewUrlMap.get(currentIndex) : src;
+  const [previewImgSrc, setPreviewImgSrc] = useState(mergedSrc);
 
   const [visible, setVisible] = useMergeValue(false, {
     defaultValue: defaultVisible,
@@ -302,7 +303,8 @@ function Preview(props: ImagePreviewProps, ref) {
 
   // Reset on first mount or image switches
   useEffect(() => {
-    setStatus('loading');
+    setPreviewImgSrc(mergedSrc);
+    setStatus(mergedSrc ? 'loading' : 'loaded');
     reset();
   }, [mergedSrc]);
 
@@ -414,8 +416,6 @@ function Preview(props: ImagePreviewProps, ref) {
                     className={cs(`${previewPrefixCls}-img`, {
                       [`${previewPrefixCls}-img-moving`]: moving,
                     })}
-                    key={mergedSrc}
-                    src={mergedSrc}
                     style={{
                       transform: `translate(${translate.x}px, ${translate.y}px) rotate(${rotate}deg)`,
                     }}
@@ -426,6 +426,8 @@ function Preview(props: ImagePreviewProps, ref) {
                       setStatus('error');
                     }}
                     onMouseDown={onMoveStart}
+                    key={previewImgSrc}
+                    src={previewImgSrc}
                   />
                   {isLoading && (
                     <div className={`${previewPrefixCls}-loading`}>


### PR DESCRIPTION
…rm cache

<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
- [ ] New feature
- [x] Bug fix
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context

<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

## Solution

<!-- Describe how the problem is fixed in detail -->

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|     Image      |      修复 `Image.Preview` 组件在从缓存中加载图片的时候 `onload` 没有触发的问题         |      Fixed `Image.Preview` component `onload` not triggering when loading images from cache         |                |

## Checklist:

- [ ] Test suite passes (`npm run test`)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
