### PR TITLE
fix(Typography): the first parameter of listener function onStart of …

### DIFF
--- a/components/Typography/operations.tsx
+++ b/components/Typography/operations.tsx
@@ -73,7 +73,7 @@ export default function Operations(props: PropsWithChildren<OperationsProps>) {
       <span
         className={`${prefixCls}-operation-edit`}
         onClick={() => {
-          editableConfig.onStart && editableConfig.onStart(String(children));
+          editableConfig.onStart && editableConfig.onStart(mergedToString(children));
           setEditing(true);
         }}
       >


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
- [ ] New feature
- [x] Bug fix
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context

<!-- Explain what problem does the PR solve -->
- 在使用Typography组件时，editable 属性可开启编辑功能，editable属性可添加一个onStart函数，onStart函数的第一个参数是获取编辑的文本，但是源码获取的方式是String(children)

- children代表的是用户自己的可编辑文本，但这个文本有可能是reactNode，所以String(reactNode)得到的文本数据是"[object Object]"
<!-- Link to related open issues if applicable -->

## Solution

<!-- Describe how the problem is fixed in detail -->
基于上面的问题，所以我们需要判断这个children是否是reactNode还是普通的文本，我使用了acro design本身的工具函数mergedToString,就可以完成此判断并返回最终合并的文本
## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|     Typography      |        修复 Typography 组件编辑状态监听函数onStart第一个参数获取编辑文本的bug       |      Fix the bug that the first parameter of the editing state listener function onStart of the Typography component gets the editing text         |                |

## Checklist:

- [x] Test suite passes (`npm run test`)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
