### PR TITLE
style(input): the add after button is not as height as input in safari

### DIFF
--- a/components/Input/__demo__/size.md
+++ b/components/Input/__demo__/size.md
@@ -124,7 +124,7 @@ class Demo extends React.Component {
             {...props}
             style={{ width: 350, marginBottom: 24, marginRight: 24 }}
             addBefore={
-              <Select size={size} placeholder="Please select" style={{ width: 100 }}>
+              <Select size={size} placeholder="Please select" style={{ width: 100, height: props.height }}>
                 <Select.Option value="http://">http://</Select.Option>
                 <Select.Option value="https://">https://</Select.Option>
               </Select>

--- a/components/Input/input-element.tsx
+++ b/components/Input/input-element.tsx
@@ -22,7 +22,7 @@ const InputComponent = React.forwardRef<RefInputType, InputComponentProps>(
       disabled,
       placeholder,
       className,
-      style,
+      style = {},
       height,
       prefixCls,
       hasParent,
@@ -56,6 +56,8 @@ const InputComponent = React.forwardRef<RefInputType, InputComponentProps>(
       },
       hasParent ? undefined : className
     );
+    const isCustomHeight = 'height' in props || 'height' in style;
+    const customHeight = height || style.height;
 
     useImperativeHandle(
       ref,
@@ -180,7 +182,9 @@ const InputComponent = React.forwardRef<RefInputType, InputComponentProps>(
           <input
             ref={refInput}
             {...inputProps}
-            style={hasParent ? {} : { ...style, ...('height' in props ? { height } : {}) }}
+            style={
+              hasParent ? {} : { ...style, ...(isCustomHeight ? { height: customHeight } : {}) }
+            }
           />
         )}
         {autoFitWidth && (

--- a/components/Input/input.tsx
+++ b/components/Input/input.tsx
@@ -50,7 +50,7 @@ function Input(baseProps: InputProps, ref) {
   const props = useMergeProps<InputProps>(baseProps, {}, componentConfig?.Input);
   const {
     className,
-    style,
+    style = {},
     addBefore,
     addAfter,
     suffix,
@@ -87,7 +87,8 @@ function Input(baseProps: InputProps, ref) {
 
   const prefixCls = getPrefixCls('input');
   const size = props.size || ctxSize;
-  const isCustomHeight = 'height' in props;
+  const isCustomHeight = 'height' in props || 'height' in style;
+  const customHeight = height || style.height;
   let suffixElement = suffix;
   const valueLength = value ? value.length : 0;
 
@@ -152,12 +153,16 @@ function Input(baseProps: InputProps, ref) {
   });
 
   return needWrapper ? (
-    <div className={classnames} style={{ ...style, ...(isCustomHeight ? { height } : {}) }}>
+    <div
+      className={classnames}
+      style={{ ...style, ...(isCustomHeight ? { height: customHeight } : {}) }}
+    >
       <span className={`${prefixCls}-group`}>
         {inputAddon(`${prefixCls}-group-addbefore`, addBefore, beforeStyle)}
         <span
           className={innerWrapperClassnames}
           ref={inputWrapperRef}
+          style={{ ...(isCustomHeight ? { height: customHeight } : {}) }}
           onMouseDown={(e) => {
             // 直接的点击input的时候，不阻止默认行为，避免无法选中输入框里的输入文本
             if ((e.target as HTMLElement).tagName !== 'INPUT') {
@@ -185,7 +190,7 @@ function Input(baseProps: InputProps, ref) {
   ) : allowClear ? (
     <span
       className={cs(className, innerWrapperClassnames)}
-      style={{ ...style, ...(isCustomHeight ? { height } : {}) }}
+      style={{ ...style, ...(isCustomHeight ? { height: customHeight } : {}) }}
       onMouseDown={keepFocus}
       onClick={() => {
         inputRef.current && inputRef.current.focus();

--- a/components/Input/search.tsx
+++ b/components/Input/search.tsx
@@ -18,9 +18,20 @@ const Search = React.forwardRef<RefInputType, InputSearchProps>((props: InputSea
     value: 'value' in props ? formatValue(props.value, props.maxLength) : undefined,
   });
 
-  const { className, style, placeholder, disabled, searchButton, loading, defaultValue, ...rest } =
-    props;
+  const {
+    className,
+    style = {},
+    placeholder,
+    disabled,
+    searchButton,
+    loading,
+    defaultValue,
+    ...rest
+  } = props;
   const prefixCls = getPrefixCls('input-search');
+  const isCustomHeight = 'height' in rest || 'height' in style;
+  const customHeight = rest.height || style.height;
+
   const classNames = cs(
     prefixCls,
     {
@@ -52,6 +63,7 @@ const Search = React.forwardRef<RefInputType, InputSearchProps>((props: InputSea
             onClick={onSearch}
             loading={loading}
             loadingFixedWidth
+            style={{ ...(isCustomHeight ? { height: customHeight } : {}) }}
             icon={searchButton === true && !loading && <IconSearch />}
           >
             {searchButton !== true && searchButton}

--- a/components/Input/style/search.less
+++ b/components/Input/style/search.less
@@ -24,7 +24,6 @@
   .@{input-prefix-cls}-search-btn {
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
-    height: 100%;
     font-size: @search-size-icon;
     color: @search-button-color-text;
   }


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
- [ ] New feature
- [x] Bug fix
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context
`Input.Search` in Safari the height of the addafter button and Input is inconsistent

<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

## Solution
Keep  addafter button is the same height as `Input`

<!-- Describe how the problem is fixed in detail -->

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|     Input      |  `Input.Search`  在 safari 中 addafter button 和 input 框高度不一致      |     `Input.Search` in Safari the height of the addafter button and Input is inconsistent  |     Close: [#557](https://github.com/arco-design/arco-design/issues/557)           | 

## Checklist:

- [ ] Test suite passes (`npm run test`)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
