### PR TITLE
fix(InputNumber) '.' not handled correctly #563

### DIFF
--- a/components/InputNumber/index.tsx
+++ b/components/InputNumber/index.tsx
@@ -217,7 +217,7 @@ function InputNumber(baseProps: InputNumberProps, ref) {
       let targetValue = value.trim().replace(/。/g, '.');
       targetValue = parser ? parser(targetValue) : targetValue;
 
-      if (isNumber(+targetValue) || targetValue === '-' || !targetValue) {
+      if (isNumber(+targetValue) || targetValue === '-' || !targetValue || targetValue === '.') {
         const formatValue = getLegalValue(targetValue);
 
         setInputValue(targetValue);


### PR DESCRIPTION
## Types of changes

<!-- What types of changes does this PR introduce -->
- [ ] New feature
- [x] Bug fix
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context

See #563

## Solution

Added condition `targetValue === '.'` so that `.` can be handled correctly.

## How is the change tested?
Manual Testing: Tried to reproduce the error mentioned in #563, and it does not happen again. 


Automated testing: `yarn test`

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
| InputNumber |修复 `InputNumber` 组件小数点特定情况下无法删除的 bug。| Fix the bug in `InputNumber` where decimal point is handled incorrectly |    #563   |

## Checklist:

- [x] Test suite passes (`npm run test`)
- [x] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [x] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

