### PR TITLE
fix: Input can not paste the same text after clear

### DIFF
--- a/components/Input/input-element.tsx
+++ b/components/Input/input-element.tsx
@@ -49,7 +49,6 @@ const InputComponent = React.forwardRef<RefInputType, InputComponentProps>(
     const refInput = useRef<HTMLInputElement>();
     const refInputMirror = useRef<HTMLSpanElement>();
     const refPrevInputWidth = useRef<number>(null);
-    const refPrevValueChangeCallbackParameter = useRef<string>(null);
 
     const maxLength = isObject(propMaxLength) ? propMaxLength.length : propMaxLength;
     const mergedMaxLength =
@@ -91,17 +90,16 @@ const InputComponent = React.forwardRef<RefInputType, InputComponentProps>(
     // 设定 <input> 初始宽度，之后的更新交由 ResizeObserver 触发
     useEffect(() => autoFitWidth && updateInputWidth(), []);
 
-    const tryTriggerValueChangeCallback: typeof onValueChange = (value, e) => {
+    const tryTriggerValueChangeCallback: typeof onValueChange = (newValue, e) => {
       if (
         onValueChange &&
         // https://github.com/arco-design/arco-design/issues/520
         // Avoid triggering onChange repeatedly for the same value
         // Compositionend is earlier than onchange in Firefox, different with chrome
-        value !== refPrevValueChangeCallbackParameter.current &&
-        (mergedMaxLength === undefined || value.length <= mergedMaxLength)
+        newValue !== value &&
+        (mergedMaxLength === undefined || newValue.length <= mergedMaxLength)
       ) {
-        onValueChange(value, e);
-        refPrevValueChangeCallbackParameter.current = value;
+        onValueChange(newValue, e);
       }
     };
 
@@ -169,7 +167,7 @@ const InputComponent = React.forwardRef<RefInputType, InputComponentProps>(
                   if (refInput.current && refInput.current.focus) {
                     refInput.current.focus();
                   }
-                  onValueChange && onValueChange('', e);
+                  tryTriggerValueChangeCallback('', e);
                   onClear && onClear();
                 }}
               >


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
- [ ] New feature
- [x] Bug fix
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context

<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

## Solution

<!-- Describe how the problem is fixed in detail -->

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|  Input  | 修复 `Input` 组件粘贴文本并清空之后，无法再次粘贴同样文本的 bug。   |   Fixed a bug where the same text could not be pasted again after the `Input` component pasted text and cleared it.  |     Close: #575     |

## Checklist:

- [ ] Test suite passes (`npm run test`)
- [x] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [x] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
