### PR TITLE
fix: cascader parameter error

### DIFF
--- a/components/Cascader/__test__/index.test.tsx
+++ b/components/Cascader/__test__/index.test.tsx
@@ -76,6 +76,12 @@ describe('Cascader basic test', () => {
     });
     // onChange事件触发
     expect(mockChange).toBeCalledTimes(1); // 得到mock函数被触发的次数
+    expect(mockChange.mock.calls[0][0]).toEqual(['shanghai', 'shanghaishi']);
+    expect(mockChange.mock.calls[0][1].map((item) => item.value)).toEqual([
+      'shanghai',
+      'shanghaishi',
+    ]);
+
     expect(wrapper.find('input').prop('value')).toBe('上海 / 上海市');
     // 消失有动画的延时
     jest.runAllTimers();
@@ -169,13 +175,15 @@ describe('support multiple correctly', () => {
 
   it('multiply select correctly', () => {
     let value = [['beijing', 'beijingshi', 'chaoyang', 'datunli']];
+    let option;
     const wrapper = mountCascader(
       <Cascader
         placeholder="请选择一个地点"
         style={{ maxWidth: 300 }}
         options={options}
-        onChange={(v) => {
+        onChange={(v, o) => {
           value = v as string[][];
+          option = o;
         }}
         mode="multiple"
         defaultValue={value}
@@ -215,6 +223,7 @@ describe('support multiple correctly', () => {
         },
       });
     expect(value.length).toEqual(2);
+    expect(option.length).toEqual(2);
   });
 
   it('support multiply search correctly', () => {

--- a/components/Cascader/cascader.tsx
+++ b/components/Cascader/cascader.tsx
@@ -29,6 +29,7 @@ import {
   getConfig,
   getStore,
   formatValue,
+  removeValueFromSet,
 } from './util';
 import useForceUpdate from '../_util/hooks/useForceUpdate';
 
@@ -127,8 +128,9 @@ function Cascader<T extends OptionProps>(baseProps: CascaderProps<T>, ref) {
       nodes.some((node) => {
         if (valueInSet(valuesSet, node.pathValue)) {
           result.push(node.getPathNodes().map((x) => x._data));
-          valuesSet.delete(node.pathValue);
+          removeValueFromSet(valuesSet, node.pathValue);
         }
+
         if (!valuesSet.size) {
           return true;
         }
@@ -194,7 +196,7 @@ function Cascader<T extends OptionProps>(baseProps: CascaderProps<T>, ref) {
       return;
     }
 
-    if (!('value' in props)) {
+    if (!isMultiple) {
       store.setNodeCheckedByValue(newValue);
     }
 

--- a/components/Cascader/util.tsx
+++ b/components/Cascader/util.tsx
@@ -46,3 +46,8 @@ export const valueInSet = (set, value: string[]) => {
   const _value = value || [];
   return set.has(_value.join(ValueSeparator));
 };
+
+export const removeValueFromSet = (set, value: string[]) => {
+  const _value = value || [];
+  return set.delete(_value.join(ValueSeparator));
+};


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
- [ ] New feature
- [x] Bug fix
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context

<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

## Solution

<!-- Describe how the problem is fixed in detail -->

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|      Cascader     |      修复 `Cascader` 组件单选时，第一次触发 `onChange` 时的第二个参数未传递当前选中节点信息的 bug。         |    Fixed the bug that the second parameter of `onChange` was not passed the information of the currently selected node when the `Cascader` component was single-selected for the first time.           |                close #596 |

## Checklist:

- [ ] Test suite passes (`npm run test`)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
