### PR TITLE
fix(table): placeholder can apply if the data is an empty string or null

### DIFF
--- a/components/Table/__test__/columns.test.tsx
+++ b/components/Table/__test__/columns.test.tsx
@@ -100,6 +100,15 @@ describe('Table columns usage test', () => {
           if (col.key === '1') {
             return { ...col, name: undefined };
           }
+          if (col.key === '2') {
+            return { ...col, name: null };
+          }
+          if (col.key === '3') {
+            return { ...col, name: '' };
+          }
+          if (col.key === '4') {
+            return { ...col, name: ' ' };
+          }
           return col;
         })}
         columns={columns}
@@ -118,10 +127,14 @@ describe('Table columns usage test', () => {
       placeholder: 'x',
     });
 
-    expect(component.find('tbody td').at(0).text()).toBe('-');
+    [0, 1, 2, 3].forEach((item) => {
+      expect(component.find('tbody tr').at(item).find('td').at(0).text()).toBe('-');
+    });
 
-    component.setProps({ columns, placeholder: 'x' });
-
-    expect(component.find('tbody td').at(0).text()).toBe('x');
+    [0, 1, 2, 3].forEach((item) => {
+      component.setProps({ columns, placeholder: 'x' });
+      component.update();
+      expect(component.find('tbody tr').at(item).find('td').at(0).text()).toBe('x');
+    });
   });
 });

--- a/components/Table/tbody/td.tsx
+++ b/components/Table/tbody/td.tsx
@@ -126,7 +126,7 @@ function Td(props: TdType) {
 
   const cellChildren = column.render
     ? renderElement
-    : v === undefined
+    : v === undefined || (typeof v === 'string' && v.trim() === '') || v === null
     ? column.placeholder === undefined
       ? placeholder
       : column.placeholder


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
- [ ] New feature
- [x] Bug fix
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context

<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

## Solution

<!-- Describe how the problem is fixed in detail -->

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|    Table       |   `placeholder` 属性在`Table` 数据为空字符或者 null 生效          |    `placeholder`   attributes take effect when `Table` data is an empty string or null         |       Close: [#606](https://github.com/arco-design/arco-design/issues/606)         |

## Checklist:

- [x] Test suite passes (`npm run test`)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
