### PR TITLE
WIP: fix(table): display correctly when table data column is true or false

### DIFF
--- a/components/Table/__test__/index.test.tsx
+++ b/components/Table/__test__/index.test.tsx
@@ -93,4 +93,33 @@ describe('Table', () => {
     const domTd2 = component.find('tbody td').at(1).getDOMNode();
     expect(getComputedStyle(domTd2).getPropertyValue('color')).toBe('rgb(1, 1, 1)');
   });
+
+  it('table data is true or false', () => {
+    const component = mountTable<TestData>(
+      <Table
+        size="small"
+        columns={columns as any}
+        data={[
+          {
+            key: '1',
+            name: 'Jane Doe',
+            salary: 23000,
+            address: '32 Park Road, London',
+            email: false,
+          },
+          {
+            key: '2',
+            name: 'Alisa Ross',
+            salary: 25000,
+            address: '35 Park Road, London',
+            email: true,
+          },
+        ]}
+      />
+    );
+
+    expect(component.find('tbody tr').at(0).find('td').at(4).text()).toBe('false');
+
+    expect(component.find('tbody tr').at(1).find('td').at(4).text()).toBe('true');
+  });
 });

--- a/components/Table/tbody/td.tsx
+++ b/components/Table/tbody/td.tsx
@@ -151,7 +151,7 @@ function Td(props: TdType) {
       ) : null}
       {(isString(ComponentBodyCell) as JSX.IntrinsicAttributes) ? (
         <ComponentBodyCell className={`${prefixCls}-cell-wrap-value`}>
-          {cellChildren}
+          {typeof cellChildren === 'boolean' ? cellChildren.toString() : cellChildren}
         </ComponentBodyCell>
       ) : (
         <ComponentBodyCell
@@ -161,7 +161,7 @@ function Td(props: TdType) {
           onHandleSave={onHandleSave}
           {...cellProps}
         >
-          {cellChildren}
+          {typeof cellChildren === 'boolean' ? cellChildren.toString() : cellChildren}
         </ComponentBodyCell>
       )}
     </>


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
- [ ] New feature
- [x] Bug fix
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context

<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

## Solution

<!-- Describe how the problem is fixed in detail -->

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|    Table       |    在 `Table` column 数据是 false 或者 true 依然正确展示         |   When `Table` column data is false or true, it will still display correctly            |      Close: [#610](https://github.com/arco-design/arco-design/issues/610)          |

## Checklist:

- [x] Test suite passes (`npm run test`)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
