### PR TITLE
fix: cascader lost label text when onSearch & defaultValue

### DIFF
--- a/components/Cascader/cascader.tsx
+++ b/components/Cascader/cascader.tsx
@@ -61,9 +61,6 @@ function Cascader<T extends OptionProps>(baseProps: CascaderProps<T>, ref) {
   const forceUpdate = useForceUpdate();
 
   const [inputValue, setInputValue] = useState('');
-  // 暂存被选中的值对应的节点。仅在onSearch的时候用到
-  // 避免出现下拉列表改变，之前选中的option找不到对应的节点，展示上会出问题。
-  const stashNodes = useRef<Store<T>['nodes']>([]);
   // const [mergeValue, setValue] = useMergeValue([], {
   //   value: 'value' in props ? formatValue(props.value, isMultiple) : undefined,
   //   defaultValue: 'defaultValue' in props ? formatValue(props.defaultValue, isMultiple) : undefined,
@@ -86,6 +83,9 @@ function Cascader<T extends OptionProps>(baseProps: CascaderProps<T>, ref) {
     () => getStore(props, mergeValue),
     [JSON.stringify(getConfig(props)), props.options]
   );
+  // 暂存被选中的值对应的节点。仅在onSearch的时候用到
+  // 避免出现下拉列表改变，之前选中的option找不到对应的节点，展示上会出问题。
+  const stashNodes = useRef<Store<T>['nodes']>(store?.getCheckedNodes() || []);
 
   useEffect(() => {
     const clearTimer = () => {


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
- [ ] New feature
- [x] Bug fix
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context

<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

## Solution

<!-- Describe how the problem is fixed in detail -->

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|     Cascader      |     修复 `Cascader` 组件在直接输入文本远程搜索时，组件默认值对应的 label  文本显示丢失的问题。        |   Fix the problem that the label text corresponding to the default value of the component is lost when the `Cascader` component is directly input text for remote search            |        Close #632         | 

## Checklist:

- [ ] Test suite passes (`npm run test`)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
