### PR TITLE
fix(input): fix allowClear and readOnly together show the clear button

### DIFF
--- a/components/Input/__test__/index.test.tsx
+++ b/components/Input/__test__/index.test.tsx
@@ -156,6 +156,11 @@ describe('Test Textarea', () => {
     expect(component.find('input').getDOMNode().getAttribute('value')).toBe('');
   });
 
+  it('test contains together allowClear and readOnly and do not show the clear button', () => {
+    const component = mountInput(<Input allowClear readOnly defaultValue="123" />);
+    expect(component.find('.arco-input-clear-icon svg').exists()).toBeFalsy();
+  });
+
   it('test password', () => {
     const component = mountInputPassword(<Input.Password visibilityToggle />);
 

--- a/components/Input/input-element.tsx
+++ b/components/Input/input-element.tsx
@@ -141,6 +141,7 @@ const InputComponent = React.forwardRef<RefInputType, InputComponentProps>(
 
     const inputProps = {
       ...otherProps,
+      readOnly,
       maxLength: mergedMaxLength,
       value: compositionValue || value || '',
       disabled,

--- a/components/Input/input-element.tsx
+++ b/components/Input/input-element.tsx
@@ -157,10 +157,10 @@ const InputComponent = React.forwardRef<RefInputType, InputComponentProps>(
 
     return (
       <>
-        {!readOnly && allowClear ? (
+        {allowClear ? (
           <>
             <input ref={refInput} {...inputProps} />
-            {!disabled && allowClear && value ? (
+            {!readOnly && !disabled && allowClear && value ? (
               <IconHover
                 className={`${prefixCls}-clear-icon`}
                 onClick={(e) => {

--- a/components/Input/input-element.tsx
+++ b/components/Input/input-element.tsx
@@ -24,6 +24,7 @@ const InputComponent = React.forwardRef<RefInputType, InputComponentProps>(
       value,
       autoFitWidth,
       onClear,
+      readOnly,
       onValueChange,
       maxLength: propMaxLength,
       ...rest
@@ -156,7 +157,7 @@ const InputComponent = React.forwardRef<RefInputType, InputComponentProps>(
 
     return (
       <>
-        {allowClear ? (
+        {!readOnly && allowClear ? (
           <>
             <input ref={refInput} {...inputProps} />
             {!disabled && allowClear && value ? (

--- a/components/Input/input.tsx
+++ b/components/Input/input.tsx
@@ -62,6 +62,7 @@ function Input(baseProps: InputProps, ref) {
     maxLength,
     showWordLimit,
     allowClear,
+    readOnly,
   } = props;
 
   const trueMaxLength = isObject(maxLength) ? maxLength.length : maxLength;
@@ -182,7 +183,7 @@ function Input(baseProps: InputProps, ref) {
         {inputAddon(`${prefixCls}-group-addafter`, addAfter, afterStyle)}
       </span>
     </div>
-  ) : allowClear ? (
+  ) : !readOnly && allowClear ? (
     <span
       className={cs(className, innerWrapperClassnames)}
       style={{ ...style, ...(isCustomHeight ? { height } : {}) }}

--- a/components/Input/input.tsx
+++ b/components/Input/input.tsx
@@ -62,7 +62,6 @@ function Input(baseProps: InputProps, ref) {
     maxLength,
     showWordLimit,
     allowClear,
-    readOnly,
   } = props;
 
   const trueMaxLength = isObject(maxLength) ? maxLength.length : maxLength;
@@ -183,7 +182,7 @@ function Input(baseProps: InputProps, ref) {
         {inputAddon(`${prefixCls}-group-addafter`, addAfter, afterStyle)}
       </span>
     </div>
-  ) : !readOnly && allowClear ? (
+  ) : allowClear ? (
     <span
       className={cs(className, innerWrapperClassnames)}
       style={{ ...style, ...(isCustomHeight ? { height } : {}) }}


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
- [ ] New feature
- [x] Bug fix
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context

<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

## Solution

<!-- Describe how the problem is fixed in detail -->

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|    Input       |  修复 `Input ` 同时设置  allowClear 和 readOnly 属性时, 依然展示清除按钮     |    Fixed display of clear button when `Input` allowClear and readOnly at same time     |      Close: [#637](https://github.com/arco-design/arco-design/issues/637)          |

## Checklist:

- [x] Test suite passes (`npm run test`)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
