### PR TITLE
fix(input-tag): fix InputTag display cleat button when set allowClear and readOnly together

### DIFF
--- a/components/InputTag/__test__/index.test.tsx
+++ b/components/InputTag/__test__/index.test.tsx
@@ -106,4 +106,9 @@ describe('InputTag', () => {
     });
     expect(mockOnClick).toBeCalled();
   });
+
+  it('test contains together allowClear and readOnly and do not show the clear button', () => {
+    const component = mount(<InputTag allowClear readOnly defaultValue={['123']} />);
+    expect(component.find('.arco-input-tag-clear-icon svg').exists()).toBeFalsy();
+  });
 });

--- a/components/InputTag/input-tag.tsx
+++ b/components/InputTag/input-tag.tsx
@@ -253,7 +253,7 @@ function InputTag(baseProps: InputTagProps<string | ObjectValueType>, ref) {
   };
 
   const clearIcon =
-    allowClear && !disabled && value.length ? (
+    allowClear && !disabled && !readOnly && value.length ? (
       <IconHover
         size={size}
         key="clearIcon"


### PR DESCRIPTION
… and readOnly together

<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
- [ ] New feature
- [x] Bug fix
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context

<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

## Solution

<!-- Describe how the problem is fixed in detail -->

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|   InpuTag     |  修复 `InputTag`组件同时设置 allowClear 和 readOnly 时, 依然展示清除按钮             |     Fixed InputTag display cleat button when set allowClear and readOnly together          |      Closed: [#649](https://github.com/arco-design/arco-design/issues/649)          |

## Checklist:

- [x] Test suite passes (`npm run test`)
- [x] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
