### PR TITLE
fix: Trigger can't pass classname to real element with disabled button as children

### DIFF
--- a/components/Dropdown/__test__/__snapshots__/demo.test.ts.snap
+++ b/components/Dropdown/__test__/__snapshots__/demo.test.ts.snap
@@ -34,7 +34,6 @@ exports[`renders Dropdown/demo/basic.md correctly 1`] = `
     class="arco-space-item"
   >
     <span
-      class=""
       style="display:inline-block;cursor:not-allowed"
     >
       <button

--- a/components/Trigger/__test__/case.test.tsx
+++ b/components/Trigger/__test__/case.test.tsx
@@ -146,4 +146,25 @@ describe('Trigger case', () => {
     expect(wrapper.find('#popup1')).toHaveLength(1);
     expect(wrapper.find('#popup2')).toHaveLength(1);
   });
+
+  it('children is disabled button, pass-through classname', async () => {
+    const c = 'my-custom-button-class';
+    const wrapper = mount(
+      <div id="test">
+        <Trigger
+          unmountOnExit={false}
+          trigger="click"
+          popup={() => {
+            return <div id="popup1"> 123123 </div>;
+          }}
+        >
+          <button id="btn" className={c} disabled>
+            Test
+          </button>
+        </Trigger>
+      </div>
+    );
+
+    expect(wrapper.find('#btn').hasClass(c)).toBeTruthy();
+  });
 });

--- a/components/Trigger/index.tsx
+++ b/components/Trigger/index.tsx
@@ -728,16 +728,13 @@ class Trigger extends PureComponent<TriggerProps, TriggerState> {
         'zIndex',
       ]);
       child = (
-        <span
-          className={element.props.className}
-          style={{ display: 'inline-block', ...picked, cursor: 'not-allowed' }}
-        >
+        <span style={{ display: 'inline-block', ...picked, cursor: 'not-allowed' }}>
           {React.cloneElement(element, {
             style: {
               ...omitted,
               pointerEvents: 'none',
             },
-            className: undefined,
+            className: element.props.className,
           })}
         </span>
       );


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
- [ ] New feature
- [x] Bug fix
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Performance improvement
- [x] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context

<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

## Solution

<!-- Describe how the problem is fixed in detail -->

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
| Trigger          | 修复当`Trigger`的子元素为`<Button disabled />`时，无法把`Button`上的`className`透传到真正的元素上的问题               | Fixed the bug that `Trigger` can't pass classname to the real element with `<Button disabled />` as children              | Close #659              |

## Checklist:

- [x] Test suite passes (`npm run test`)
- [x] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [x] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
