### PR TITLE
chore: update docgen config to avoid generating property document from HTML element

### DIFF
--- a/.config/docgen.config.js
+++ b/.config/docgen.config.js
@@ -2,5 +2,5 @@ module.exports = (config) => {
   config.languages = ['zh-CN', 'en-US'];
   config.template = '__template__/index.[language].md';
   config.outputFileName = 'README.[language].md';
-  config.tsParseTool = ['ts-document'];
+  config.tsParseTool = ['ts-document', { strictComment: true }];
 };

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "react-dom": ">=16"
   },
   "devDependencies": {
-    "@arco-design/arco-scripts": "^1.25.9",
     "@storybook/addon-actions": "^6.1.11",
     "@storybook/addon-essentials": "^6.1.11",
     "@storybook/addon-links": "^6.1.11",
@@ -76,6 +75,7 @@
     "@types/shallowequal": "^1.1.1",
     "@typescript-eslint/eslint-plugin": "^4.31.2",
     "@typescript-eslint/parser": "^4.31.2",
+    "arco-scripts": "^1.25.17",
     "chalk": "^2.4.2",
     "concurrently": "^5.2.0",
     "cross-env": "^7.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,122 +2,9 @@
 # yarn lockfile v1
 
 
-"@arco-design/arco-babel-config@^1.2.0":
-  version "1.2.0"
-  resolved "https://registry.npmjs.org/@arco-design/arco-babel-config/-/arco-babel-config-1.2.0.tgz"
-  integrity sha512-5Xk29LbsWk8F53klo1ZMy2EpSNbxBGiiZJnWylF8uqKpbnemdxoicoBjeiVbr+GwgjY7tT2nxlEo7wsjEoitag==
-  dependencies:
-    "@babel/core" "^7.5.5"
-    "@babel/plugin-proposal-class-properties" "^7.13.0"
-    "@babel/plugin-proposal-export-default-from" "^7.12.13"
-    "@babel/plugin-syntax-dynamic-import" "^7.8.3"
-    "@babel/plugin-transform-react-jsx-source" "^7.12.13"
-    "@babel/plugin-transform-runtime" "^7.13.10"
-    "@babel/preset-env" "^7.13.12"
-    "@babel/preset-react" "^7.12.13"
-    "@babel/preset-typescript" "^7.13.0"
-    "@babel/runtime" "^7.13.10"
-    babel-plugin-import "^1.13.3"
-
-"@arco-design/arco-dev-utils@^2.2.0":
-  version "2.2.0"
-  resolved "https://registry.npmjs.org/@arco-design/arco-dev-utils/-/arco-dev-utils-2.2.0.tgz"
-  integrity sha512-1j7JV6QAOTnKy8vyQRGpGBjcMjbfH7+bdth34K5YevbamRMh2zVO914q7UCQ4fZPXhKqYlESakZ90Y2My/Aftw==
-  dependencies:
-    chalk "^4.0.0"
-    cross-spawn "^7.0.3"
-    fs-extra "^9.0.1"
-    gulp "^4.0.2"
-    gulp-if "^3.0.0"
-    gulp-replace "^1.0.0"
-    inquirer "^7.3.3"
-
-"@arco-design/arco-markdown-loader@^1.15.3":
-  version "1.15.3"
-  resolved "https://registry.npmjs.org/@arco-design/arco-markdown-loader/-/arco-markdown-loader-1.15.3.tgz"
-  integrity sha512-2avbgNZVPDM3ZFAKVnGw34SUuGGGzXbEayhM+tdPU78i6FMTjxlLmc2pXIErXB87fGpc7LF7SmuRGRCbMXYtmw==
-  dependencies:
-    "@babel/core" "^7.5.5"
-    "@babel/plugin-transform-typescript" "^7.9.6"
-    front-matter "^3.0.1"
-    fs-extra "^7.0.1"
-    loader-utils "^1.2.3"
-    lru-cache "^6.0.0"
-    marked "^2.0.1"
-    nanoid "^3.1.22"
-    prismjs "^1.23.0"
-    react-helmet "^6.1.0"
-
-"@arco-design/arco-scripts@^1.25.9":
-  version "1.25.9"
-  resolved "https://registry.yarnpkg.com/@arco-design/arco-scripts/-/arco-scripts-1.25.9.tgz#4d93fc06894234e2d9535b1e5370862ef7e6a19a"
-  integrity sha512-L6OHGyYn6sT4ZRqZgdLgOXrx92ue/4qiwU1ltDcU9mbfZvVg/itdkUhOxT69HgMkcbt7vKVmYC2M3oEvlrlsxw==
-  dependencies:
-    "@arco-design/arco-babel-config" "^1.2.0"
-    "@arco-design/arco-dev-utils" "^2.2.0"
-    "@arco-design/arco-markdown-loader" "^1.15.3"
-    "@svgr/webpack" "^4.2.0"
-    axios "~0"
-    babel-jest "^26.0.1"
-    babel-loader "^8.1.0"
-    chalk "^4.0.0"
-    chokidar "^3.5.1"
-    commander "^3.0.1"
-    css-loader "^3.2.1"
-    doctrine "^3.0.0"
-    enzyme "^3.11.0"
-    enzyme-to-json "^3.4.4"
-    esbuild-loader "^2.11.0"
-    file-loader "^1.1.11"
-    fork-ts-checker-webpack-plugin "^5.2.1"
-    front-matter "^4.0.0"
-    fs-extra "^9.0.0"
-    glob "^7.1.2"
-    gulp "^4.0.2"
-    gulp-clean-css "^4.3.0"
-    gulp-copy "^4.0.1"
-    gulp-if "^3.0.0"
-    gulp-less "^5.0.0"
-    gulp-plumber "^1.2.1"
-    gulp-rename "^2.0.0"
-    gulp-replace "^1.0.0"
-    gulp-typescript "^5.0.1"
-    gulp-watch "^5.0.1"
-    html-webpack-plugin "^3.2.0"
-    inquirer "^8.1.2"
-    jest "^26.0.1"
-    less "^3.13.1"
-    less-loader "~4.1.0"
-    less-plugin-autoprefix "^2.0.0"
-    less-plugin-npm-import "^2.1.0"
-    lodash.debounce "^4.0.8"
-    merge-stream "^2.0.0"
-    mini-css-extract-plugin "^0.4.0"
-    moment "^2.29.1"
-    node-typescript-compiler "^2.1.1"
-    nunjucks "^3.2.3"
-    optimize-css-assets-webpack-plugin "^5.0.3"
-    parse-es-import "^0.3.1"
-    postcss-loader "4.3.0"
-    progress-bar-webpack-plugin "^2.1.0"
-    react-docgen-typescript "^2.1.0"
-    style-loader "^1.2.1"
-    terser-webpack-plugin "^2.3.2"
-    through2 "^4.0.2"
-    ts-document "^0.2.1"
-    ts-jest "^26.0.0"
-    ts-loader "^7.0.5"
-    typescript "^4.0.0"
-    vinyl-fs "^3.0.3"
-    webpack "^4.29.3"
-    webpack-cli "^3.3.8"
-    webpack-dev-server "^3.8.0"
-    webpack-merge "^4.2.2"
-    write-file-webpack-plugin "^4.5.1"
-
 "@arco-design/color@^0.4.0":
   version "0.4.0"
-  resolved "https://registry.npmjs.org/@arco-design/color/-/color-0.4.0.tgz"
+  resolved "https://registry.yarnpkg.com/@arco-design/color/-/color-0.4.0.tgz#52ddb40d318ee6df1057ca8c653cc1675023928f"
   integrity sha512-s7p9MSwJgHeL8DwcATaXvWT3m2SigKpxx4JA1BGPHL4gfvaQsmQfrLBDpjOJFJuJ2jG2dMt3R3P8Pm9E65q18g==
   dependencies:
     color "^3.1.3"
@@ -3559,6 +3446,121 @@ archy@^1.0.0:
   resolved "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz"
   integrity sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=
 
+arco-cli-dev-utils@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/arco-cli-dev-utils/-/arco-cli-dev-utils-1.1.0.tgz#1923518545b0c8436544a0daa00ab03602551c29"
+  integrity sha512-bhrXoi/zwUGZUYMUUQnSOXW9NKzucsx+WwqwJZ8geRwBe7jhmUFiP0X8wJ/CIgGt0xZqvxnu0SEwZ47XO+iA9w==
+  dependencies:
+    chalk "^4.0.0"
+    cross-spawn "^7.0.3"
+    fs-extra "^9.0.1"
+    gulp "^4.0.2"
+    gulp-if "^3.0.0"
+    gulp-replace "^1.0.0"
+    inquirer "^7.3.3"
+    os-locale "^5.0.0"
+    semver "^7.3.5"
+
+arco-markdown-loader@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/arco-markdown-loader/-/arco-markdown-loader-1.0.0.tgz#ab6d9e0e980973b5fdeabdd94b19432f366471a0"
+  integrity sha512-iZZP9j5n5HwG7vbPxa7K3zAKCMKU2oV7IM2udWpHv3AxjKFxB5FUM4WFd/zSLxi+oEFBDSDZwiZ5qPI4o3f1dw==
+  dependencies:
+    "@babel/core" "^7.5.5"
+    "@babel/plugin-transform-typescript" "^7.9.6"
+    front-matter "^3.0.1"
+    fs-extra "^7.0.1"
+    loader-utils "^1.2.3"
+    lru-cache "^6.0.0"
+    marked "^2.0.1"
+    nanoid "^3.1.22"
+    prismjs "^1.23.0"
+    react-helmet "^6.1.0"
+
+arco-scripts-babel-config@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/arco-scripts-babel-config/-/arco-scripts-babel-config-1.0.0.tgz#6ab819ebc84a84747c3b44e40fa14fcecc222ae5"
+  integrity sha512-ySwlZDPPMTe+pj8JQt8enphFWw4YnB3B3xA5kxhbAxbttq76SLg3wWdl3A/SsvXMMWKK0IEe3W7dYBstpNF4qA==
+  dependencies:
+    "@babel/core" "^7.5.5"
+    "@babel/plugin-proposal-class-properties" "^7.13.0"
+    "@babel/plugin-proposal-export-default-from" "^7.12.13"
+    "@babel/plugin-syntax-dynamic-import" "^7.8.3"
+    "@babel/plugin-transform-react-jsx-source" "^7.12.13"
+    "@babel/plugin-transform-runtime" "^7.13.10"
+    "@babel/preset-env" "^7.13.12"
+    "@babel/preset-react" "^7.12.13"
+    "@babel/preset-typescript" "^7.13.0"
+    "@babel/runtime" "^7.13.10"
+    babel-plugin-import "^1.13.3"
+
+arco-scripts@^1.25.17:
+  version "1.25.17"
+  resolved "https://registry.yarnpkg.com/arco-scripts/-/arco-scripts-1.25.17.tgz#46a6b88e81d4c995f27b94965df5d2db4777ec06"
+  integrity sha512-DoCg0AUsiSxOjy2fifbIYD92PxmlMmIq2wxN9OKppkmFteh2uCUivV8tqaoQIVtBHYPjDW0pWOalckjrPJdb1w==
+  dependencies:
+    "@svgr/webpack" "^4.2.0"
+    arco-cli-dev-utils "^1.0.0"
+    arco-markdown-loader "^1.0.0"
+    arco-scripts-babel-config "^1.0.0"
+    axios "~0"
+    babel-jest "^26.0.1"
+    babel-loader "^8.1.0"
+    chalk "^4.0.0"
+    chokidar "^3.5.1"
+    commander "^3.0.1"
+    css-loader "^3.2.1"
+    doctrine "^3.0.0"
+    enzyme "^3.11.0"
+    enzyme-to-json "^3.4.4"
+    esbuild-loader "^2.11.0"
+    file-loader "^1.1.11"
+    fork-ts-checker-webpack-plugin "^5.2.1"
+    front-matter "^4.0.0"
+    fs-extra "^9.0.0"
+    glob "^7.1.2"
+    gulp "^4.0.2"
+    gulp-clean-css "^4.3.0"
+    gulp-copy "^4.0.1"
+    gulp-if "^3.0.0"
+    gulp-less "^5.0.0"
+    gulp-plumber "^1.2.1"
+    gulp-rename "^2.0.0"
+    gulp-replace "^1.0.0"
+    gulp-typescript "^5.0.1"
+    gulp-watch "^5.0.1"
+    html-webpack-plugin "^3.2.0"
+    inquirer "^8.1.2"
+    jest "^26.0.1"
+    less "^3.13.1"
+    less-loader "~4.1.0"
+    less-plugin-autoprefix "^2.0.0"
+    less-plugin-npm-import "^2.1.0"
+    lodash.debounce "^4.0.8"
+    merge-stream "^2.0.0"
+    mini-css-extract-plugin "^0.4.0"
+    moment "^2.29.1"
+    node-typescript-compiler "^2.1.1"
+    nunjucks "^3.2.3"
+    optimize-css-assets-webpack-plugin "^5.0.3"
+    parse-es-import "^0.3.1"
+    postcss-loader "4.3.0"
+    progress-bar-webpack-plugin "^2.1.0"
+    react-docgen-typescript "^2.1.0"
+    style-loader "^1.2.1"
+    terser-webpack-plugin "^2.3.2"
+    through2 "^4.0.2"
+    ts-document "^0.3.0"
+    ts-jest "^26.0.0"
+    ts-loader "^7.0.5"
+    typescript "^4.0.0"
+    vinyl-fs "^3.0.3"
+    webpack "^4.29.3"
+    webpack-cli "^3.3.8"
+    webpack-dev-server "^3.8.0"
+    webpack-merge "^4.2.2"
+    write-file-webpack-plugin "^4.5.1"
+
 are-we-there-yet@~1.1.2:
   version "1.1.7"
   resolved "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.7.tgz"
@@ -5151,7 +5153,7 @@ color-support@^1.1.3:
 
 color@^3.0.0, color@^3.1.3:
   version "3.2.1"
-  resolved "https://registry.npmjs.org/color/-/color-3.2.1.tgz"
+  resolved "https://registry.yarnpkg.com/color/-/color-3.2.1.tgz#3544dc198caf4490c3ecc9a790b54fe9ff45e164"
   integrity sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==
   dependencies:
     color-convert "^1.9.3"
@@ -8895,6 +8897,11 @@ invert-kv@^1.0.0:
   resolved "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz"
   integrity sha1-EEqOSqym09jNFXqO+L+rLXo//bY=
 
+invert-kv@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-3.0.1.tgz#a93c7a3d4386a1dc8325b97da9bb1620c0282523"
+  integrity sha512-CYdFeFexxhv/Bcny+Q0BfOV+ltRlJcd4BBZBYFX/O0u4npJrgZtIcjokegtiSMAvlMTJ+Koq0GBCc//3bueQxw==
+
 ip-regex@^2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz"
@@ -10232,6 +10239,13 @@ lcid@^1.0.0:
   dependencies:
     invert-kv "^1.0.0"
 
+lcid@^3.0.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/lcid/-/lcid-3.1.1.tgz#9030ec479a058fc36b5e8243ebaac8b6ac582fd0"
+  integrity sha512-M6T051+5QCGLBQb8id3hdvIW8+zeFV2FyBGFS9IEK5H9Wt4MueD4bW1eWikpHgZp+5xR3l5c8pZUkQsIA0BFZg==
+  dependencies:
+    invert-kv "^3.0.0"
+
 lead@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/lead/-/lead-1.0.0.tgz"
@@ -10556,6 +10570,13 @@ makeerror@1.0.12:
   dependencies:
     tmpl "1.0.5"
 
+map-age-cleaner@^0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz#7d583a7306434c055fe474b0f45078e6e1b4b92a"
+  integrity sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==
+  dependencies:
+    p-defer "^1.0.0"
+
 map-cache@^0.2.0, map-cache@^0.2.2:
   version "0.2.2"
   resolved "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz"
@@ -10687,6 +10708,15 @@ media-typer@0.3.0:
   version "0.3.0"
   resolved "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
   integrity sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=
+
+mem@^5.0.0:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/mem/-/mem-5.1.1.tgz#7059b67bf9ac2c924c9f1cff7155a064394adfb3"
+  integrity sha512-qvwipnozMohxLXG1pOqoLiZKNkC4r4qqRucSoDwXowsNGDSULiqFTRUF05vcZWnwJSG22qTsynQhxbaMtnX9gw==
+  dependencies:
+    map-age-cleaner "^0.1.3"
+    mimic-fn "^2.1.0"
+    p-is-promise "^2.1.0"
 
 memfs@^3.1.2:
   version "3.3.0"
@@ -11659,6 +11689,15 @@ os-locale@^1.4.0:
   dependencies:
     lcid "^1.0.0"
 
+os-locale@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/os-locale/-/os-locale-5.0.0.tgz#6d26c1d95b6597c5d5317bf5fba37eccec3672e0"
+  integrity sha512-tqZcNEDAIZKBEPnHPlVDvKrp7NzgLi7jRmhKiUoa2NUmhl13FtkAGLUVR+ZsYvApBQdBfYm43A4tXXQ4IrYLBA==
+  dependencies:
+    execa "^4.0.0"
+    lcid "^3.0.0"
+    mem "^5.0.0"
+
 os-tmpdir@~1.0.2:
   version "1.0.2"
   resolved "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz"
@@ -11675,6 +11714,11 @@ p-all@^2.1.0:
   integrity sha512-HbZxz5FONzz/z2gJfk6bFca0BCiSRF8jU3yCsWOen/vR6lZjfPOu/e7L3uFzTW1i0H8TlC3vqQstEJPQL4/uLA==
   dependencies:
     p-map "^2.0.0"
+
+p-defer@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/p-defer/-/p-defer-1.0.0.tgz#9f6eb182f6c9aa8cd743004a7d4f96b196b0fb0c"
+  integrity sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=
 
 p-each-series@^2.1.0:
   version "2.2.0"
@@ -11699,6 +11743,11 @@ p-finally@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz"
   integrity sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=
+
+p-is-promise@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/p-is-promise/-/p-is-promise-2.1.0.tgz#918cebaea248a62cf7ffab8e3bca8c5f882fc42e"
+  integrity sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==
 
 p-limit@^1.1.0:
   version "1.3.0"
@@ -15170,10 +15219,10 @@ ts-dedent@^2.0.0, ts-dedent@^2.1.1:
   resolved "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.2.0.tgz"
   integrity sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==
 
-ts-document@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.npmjs.org/ts-document/-/ts-document-0.2.1.tgz"
-  integrity sha512-2vGCcx8MxSPHzt6fAo5lUIqmNQyKbiUzFyAdNbnNQlEEYAB5rwbGhI0TNnAo+B7U1kYa3iKkiBhyAwKIssVbXw==
+ts-document@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/ts-document/-/ts-document-0.3.0.tgz#2a34480ef755ef92fa40435ea0641f315f99aa31"
+  integrity sha512-Jysh9JCODspM1pmu8I5nMEXm20SczPrCFqHUeaILADdye6gy5LLmtedgPHeBVziy8XXSboFfWOuYktBKQNm1Og==
   dependencies:
     ts-morph "^11.0.0"
 


### PR DESCRIPTION
升级 `arco-scripits`，避免 `docgen` 生成文档时提取到 HTML 原生属性。