### PR TITLE
fix: The onSelect event is not triggered when the TimePicker input is…

### DIFF
--- a/components/TimePicker/picker.tsx
+++ b/components/TimePicker/picker.tsx
@@ -215,10 +215,18 @@ const Picker = (baseProps: InnerPickerProps) => {
       const newValueShow = [...(isArray(valueShow) ? valueShow : (value as Dayjs[]) || [])];
       if (isValidTimeString(newInputValue, format)) {
         newValueShow[focusedInputIndex] = newInputDayjs;
+        const localDayjsArray = newValueShow.map((nv) => toLocal(nv, utcOffset, timezone));
+        props.onSelect &&
+          props.onSelect(
+            localDayjsArray.map((la) => la && la.format(format)),
+            localDayjsArray
+          );
         setValueShow(newValueShow);
         setInputValue(undefined);
       }
     } else if (isValidTimeString(newInputValue, format)) {
+      const localDayjs = toLocal(newInputDayjs, utcOffset, timezone);
+      props.onSelect && props.onSelect(localDayjs.format(format), localDayjs);
       setValueShow(newInputDayjs);
       setInputValue(undefined);
     }


### PR DESCRIPTION
… correct

<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context

<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

## Solution

<!-- Describe how the problem is fixed in detail -->

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
| TimePicker   | 修复 `TimePicker` 输入正确时不触发 `onSelect` 事件的 bug。   | Fix the `onSelect` event not triggered when the `TimePicker` input is correct.  | Close: https://github.com/arco-design/arco-design/issues/706  |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->
## Checklist:

- [ ] Test suite passes (`npm run test`)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
