### PR TITLE
fix: Menu should keep open keys after collapse/uncollapse

### DIFF
--- a/components/Menu/__test__/index.test.tsx
+++ b/components/Menu/__test__/index.test.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React, { useRef, useState } from 'react';
 import { mount } from 'enzyme';
 import { act } from 'react-dom/test-utils';
 import mountTest from '../../../tests/mountTest';
@@ -195,17 +195,38 @@ describe('Menu', () => {
   });
 
   it('collapse', () => {
-    const component = mount(
-      <Menu mode="vertical" collapse defaultSelectedKeys={['3']}>
-        <MenuItem key="1">设计指南</MenuItem>
-        <SubMenu key="layout" title={<span>布局组件</span>}>
-          <MenuItem key="11">栅格</MenuItem>
-          <MenuItem key="12">分隔符</MenuItem>
-          <MenuItem key="13">布局</MenuItem>
-        </SubMenu>
-      </Menu>
-    );
+    const Demo = () => {
+      const [collapse, setCollapse] = useState(false);
+      return (
+        <div>
+          <button id="collapse" onClick={() => setCollapse(!collapse)}>
+            Collapse
+          </button>
+          <Menu mode="vertical" collapse={collapse} defaultOpenKeys={['layout']}>
+            <MenuItem key="1">设计指南</MenuItem>
+            <SubMenu key="layout" title={<span>布局组件</span>}>
+              <MenuItem key="11">栅格</MenuItem>
+              <MenuItem key="12">分隔符</MenuItem>
+              <MenuItem key="13">布局</MenuItem>
+            </SubMenu>
+          </Menu>
+        </div>
+      );
+    };
+
+    const component = mount(<Demo />);
+
+    expect(
+      component.find('.arco-menu-inline-content').at(0).getDOMNode().getAttribute('style')
+    ).toBe('height: auto;');
+
+    component.find('#collapse').simulate('click');
     expect(component.find(Menu.Item).at(0).find(Tooltip).exists()).toBe(true);
+
+    component.find('#collapse').simulate('click');
+    expect(
+      component.find('.arco-menu-inline-content').at(0).getDOMNode().getAttribute('style')
+    ).toBe('height: auto;');
   });
 
   it('overflowItems should be pack up', () => {

--- a/components/Menu/index.tsx
+++ b/components/Menu/index.tsx
@@ -80,7 +80,7 @@ function Menu(baseProps: MenuProps, ref) {
   const mergedCollapse = siderCollapsed || collapse || inDropdown || mode === 'popButton';
   const theme = propTheme || menuContext.theme || DEFAULT_THEME;
 
-  const refInlineMenuKeys = useRef<string[]>([]);
+  const refSubMenuKeys = useRef<string[]>([]);
   const refPrevSubMenuKeys = useRef<string[]>([]);
   const forceUpdate = useForceUpdate();
 
@@ -113,16 +113,16 @@ function Menu(baseProps: MenuProps, ref) {
   // autoOpen 时，初次渲染展开所有的子菜单
   useEffect(() => {
     // 从 openKeys 中过滤已经不存在的 subMenuKey
-    let validOpenKeys = openKeys.filter((key) => refInlineMenuKeys.current.indexOf(key) !== -1);
+    let validOpenKeys = openKeys.filter((key) => refSubMenuKeys.current.indexOf(key) !== -1);
     if (autoOpen) {
-      const keysAdded = refInlineMenuKeys.current.filter(
+      const keysAdded = refSubMenuKeys.current.filter(
         (key) => refPrevSubMenuKeys.current.indexOf(key) === -1
       );
       validOpenKeys = openKeys.concat(keysAdded);
     }
     setOpenKeys(accordion ? validOpenKeys.slice(0, 1) : validOpenKeys);
-    refPrevSubMenuKeys.current = refInlineMenuKeys.current.slice();
-  }, [refInlineMenuKeys.current.toString()]);
+    refPrevSubMenuKeys.current = refSubMenuKeys.current.slice();
+  }, [refSubMenuKeys.current.toString()]);
 
   const mergedHasCollapseButton =
     mode !== 'horizontal' && mode !== 'popButton' && !inDropdown && hasCollapseButton;
@@ -211,9 +211,9 @@ function Menu(baseProps: MenuProps, ref) {
           clearHotkeyInfo,
           collectInlineMenuKeys: (key, unmount) => {
             if (unmount) {
-              refInlineMenuKeys.current = refInlineMenuKeys.current.filter((x) => x !== key);
+              refSubMenuKeys.current = refSubMenuKeys.current.filter((x) => x !== key);
             } else {
-              refInlineMenuKeys.current.push(key);
+              refSubMenuKeys.current.push(key);
             }
             forceUpdate();
           },

--- a/components/Menu/sub-menu/index.tsx
+++ b/components/Menu/sub-menu/index.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useContext } from 'react';
+import React, { forwardRef, useContext, useEffect } from 'react';
 import SubMenuInline from './inline';
 import SubMenuPop from './pop';
 import { MenuSubMenuProps } from '../interface';
@@ -6,11 +6,18 @@ import MenuContext from '../context';
 
 function SubMenu(props: MenuSubMenuProps, ref) {
   const { children, popup, level } = props;
-  const { mode, collapse, inDropdown } = useContext(MenuContext);
+  const { mode, collapse, inDropdown, collectInlineMenuKeys } = useContext(MenuContext);
 
   const forcePopup = !!(typeof popup === 'function' ? popup(level) : popup);
   const mergedPopup = forcePopup || collapse || inDropdown || mode !== 'vertical';
   const MergedMenu = mergedPopup ? SubMenuPop : SubMenuInline;
+
+  useEffect(() => {
+    collectInlineMenuKeys(props._key);
+    return () => {
+      collectInlineMenuKeys(props._key, true);
+    };
+  }, []);
 
   return (
     <MergedMenu forwardedRef={ref} {...props}>

--- a/components/Menu/sub-menu/inline.tsx
+++ b/components/Menu/sub-menu/inline.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useMemo } from 'react';
+import React, { useContext, useMemo } from 'react';
 import { CSSTransition } from 'react-transition-group';
 import cs from '../../_util/classNames';
 import useStateWithPromise from '../../_util/hooks/useStateWithPromise';
@@ -24,7 +24,6 @@ const SubMenuInline = (props: MenuSubMenuProps & { forwardedRef }) => {
     icons,
     onClickSubMenu,
     onClickMenuItem,
-    collectInlineMenuKeys,
   } = useContext(MenuContext);
 
   const baseClassName = `${prefixCls}-inline`;
@@ -49,13 +48,6 @@ const SubMenuInline = (props: MenuSubMenuProps & { forwardedRef }) => {
     const id = `${menuId}-submenu-inline-${globalInlineSubMenuIndex}`;
     globalInlineSubMenuIndex++;
     return id;
-  }, []);
-
-  useEffect(() => {
-    collectInlineMenuKeys(props._key);
-    return () => {
-      collectInlineMenuKeys(props._key, true);
-    };
   }, []);
 
   // Should omit these properties in Menu.Item


### PR DESCRIPTION

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context

<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

## Solution

<!-- Describe how the problem is fixed in detail -->

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|  Menu   |  修复 `Menu` 组件 `collapse` 属性变化时，已经展开的子菜单被收起的 bug。   |  Fixed the bug that the expanded SubMenu was collapsed when the `collapse` property of the `Menu` component was changed. |    Close #814        |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->
## Checklist:

- [x] Test suite passes (`npm run test`)
- [x] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [x] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
