### PR TITLE
fix: Dropdown will prevent input element in dropdown menu get focused

### DIFF
--- a/components/Dropdown/index.tsx
+++ b/components/Dropdown/index.tsx
@@ -45,8 +45,8 @@ function Dropdown(baseProps: DropdownProps, _) {
 
   const changePopupVisible = (visible: boolean) => {
     setPopupVisible(visible);
-    onVisibleChange && onVisibleChange(visible);
-    triggerProps && triggerProps.onVisibleChange && triggerProps.onVisibleChange(visible);
+    onVisibleChange?.(visible);
+    triggerProps?.onVisibleChange?.(visible);
   };
 
   const handleVisibleChange = (visible: boolean) => {
@@ -71,15 +71,17 @@ function Dropdown(baseProps: DropdownProps, _) {
               returnValueOfOnClickMenuItem = content.props.onClickMenuItem(key, event);
             }
 
-            // Set focus to avoid onblur
-            const child = triggerRef.current && triggerRef.current.getRootElement();
-            child && child.focus && child.focus();
+            const triggerRootElement = triggerRef.current && triggerRef.current.getRootElement();
 
             // Trigger onVisibleChange. Outer component can determine whether to change the state based on the current visibility value.
             if (returnValueOfOnClickMenuItem instanceof Promise) {
-              returnValueOfOnClickMenuItem.finally(() => changePopupVisible(false));
+              returnValueOfOnClickMenuItem.finally(() => {
+                changePopupVisible(false);
+                triggerRootElement?.focus();
+              });
             } else if (returnValueOfOnClickMenuItem !== false) {
               changePopupVisible(false);
+              triggerRootElement?.focus();
             }
           },
         })


### PR DESCRIPTION

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|  Dropdown | 修复 `Dropdown` 下拉菜单中的输入框无法被聚焦的 bug。  |  Fixed the bug that input box in the menu of `Dropdown` can not be focused.    |    Close #841     |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->
## Checklist:

- [ ] Test suite passes (`npm run test`)
- [x] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [x] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
