### PR TITLE
enhancement: InputNumber use non-scientific notation

### DIFF
--- a/components/Dropdown/index.tsx
+++ b/components/Dropdown/index.tsx
@@ -45,8 +45,8 @@ function Dropdown(baseProps: DropdownProps, _) {
 
   const changePopupVisible = (visible: boolean) => {
     setPopupVisible(visible);
-    onVisibleChange?.(visible);
-    triggerProps?.onVisibleChange?.(visible);
+    onVisibleChange && onVisibleChange(visible);
+    triggerProps && triggerProps.onVisibleChange && triggerProps.onVisibleChange(visible);
   };
 
   const handleVisibleChange = (visible: boolean) => {
@@ -71,17 +71,15 @@ function Dropdown(baseProps: DropdownProps, _) {
               returnValueOfOnClickMenuItem = content.props.onClickMenuItem(key, event);
             }
 
-            const triggerRootElement = triggerRef.current && triggerRef.current.getRootElement();
+            // Set focus to avoid onblur
+            const child = triggerRef.current && triggerRef.current.getRootElement();
+            child && child.focus && child.focus();
 
             // Trigger onVisibleChange. Outer component can determine whether to change the state based on the current visibility value.
             if (returnValueOfOnClickMenuItem instanceof Promise) {
-              returnValueOfOnClickMenuItem.finally(() => {
-                changePopupVisible(false);
-                triggerRootElement?.focus();
-              });
+              returnValueOfOnClickMenuItem.finally(() => changePopupVisible(false));
             } else if (returnValueOfOnClickMenuItem !== false) {
               changePopupVisible(false);
-              triggerRootElement?.focus();
             }
           },
         })

--- a/components/InputNumber/__test__/index.test.tsx
+++ b/components/InputNumber/__test__/index.test.tsx
@@ -29,6 +29,24 @@ describe('InputNumber ', () => {
     expect(+wrapper.find('.arco-input').prop('value')).toBe(0);
   });
 
+  it('init value with scientific notation', () => {
+    const wrapper = mountInputNumber(
+      <>
+        <InputNumber defaultValue={1.234e5} />
+        <InputNumber defaultValue={-2.34e-5} />
+        <InputNumber defaultValue={-0.000000000000000000001} />
+        <InputNumber defaultValue={10000000000000000000000} />
+        <InputNumber defaultValue={-10000000000000000000000} />
+      </>
+    );
+
+    expect(wrapper.find('.arco-input').at(0).prop('value')).toBe('123400');
+    expect(wrapper.find('.arco-input').at(1).prop('value')).toBe('-0.0000234');
+    expect(wrapper.find('.arco-input').at(2).prop('value')).toBe('-0.000000000000000000001');
+    expect(wrapper.find('.arco-input').at(3).prop('value')).toBe('10000000000000000000000');
+    expect(wrapper.find('.arco-input').at(4).prop('value')).toBe('-10000000000000000000000');
+  });
+
   it('init value with empty string correctly', () => {
     const wrapper = mountInputNumber(<InputNumber value="" />);
     expect(wrapper.find('.arco-input').prop('value')).toBe('');

--- a/components/InputNumber/index.tsx
+++ b/components/InputNumber/index.tsx
@@ -20,7 +20,7 @@ import { RefInputType } from '../Input/interface';
 import { InputNumberProps } from './interface';
 import useMergeProps from '../_util/hooks/useMergeProps';
 import omit from '../_util/omit';
-import { toFixed } from './utils';
+import { toFixed, toSafeString } from './utils';
 
 NP.enableBoundaryChecking(false);
 
@@ -205,7 +205,7 @@ function InputNumber(baseProps: InputNumberProps, ref) {
     } else if (value == null) {
       _value = '';
     } else {
-      _value = value.toString();
+      _value = toSafeString(value);
     }
 
     return formatter ? formatter(_value) : _value;

--- a/components/InputNumber/utils.ts
+++ b/components/InputNumber/utils.ts
@@ -1,5 +1,46 @@
-// Replace number.toFixed with Math.round
+import NP from 'number-precision';
+
+/**
+ * Replace number.toFixed with Math.round
+ */
 export function toFixed(number: number, precision: number): string {
   const pow = 10 ** precision;
   return (Math.round(number * pow) / pow).toFixed(precision);
+}
+
+/**
+ * Convert number to non-scientific notation
+ */
+export function toSafeString(number: number | string): string {
+  // Use native Number.toString when it is NaN or non-scientific notation
+  const nativeNumberStr = number.toString();
+  if (Number.isNaN(+number) || !nativeNumberStr.includes('e')) {
+    return nativeNumberStr;
+  }
+
+  try {
+    const isNegative = number < 0;
+    const absoluteValue = Math.abs(+number);
+    // Get decimal length
+    const digitLength = NP.digitLength(absoluteValue);
+    // Convert decimal to integer
+    const integerNum = NP.float2Fixed(absoluteValue);
+    // Convert integer to non-scientific notation string
+    const integerStr = integerNum
+      .toString()
+      .replace(/e\+(\d+)/i, (_, $1) => new Array(+$1).fill(0).join(''));
+
+    return `${isNegative ? '-' : ''}${
+      digitLength === 0
+        ? integerStr
+        : integerStr.replace(new RegExp(`\\d{1,${digitLength}}$`), (match) => {
+            const decimalStr = `${new Array(digitLength).fill(0).join('')}${match}`.slice(
+              -digitLength
+            );
+            return `${integerStr.length <= digitLength ? 0 : ''}.${decimalStr}`;
+          })
+    }`;
+  } catch (e) {}
+
+  return nativeNumberStr;
 }

--- a/stories/components/InputNumber.jsx
+++ b/stories/components/InputNumber.jsx
@@ -1,8 +1,8 @@
 import React, { useEffect, useState } from 'react';
 import { InputNumber, Button } from '@self';
 
-export default function() {
-  const [value, setValue] = useState(5);
+export default function () {
+  const [value, setValue] = useState(10000000000000000000000);
   return (
     <div>
       <Button onClick={() => setValue(value + 10)}>Add</Button>


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [ ] Bug fix
- [x] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|   InputNumber      |    `InputNumber` 组件始终使用非科学计数法展示数值。   |  The `InputNumber` component always displays numbers in non-scientific notation.   |     Close #62      |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->
## Checklist:

- [x] Test suite passes (`npm run test`)
- [x] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [x] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
