### PR TITLE
fix: preview switching under current control

### DIFF
--- a/components/Image/image-preview-group.tsx
+++ b/components/Image/image-preview-group.tsx
@@ -62,11 +62,6 @@ function PreviewGroup(props: PropsWithChildren<ImagePreviewGroupProps>, ref) {
     defaultValue: defaultCurrent,
   });
 
-  useEffect(() => {
-    if (isFirstRender) return;
-    onChange && onChange(currentIndex);
-  }, [currentIndex]);
-
   function registerPreviewUrl(id: number, url: string, preview: boolean) {
     if (!propPreviewUrlMap) {
       setPreviewUrlMap((pre) =>
@@ -98,6 +93,11 @@ function PreviewGroup(props: PropsWithChildren<ImagePreviewGroupProps>, ref) {
   const handleVisibleChange = (visible, preVisible) => {
     setVisible(visible);
     onVisibleChange && onVisibleChange(visible, preVisible);
+  };
+
+  const handleSwitch = (index: number) => {
+    onChange && onChange(index);
+    setCurrentIndex(index);
   };
 
   const loopImageIndex = (children) => {
@@ -132,7 +132,7 @@ function PreviewGroup(props: PropsWithChildren<ImagePreviewGroupProps>, ref) {
         previewUrlMap: canPreviewUrlMap,
         infinite,
         currentIndex,
-        setCurrentIndex,
+        setCurrentIndex: handleSwitch,
         setPreviewUrlMap,
         registerPreviewUrl,
         visible,


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context

<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

多图预览`<Image.PreviewGroup />`使用`current + onChange`受控的情况下不能切换， #877 。

## Solution

<!-- Describe how the problem is fixed in detail -->

由于是使用`useEffect`依赖于`currentIndex`变化触发的，在`current`受控的情况下使用`setCurrentIndex`，在`re-render`之后由于会被`propCurrentIndex`覆盖掉，所以并不会触发`Effect`，所以解决方案是在`setCurrentIndex`之前即触发`onChange`。

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

与 https://codesandbox.io/s/ecstatic-tereshkova-s6wlb4?file=/index.js 相同的示例，能够切换图片。

<img width="1680" alt="image" src="https://user-images.githubusercontent.com/33169019/168984297-3ddccc5d-7ce4-47c5-aba9-cebf61e26d37.png">


<img width="1167" alt="image" src="https://user-images.githubusercontent.com/33169019/168984134-10584954-040b-44bc-bc63-2963cf97aa01.png">


## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|     Image     |       修复 `<Image.PreviewGroup />`  组件在 `current` 受控时 `onChange` 事件不触发的问题        |      Fixed `<Image.PreviewGroup />` component's `onChange` event not firing when `current` is controlled        |       close #877          |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->
## Checklist:

- [x] Test suite passes (`npm run test`)
- [x] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [x] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
