### PR TITLE
style: SubMenu icon does not show when Menu is collapsed

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -24,8 +24,13 @@ function getLoaderForStyle(isCssModule) {
 module.exports = {
   stories: ['../stories/index.stories.js'],
   webpackFinal: (config) => {
-    config.resolve.alias['@self/icon'] = path.resolve(__dirname, '../icon');
-    config.resolve.alias['@self'] = path.resolve(__dirname, '../es');
+    const dirIcon = path.resolve(__dirname, '../icon');
+    const dirComponent = path.resolve(__dirname, '../es');
+
+    config.resolve.alias['@self/icon'] = dirIcon;
+    config.resolve.alias['@self'] = dirComponent;
+    config.resolve.alias['@arco-design/web-react/icon'] = dirIcon;
+    config.resolve.alias['@arco-design/web-react'] = dirComponent;
 
     config.resolve.modules = ['node_modules', path.resolve(__dirname, '../site/node_modules')];
     // 解决 webpack 编译警告

--- a/components/Menu/indent.tsx
+++ b/components/Menu/indent.tsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { useContext } from 'react';
+import MenuContext from './context';
 
 export default function MenuIndent(props: {
   prefixCls: string;
@@ -6,8 +7,10 @@ export default function MenuIndent(props: {
   levelIndent?: number;
 }) {
   const { prefixCls, levelIndent } = props;
+  const { collapse } = useContext(MenuContext);
   const level = props.level - 1;
-  return level > 0 ? (
+
+  return !collapse && level > 0 ? (
     <span>
       {[...new Array(level)].map((_, index) => {
         return (

--- a/components/Menu/style/index.less
+++ b/components/Menu/style/index.less
@@ -348,6 +348,7 @@
       padding: @menu-collapse-padding-vertical @menu-collapse-padding-horizontal;
     }
 
+    .@{menu-prefix-cls}-group-title,
     .@{menu-prefix-cls}-icon-suffix {
       display: none;
     }
@@ -355,7 +356,7 @@
     // Hide text after icon when menu is collapsed
     @style-item-text: {
       .@{prefix}-icon {
-        margin-right: 100%;
+        margin-right: 100vw;
       }
     };
 


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|   Menu  |  修复 `Menu` 组件折叠状态下子菜单标题的图标未展示的 bug。     |  Fixed the bug that the icon of SubMenu title was not displayed when Menu is collapsed.   |                |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->
## Checklist:

- [x] Test suite passes (`npm run test`)
- [x] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [x] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
