### PR TITLE
fix: Dropdown.Menu's callback onMenuItemClick missing the third argument keyPath

### DIFF
--- a/components/Dropdown/__test__/index.test.tsx
+++ b/components/Dropdown/__test__/index.test.tsx
@@ -46,12 +46,15 @@ describe('Dropdown', () => {
   });
 
   it('click menu item', () => {
+    const onClickMenuItem = jest.fn();
     const wrapper = mountDropdown(
       <Dropdown
         trigger="click"
         droplist={
           <Menu
-            onClickMenuItem={(key) => {
+            onClickMenuItem={(key, _, keyPath) => {
+              onClickMenuItem(keyPath);
+
               if (key === '2') {
                 return false;
               }
@@ -87,6 +90,7 @@ describe('Dropdown', () => {
 
     simulateMenuItemClick(0);
     expect(getIsTriggerVisible()).toBe(false);
+    expect(onClickMenuItem).toBeCalledWith(['1']);
 
     wrapper.find(Button).simulate('click');
     simulateMenuItemClick(1);

--- a/components/Dropdown/index.tsx
+++ b/components/Dropdown/index.tsx
@@ -62,13 +62,13 @@ function Dropdown(baseProps: DropdownProps, _) {
           prefixCls: `${prefixCls}-menu`,
           inDropdown: true,
           selectable: false,
-          onClickMenuItem: (key, event) => {
+          onClickMenuItem: (...args) => {
             let returnValueOfOnClickMenuItem = null;
 
             // Trigger onClickMenuItem first
             const content = getPopupContent();
             if (content.props.onClickMenuItem) {
-              returnValueOfOnClickMenuItem = content.props.onClickMenuItem(key, event);
+              returnValueOfOnClickMenuItem = content.props.onClickMenuItem(...args);
             }
 
             // Set focus to avoid onblur


### PR DESCRIPTION
## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|   Dropdown   |   修复 `Dropdown` 内的 `Menu` 组件 `onMenuItemClick` 的第三个参数 `keyPath` 缺失的 bug。  |   Fixed the bug that the third parameter `keyPath` of `onMenuItemClick` in `Dropdown.Menu` was missing.    |                |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->
## Checklist:

- [ ] Test suite passes (`npm run test`)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
