### PR TITLE
feat: Upload  supports imageRender & progressRender

### DIFF
--- a/components/Upload/README.en-US.md
+++ b/components/Upload/README.en-US.md
@@ -88,6 +88,8 @@ type CustomIconType = {
   startIcon?: ReactNode;
   errorIcon?: ReactNode;
   fileName?: (file: UploadItem) => ReactNode;
+  progressRender?: (file: UploadItem, originDom: ReactNode) => ReactElement; // 2.34.0
+  imageRender?: (file: UploadItem) => ReactNode; // 2.34.0
 }
 ```
 

--- a/components/Upload/README.zh-CN.md
+++ b/components/Upload/README.zh-CN.md
@@ -88,6 +88,8 @@ type CustomIconType = {
   startIcon?: ReactNode;
   errorIcon?: ReactNode;
   fileName?: (file: UploadItem) => ReactNode;
+  progressRender?: (file: UploadItem, originDom: ReactNode) => ReactElement; // 2.34.0
+  imageRender?: (file: UploadItem) => ReactNode; // 2.34.0
 }
 ```
 

--- a/components/Upload/__test__/list.test.tsx
+++ b/components/Upload/__test__/list.test.tsx
@@ -89,4 +89,32 @@ describe('Upload list', function () {
 
     expect(changeFile.status).toBe(STATUS.uploading);
   });
+
+  it('showUploadList progressRender, imageRender', async function () {
+    const wrapper = mount<UploadProps>(
+      <Upload
+        fileList={[defaultFileList[0]]}
+        action="/sss"
+        showUploadList={{
+          progressRender: () => {
+            return <div id="progress">aaa</div>;
+          },
+          imageRender: () => {
+            return <div id="image">aaa</div>;
+          }
+        }}
+      />
+    );
+
+    expect(wrapper.find('#progress')).toHaveLength(1);
+
+    wrapper.setProps({
+      listType: 'picture-card',
+    });
+
+    wrapper.update();
+
+    expect(wrapper.find('#image')).toHaveLength(1);
+  });
+
 });

--- a/components/Upload/interface.tsx
+++ b/components/Upload/interface.tsx
@@ -24,6 +24,10 @@ export type CustomIconType = {
   errorIcon?: ReactNode;
   successIcon?: ReactNode;
   fileName?: (file: UploadItem) => ReactNode;
+  // 2.34.0
+  progressRender?: (file: UploadItem, originDom: ReactNode) => React.ReactElement;
+  // 2.34.0
+  imageRender?: (file: UploadItem) => React.ReactNode;
 };
 
 export type RequestOptions = Pick<

--- a/components/Upload/list/pictureItem.tsx
+++ b/components/Upload/list/pictureItem.tsx
@@ -33,7 +33,7 @@ const PictureItem = (props: UploadListProps & { file: UploadItem }) => {
         />
       ) : (
         <>
-          <img src={url} />
+          {isFunction(actionIcons.imageRender) ? actionIcons.imageRender(file) : <img src={url} />}
           <div className={`${cls}-mask`}>
             {file.status === STATUS.fail && (
               <div className={`${cls}-error-tip`}>

--- a/components/Upload/list/textItem.tsx
+++ b/components/Upload/list/textItem.tsx
@@ -81,7 +81,11 @@ const TextItem = (
       <div className={cls}>
         {props.listType === 'picture-list' && (
           <div className={`${cls}-thumbnail`}>
-            <img src={url} />
+            {isFunction(showUploadList.imageRender) ? (
+              showUploadList.imageRender(file)
+            ) : (
+              <img src={url} />
+            )}
           </div>
         )}
         <div className={`${cls}-content`}>

--- a/components/Upload/list/uploadProgress.tsx
+++ b/components/Upload/list/uploadProgress.tsx
@@ -8,6 +8,7 @@ import IconUpload from '../../../icon/react-icon/IconUpload';
 import IconPlayArrowFill from '../../../icon/react-icon/IconPlayArrowFill';
 import IconPause from '../../../icon/react-icon/IconPause';
 import Tooltip from '../../Tooltip';
+import { isFunction } from '../../_util/is';
 
 const UploadProgress: FC<
   {
@@ -20,12 +21,12 @@ const UploadProgress: FC<
     onAbort?: UploadListProps['onAbort'];
   } & CustomIconType
 > = (props) => {
-  const { file, prefixCls, progressProps } = props;
+  const { file, prefixCls, progressProps, progressRender } = props;
   const { locale } = useContext(ConfigContext);
   const { status, percent = 0 } = file;
   const cls = `${prefixCls}-list`;
   const widthStyle = progressProps && progressProps.width ? { width: progressProps.width } : {};
-  return (
+  const dom = (
     <>
       {status === STATUS.fail && props.reuploadIcon !== null && (
         <span
@@ -89,6 +90,8 @@ const UploadProgress: FC<
       )}
     </>
   );
+
+  return isFunction(progressRender) ? progressRender(file, dom) : dom;
 };
 
 export default UploadProgress;

--- a/components/Upload/style/index.less
+++ b/components/Upload/style/index.less
@@ -377,7 +377,6 @@
   &-item-picture {
     width: @upload-picture-item-size-width;
     height: @upload-picture-item-size-width;
-    line-height: @upload-picture-item-size-width;
     position: relative;
     overflow: hidden;
     border-radius: @upload-picture-item-border-radius;

--- a/components/Upload/style/token.less
+++ b/components/Upload/style/token.less
@@ -79,7 +79,7 @@
 @upload-picture-item-border-radius: @radius-small;
 @upload-picture-item-margin-right: @spacing-4;
 @upload-picture-item-margin-bottom: @spacing-4;
-@upload-picture-item-color-bg: @color-transparent;
+@upload-picture-item-color-bg: var(~'@{arco-cssvars-prefix}-color-fill-2');
 @upload-picture-item-color-operation_bg: rgba(0, 0, 0, 0.5);
 @upload-picture-item-color-operation-icon: var(~'@{arco-cssvars-prefix}-color-white');
 @upload-picture-item-color-error-icon: var(~'@{arco-cssvars-prefix}-color-white');

--- a/components/Upload/uploader.tsx
+++ b/components/Upload/uploader.tsx
@@ -246,7 +246,7 @@ class Uploader extends React.Component<UploaderProps, UploaderState> {
             }}
             prefixCls={prefixCls}
           >
-            {children}
+            {isFunction(children) ? children({ fileList: this.props.fileList }) : children}
           </TriggerNode>
         </CSSTransition>
         {tip && listType !== 'picture-card' && !drag ? (


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [x] New feature
- [ ] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context

<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

## Solution

<!-- Describe how the problem is fixed in detail -->

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|       Upload    |   `Upload` 组件支持通过 `showUploadList.imageRender` 属性渲染图片。          | The `Upload` component supports rendering images via the `showUploadList.imageRender` property.              |      close #884           |
|       Upload    |   `Upload` 组件支持通过 `showUploadList.progressRender` 属性渲染上传进度节点。       |      The `Upload` component supports rendering upload progress nodes via the `showUploadList.progressRender` property.         |      close #884           |
|       Upload    |   `Upload` 组件支持传入函数类型的 `children` 渲染触发上传的节点内容。       |      The `Upload` component supports `children` passed in the function type to render the node content that triggers the upload.         |      close #883           |
|       Upload    |   `Upload` 组件照片墙模式下图片展示区域新增默认灰色背景。       |    The default gray background has been added to the picture display area in the photo wall mode of the `Upload` component.           |                |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->
## Checklist:

- [ ] Test suite passes (`npm run test`)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
