### PR TITLE
fix(Layout.Sider): Add CSS units support for width property

### DIFF
--- a/components/Layout/__test__/index.test.tsx
+++ b/components/Layout/__test__/index.test.tsx
@@ -60,14 +60,14 @@ describe('Layout', () => {
       </Sider>
     );
 
-    expect(wrapper.find('.arco-layout-sider').at(0).prop('style').width).toEqual(60);
+    expect(wrapper.find('.arco-layout-sider').at(0).prop('style').width).toEqual("60px");
     wrapper.setProps({
       collapsed: false,
       width: 300,
     });
     jest.advanceTimersByTime(1000);
     wrapper.update();
-    expect(wrapper.find('.arco-layout-sider').at(0).prop('style').width).toEqual(300);
+    expect(wrapper.find('.arco-layout-sider').at(0).prop('style').width).toEqual("300px");
   });
 
   it('has Resize Sider', () => {

--- a/components/Layout/sider.tsx
+++ b/components/Layout/sider.tsx
@@ -60,8 +60,8 @@ function Sider(props: SiderProps, ref) {
   const [collapsed, setCollapsed] = useMergeValue(false, {
     value: props.collapsed,
   });
-  const propsWidth = isNumber(width) ? width : parseFloat(width);
-  const [siderWidth, setSiderWidth] = useState(propsWidth);
+  const propsWidth = isNumber(width) ? `${width}px` : String(width);
+  const [siderWidth, setSiderWidth] = useState<string>(propsWidth);
 
   const refResponsiveHandlerToken = useRef(null);
   // 提供给 ResponsiveHandler，使得其可以获得最新的 state 值

--- a/components/Layout/sider.tsx
+++ b/components/Layout/sider.tsx
@@ -60,6 +60,8 @@ function Sider(props: SiderProps, ref) {
   const [collapsed, setCollapsed] = useMergeValue(false, {
     value: props.collapsed,
   });
+  //Parsing props width from number to string, to be used as css property value. 
+  //Using px as the default unit
   const propsWidth = isNumber(width) ? `${width}px` : String(width);
   const [siderWidth, setSiderWidth] = useState<string>(propsWidth);
 
@@ -104,7 +106,10 @@ function Sider(props: SiderProps, ref) {
   }, []);
 
   useEffect(() => {
-    setSiderWidth(collapsed ? collapsedWidth : propsWidth);
+    //Parsing collapsed width from number to string, to be used as css property value. 
+    //Using px as the default unit
+    const _collapsedWidth = isNumber(collapsedWidth) ? `${collapsedWidth}px` : String(collapsedWidth)
+    setSiderWidth(collapsed ? _collapsedWidth : propsWidth);
   }, [collapsed, propsWidth, collapsedWidth]);
 
   const resizable =


### PR DESCRIPTION

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context

#946 中，以及 #937 的评论中，提出了以下问题：
<img width="878" alt="image" src="https://user-images.githubusercontent.com/8275280/171556072-292239ae-c8ae-4c19-9368-ec30ab7bbea3.png">

该问题的根本原因是，目前传给 Sider 的 width 属性的值 (`siderWidth`) 的类型是 number，而不是 string。这会导致这个值无法明确指定长度单位，从而只能被浏览器自动 fallback 为 px 。

```javascript
style={{
  width: siderWidth, 
}}
```

## Solution
1. 修改了测试用例，将预期的 width 属性值从 number 改成对应的以 px 为单位的 string。例如，`300`改为`300px`。
2. 对 propsWidth 和 collapsedWidth 都进行类型判定和转换，如果 raw value 是有单位的string，则保持不变，否则加上"px"变成string，使得长度单位更加精确。

## How is the change tested?
通过自动化单元测试，以及手动对组件进行测试，验证了修改后的 `width` 可以支持"rem"等其他单位。
<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|`Layout.Sider` | 增加 width 属性对 css 单位的支持|  Add CSS units support for width property | #946  |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->
## Checklist:

- [x] Test suite passes (`npm run test`)
- [x] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [x] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
