### PR TITLE
[WIP] [help wanted]: style(Tree): fix block node style

### DIFF
--- a/components/Select/option.tsx
+++ b/components/Select/option.tsx
@@ -61,11 +61,11 @@ function Option(props: OptionProps, ref) {
   const wrapperProps = {
     ref,
     role: 'option',
-    ['aria-selected']: isChecked,
+    'aria-selected': isChecked,
   };
   // Mark the option that created/creating by user self
-  _isUserCreatedOption && Object.assign(wrapperProps, { ['data-user-created']: true });
-  _isUserCreatingOption && Object.assign(wrapperProps, { ['data-user-creating']: true });
+  _isUserCreatedOption && Object.assign(wrapperProps, { 'data-user-created': true });
+  _isUserCreatingOption && Object.assign(wrapperProps, { 'data-user-creating': true });
 
   if (_isMultipleMode) {
     return (

--- a/components/Tree/node.tsx
+++ b/components/Tree/node.tsx
@@ -56,6 +56,7 @@ function TreeNode(props: PropsWithChildren<NodeProps>, ref) {
     showLine,
     loading,
     selectable = true,
+    blockNode,
   } = props;
 
   const prefixCls = getPrefixCls('tree-node');
@@ -68,6 +69,7 @@ function TreeNode(props: PropsWithChildren<NodeProps>, ref) {
       [`${prefixCls}-disabled-selectable`]: !selectable,
       [`${prefixCls}-disabled`]: disabled,
       [`${prefixCls}-draggable`]: draggable,
+      [`${prefixCls}-block`]: blockNode,
     },
     props.className
   );
@@ -219,7 +221,6 @@ function TreeNode(props: PropsWithChildren<NodeProps>, ref) {
               state.isAllowDrop &&
               state.dragPosition === 0,
             [`${prefixCls}-title-dragging`]: state.isDragging,
-            [`${prefixCls}-title-block`]: props.blockNode,
           })}
           onClick={(e) => {
             const { onSelect, actionOnClick } = treeContext;

--- a/components/Tree/style/index.less
+++ b/components/Tree/style/index.less
@@ -160,9 +160,13 @@
     }
   }
 
-  &-node-title-block {
+  &-node-block {
     flex: 1;
     box-sizing: content-box;
+
+    &:hover {
+      background-color: @tree-color-title-bg_hover;
+    }
 
     .@{tree-node-prefix-cls}-drag-icon {
       position: absolute;
@@ -196,7 +200,6 @@
     // overflow: hidden;
 
     &:hover {
-      background-color: @tree-color-title-bg_hover;
       color: @tree-color-title-text_hover;
 
       .@{tree-node-prefix-cls}-drag-icon {


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [ ] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [x] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context

See #1006 

![image](https://user-images.githubusercontent.com/8275280/174927280-54aa8e9d-0ae9-477d-b5af-e95e58b55ff8.png)

## Solution

把对 `:hover` 时背景色的处理、以及点击、拖拽事件，都从 `node-title` 拿到了 `node` 上，解决了 blockNode 的样式问题和事件处理问题。

<img width="657" alt="Screen Shot 2022-06-21 at 8 38 25 PM" src="https://user-images.githubusercontent.com/8275280/174918993-e7524c02-5428-4084-8adf-94bdafae07ad.png">

唯一的遗留问题是：拖拽 icon 不能正常显示出来

（正常：）
<img width="75" alt="image" src="https://user-images.githubusercontent.com/8275280/175210220-9fe62efd-b82b-415c-8492-68c9d08ec8d7.png">
（缺失拖拽icon：）
<img width="130" alt="image" src="https://user-images.githubusercontent.com/8275280/175210266-f683803f-1a5e-46ab-a6bb-0bff89eeb78a.png">


希望好心人可以指导一下，该怎么正确处理这个icon的显示位置 ❤️  或者如果我目前PR里的解决方法不好的话，也恳请指教

（或者如果已经有同学解决了这个 issue 的话，就 close 我这个 PR 就好，我去看你的 PR 学习一下~）


## How is the change tested?

WIP

（测试用例暂时还没修改，等问题都解决了再修改测试用例~）

## Changelog

WIP


## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
