### PR TITLE
fix: avoid InputNumber being interfered with by Input's global config

### DIFF
--- a/components/Input/interface.tsx
+++ b/components/Input/interface.tsx
@@ -116,6 +116,7 @@ export interface InputProps
    * @en With `maxLength`, Show word count.
    */
   showWordLimit?: boolean;
+  _ignorePropsFromGlobal?: boolean;
 }
 
 /**

--- a/components/InputNumber/index.tsx
+++ b/components/InputNumber/index.tsx
@@ -280,6 +280,7 @@ function InputNumber(baseProps: InputNumberProps, ref) {
 
   return (
     <Input
+      _ignorePropsFromGlobal
       role="spinbutton"
       aria-valuemax={max}
       aria-valuemin={min}

--- a/components/Pagination/page-jumper.tsx
+++ b/components/Pagination/page-jumper.tsx
@@ -70,6 +70,7 @@ function PageJumper(props: PageJumperProps) {
       {!simple && <span className={`${prefixCls}-text-goto`}>{locale.Pagination.goto}</span>}
       {inputConfig.showJumper ? (
         <Input
+          _ignorePropsFromGlobal
           ref={(ref) => (inputRef.current = ref)}
           className={`${prefixCls}-input`}
           value={!isUndefined(inputText) ? inputText.toString() : undefined}

--- a/components/_util/hooks/useMergeProps.ts
+++ b/components/_util/hooks/useMergeProps.ts
@@ -5,9 +5,10 @@ export default function useMergeProps<PropsType>(
   defaultProps: Partial<PropsType>,
   globalComponentConfig: Partial<PropsType>
 ): PropsType {
+  const { _ignorePropsFromGlobal } = componentProps as any;
   const _defaultProps = useMemo(() => {
-    return { ...defaultProps, ...globalComponentConfig };
-  }, [defaultProps, globalComponentConfig]);
+    return { ...defaultProps, ...(_ignorePropsFromGlobal ? {} : globalComponentConfig) };
+  }, [defaultProps, globalComponentConfig, _ignorePropsFromGlobal]);
 
   const props = useMemo(() => {
     const mProps = { ...componentProps };


### PR DESCRIPTION
## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
| InputNumber |  修复 `InputNumber` 被 `Input` 的全局配置影响的 bug。 |  Fixed a bug where `InputNumber` was affected by the global configuration of `Input`.  |  Close #1020   |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->
## Checklist:

- [ ] Test suite passes (`npm run test`)
- [x] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [x] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
