### PR TITLE
style: Dropdown should hide itself when it's empty

### DIFF
--- a/components/Dropdown/index.tsx
+++ b/components/Dropdown/index.tsx
@@ -57,33 +57,46 @@ function Dropdown(baseProps: DropdownProps, _) {
 
   const renderPopup = () => {
     const content = getPopupContent();
-    return content && content.props.isMenu
-      ? React.cloneElement(content as ReactElement, {
-          prefixCls: `${prefixCls}-menu`,
-          inDropdown: true,
-          selectable: false,
-          onClickMenuItem: (...args) => {
-            let returnValueOfOnClickMenuItem = null;
 
-            // Trigger onClickMenuItem first
-            const content = getPopupContent();
-            if (content.props.onClickMenuItem) {
-              returnValueOfOnClickMenuItem = content.props.onClickMenuItem(...args);
-            }
+    if (content?.props?.isMenu) {
+      let isEmpty = true;
+      for (const child of React.Children.toArray(content.props.children)) {
+        if (child !== null && child !== undefined) {
+          isEmpty = false;
+          break;
+        }
+      }
 
-            // Set focus to avoid onblur
-            const child = triggerRef.current && triggerRef.current.getRootElement();
-            child && child.focus && child.focus();
+      return React.cloneElement(content as ReactElement, {
+        prefixCls: cs(`${prefixCls}-menu`, {
+          [`${prefixCls}-menu-hidden`]: isEmpty,
+        }),
+        inDropdown: true,
+        selectable: false,
+        onClickMenuItem: (...args) => {
+          let returnValueOfOnClickMenuItem = null;
 
-            // Trigger onVisibleChange. Outer component can determine whether to change the state based on the current visibility value.
-            if (returnValueOfOnClickMenuItem instanceof Promise) {
-              returnValueOfOnClickMenuItem.finally(() => changePopupVisible(false));
-            } else if (returnValueOfOnClickMenuItem !== false) {
-              changePopupVisible(false);
-            }
-          },
-        })
-      : content;
+          // Trigger onClickMenuItem first
+          const content = getPopupContent();
+          if (content.props.onClickMenuItem) {
+            returnValueOfOnClickMenuItem = content.props.onClickMenuItem(...args);
+          }
+
+          // Set focus to avoid onblur
+          const child = triggerRef.current && triggerRef.current.getRootElement();
+          child && child.focus && child.focus();
+
+          // Trigger onVisibleChange. Outer component can determine whether to change the state based on the current visibility value.
+          if (returnValueOfOnClickMenuItem instanceof Promise) {
+            returnValueOfOnClickMenuItem.finally(() => changePopupVisible(false));
+          } else if (returnValueOfOnClickMenuItem !== false) {
+            changePopupVisible(false);
+          }
+        },
+      });
+    }
+
+    return content;
   };
 
   return (


### PR DESCRIPTION

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [ ] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [x] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|   Dropdown   |   在 `Dropdown` 的菜单项没有子节点时彻底隐藏弹出菜单。  |   Completely hides the popup menu when the `Dropdown` menu item has no children.    |                |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->
## Checklist:

- [ ] Test suite passes (`npm run test`)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
