### PR TITLE
fix: react warning caused by _ignorePropsFromGlobal

### DIFF
--- a/components/Input/input.tsx
+++ b/components/Input/input.tsx
@@ -17,7 +17,7 @@ import useMergeValue from '../_util/hooks/useMergeValue';
 import InputComponent from './input-element';
 import Group from './group';
 import { contains } from '../_util/dom';
-import useMergeProps from '../_util/hooks/useMergeProps';
+import useMergeProps, { MergePropsOptions } from '../_util/hooks/useMergeProps';
 
 const keepFocus = (e) => {
   e.target.tagName !== 'INPUT' && e.preventDefault();
@@ -198,16 +198,16 @@ function Input(baseProps: InputProps, ref) {
   );
 }
 
-type InputRefType = ForwardRefExoticComponent<InputProps & React.RefAttributes<RefInputType>> & {
+type InputRefType = ForwardRefExoticComponent<
+  InputProps & React.RefAttributes<RefInputType> & MergePropsOptions
+> & {
   Search: typeof Search;
   TextArea: typeof TextArea;
   Password: typeof Password;
   Group: typeof Group;
 };
 
-const InputElement: InputRefType = React.forwardRef<RefInputType, InputProps>(
-  Input
-) as InputRefType;
+const InputElement = React.forwardRef(Input) as InputRefType;
 
 InputElement.displayName = 'Input';
 

--- a/components/Input/interface.tsx
+++ b/components/Input/interface.tsx
@@ -116,7 +116,6 @@ export interface InputProps
    * @en With `maxLength`, Show word count.
    */
   showWordLimit?: boolean;
-  _ignorePropsFromGlobal?: boolean;
 }
 
 /**

--- a/components/_util/hooks/useMergeProps.ts
+++ b/components/_util/hooks/useMergeProps.ts
@@ -1,17 +1,23 @@
 import { useMemo } from 'react';
+import omit from '../omit';
+
+export type MergePropsOptions = {
+  _ignorePropsFromGlobal?: boolean;
+};
 
 export default function useMergeProps<PropsType>(
-  componentProps: PropsType,
+  componentProps: PropsType & MergePropsOptions,
   defaultProps: Partial<PropsType>,
   globalComponentConfig: Partial<PropsType>
 ): PropsType {
-  const { _ignorePropsFromGlobal } = componentProps as any;
+  const { _ignorePropsFromGlobal } = componentProps;
   const _defaultProps = useMemo(() => {
     return { ...defaultProps, ...(_ignorePropsFromGlobal ? {} : globalComponentConfig) };
   }, [defaultProps, globalComponentConfig, _ignorePropsFromGlobal]);
 
   const props = useMemo(() => {
-    const mProps = { ...componentProps };
+    // Must remove property of MergePropsOptions before passing it to component
+    const mProps = omit(componentProps, ['_ignorePropsFromGlobal']) as PropsType;
 
     // https://github.com/facebook/react/blob/cae635054e17a6f107a39d328649137b83f25972/packages/react/src/ReactElement.js#L312
     for (const propName in _defaultProps) {


### PR DESCRIPTION
## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|  Input | 修复 `Input` 组件导致的控制台 React Warning(not recognize prop on a DOM element)。 | Fix console React Warning (not recognize prop on a DOM element) caused by `Input` component.  |  Close #1067  |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->
## Checklist:

- [ ] Test suite passes (`npm run test`)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)
