### PR TITLE
TreeSelect to support controlled inputValue like Select did

### DIFF
--- a/components/TreeSelect/README.en-US.md
+++ b/components/TreeSelect/README.en-US.md
@@ -28,6 +28,7 @@ Can choose tree structure data.Only Single choice is supports.
 |treeCheckable|Whether to show checkbox|boolean |`-`|-|
 |treeCheckStrictly|Whether the parent and child nodes are related|boolean |`-`|-|
 |unmountOnExit|Whether to destroy the DOM after hiding|boolean |`-`|-|
+|inputValue|To set input search value|string |`-`|2.38.0|
 |placeholder|Placeholder of element|string |`-`|-|
 |fieldNames|Custom field name for key, title, isLeaf, disabled and children|[TreeProps](tree#tree)['fieldNames'] |`DefaultFieldNames`|2.11.0|
 |size|Height of element, `24px` `28px` `32px` `36px`|'mini' \| 'small' \| 'default' \| 'large' |`-`|-|
@@ -55,6 +56,7 @@ Can choose tree structure data.Only Single choice is supports.
 |onChange|Callback when the selection changed|(value: any,extra: {trigger?: [NodeProps](tree#treenode);checked?: boolean;selected?: boolean;}) => void |`-`|`extra` in `2.29.0`|
 |onClear|Callback when clicked clear, the parameter is the visible state of current dropdown|(visible: boolean) => void |`-`|-|
 |onClick|Callback when the mouse clicks on the drop-down box|(e) => void |`-`|-|
+|onInputValueChange|Callback when the search value of input is changed.|(value: string, reason: [InputValueChangeReason](#inputvaluechangereason)) => void |`-`|2.38.0|
 |onSearch|Callback when searching data. When undefined, it will search in the data already|(inputValue: string) => void |`-`|-|
 |onVisibleChange|Callback when the visibility of the popup is changed|(visible: boolean) => void |`-`|-|
 |renderTag|Custom tag rendering, `props` is the current tag attribute, `index` is the order of the current tag, `values` is the value of all tags|(props: {value: any;label: ReactNode;closable: boolean;onClose: (event) => void;},index: number,values: [ObjectValueType](#objectvaluetype)[]) => ReactNode |`-`|index、values added in 2.15.0|
@@ -91,6 +93,17 @@ export type TreeDataType = NodeProps & {
   children?: TreeDataType[];
   [key: string]: any;
 };
+```
+
+### InputValueChangeReason
+
+```js
+// 造成输入框值改变的原因：用户输入、选中选项、选项下拉框收起、触发自动分词
+export type InputValueChangeReason =
+  | "manual"
+  | "optionChecked"
+  | "optionListHide"
+  | "tokenSeparator";
 ```
 
 ### ObjectValueType

--- a/components/TreeSelect/README.zh-CN.md
+++ b/components/TreeSelect/README.zh-CN.md
@@ -28,6 +28,7 @@
 |treeCheckable|是否展示复选框|boolean |`-`|-|
 |treeCheckStrictly|父子节点是否关联|boolean |`-`|-|
 |unmountOnExit|是否在隐藏之后销毁 DOM 结构|boolean |`-`|-|
+|inputValue|输入框搜索文本的受控值|string |`-`|2.38.0|
 |placeholder|选择框默认文字。|string |`-`|-|
 |fieldNames|指定 key，title，isLeaf，disabled，children 对应的字段|[TreeProps](tree#tree)['fieldNames'] |`DefaultFieldNames`|2.11.0|
 |size|分别不同尺寸的选择器。对应 `24px`, `28px`, `32px`, `36px`|'mini' \| 'small' \| 'default' \| 'large' |`-`|-|
@@ -55,6 +56,7 @@
 |onChange|选中值改变的回调|(value: any,extra: {trigger?: [NodeProps](tree#treenode);checked?: boolean;selected?: boolean;}) => void |`-`|`extra` in `2.29.0`|
 |onClear|点击清除时触发，参数是当前下拉框的展开状态。|(visible: boolean) => void |`-`|-|
 |onClick|鼠标点击下拉框时的回调|(e) => void |`-`|-|
+|onInputValueChange|输入框搜索文本改变的回调。|(value: string, reason: [InputValueChangeReason](#inputvaluechangereason)) => void |`-`|2.38.0|
 |onSearch|自定义搜索方法。未定义的时候将会在已经在数据中进行搜索|(inputValue: string) => void |`-`|-|
 |onVisibleChange|下拉框收起展开时触发|(visible: boolean) => void |`-`|-|
 |renderTag|自定义标签渲染，`props` 为当前标签属性，`index` 为当前标签的顺序，`values` 为所有标签的值.|(props: {value: any;label: ReactNode;closable: boolean;onClose: (event) => void;},index: number,values: [ObjectValueType](#objectvaluetype)[]) => ReactNode |`-`|index、values added in 2.15.0|
@@ -91,6 +93,17 @@ export type TreeDataType = NodeProps & {
   children?: TreeDataType[];
   [key: string]: any;
 };
+```
+
+### InputValueChangeReason
+
+```js
+// 造成输入框值改变的原因：用户输入、选中选项、选项下拉框收起、触发自动分词
+export type InputValueChangeReason =
+  | "manual"
+  | "optionChecked"
+  | "optionListHide"
+  | "tokenSeparator";
 ```
 
 ### ObjectValueType

--- a/components/TreeSelect/hook/useMergedInputValue.ts
+++ b/components/TreeSelect/hook/useMergedInputValue.ts
@@ -1,0 +1,24 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { isUndefined } from '../../_util/is';
+
+export default function useMergeInputValue<T>(
+  defaultStateValue?: T,
+  inputValue?: T
+): [T, React.Dispatch<React.SetStateAction<T>>] {
+  const hasInputValue = !isUndefined(inputValue);
+  const [stateValue, setStateValue] = useState<T>(hasInputValue ? inputValue : defaultStateValue);
+  const firstRenderRef = useRef(true);
+  useEffect(() => {
+    if (firstRenderRef.current) {
+      firstRenderRef.current = false;
+      return;
+    }
+    // inputValue start with non-undefined, this means user remove the inputValue prop
+    if (inputValue === undefined) {
+      setStateValue(defaultStateValue);
+    }
+  }, [inputValue, defaultStateValue]);
+  const mergedValue = hasInputValue ? inputValue : stateValue;
+  //  Prevent triggering setStateValue while having inputValue given
+  return [mergedValue, hasInputValue ? () => {} : setStateValue];
+}

--- a/components/TreeSelect/interface.ts
+++ b/components/TreeSelect/interface.ts
@@ -2,6 +2,7 @@ import { ReactNode, CSSProperties } from 'react';
 import { TreeDataType, NodeProps, TreeProps } from '../Tree/interface';
 import { TriggerProps } from '../Trigger';
 import { SelectViewCommonProps } from '../_class/select-view';
+import { InputValueChangeReason } from '../Select/interface';
 
 export type TreeSelectDataType = TreeDataType & { value?: string };
 export type LabelValue = { label: ReactNode; value: string; disabled?: boolean };
@@ -33,6 +34,12 @@ export interface TreeSelectProps extends SelectViewCommonProps {
     | string[]
     | { label: ReactNode; value: string; disabled?: boolean }
     | { label: ReactNode; value: string; disabled?: boolean }[];
+  /**
+   * @zh 输入框搜索文本的受控值
+   * @en To set input search value
+   * @version 2.38.0
+   */
+  inputValue?: string;
   /**
    * @zh 指定 key，title，isLeaf，disabled，children 对应的字段
    * @en Custom field name for key, title, isLeaf, disabled and children
@@ -156,6 +163,12 @@ export interface TreeSelectProps extends SelectViewCommonProps {
    * @en Callback when searching data. When undefined, it will search in the data already
    */
   onSearch?: (inputValue: string) => void;
+  /**
+   * @zh 输入框搜索文本改变的回调。
+   * @en Callback when the search value of input is changed.
+   * @version 2.38.0
+   */
+  onInputValueChange?: (value: string, reason: InputValueChangeReason) => void;
   /**
    * @zh 点击清除时触发，参数是当前下拉框的展开状态。
    * @en Callback when clicked clear, the parameter is the visible state of current dropdown

--- a/components/TreeSelect/tree-select.tsx
+++ b/components/TreeSelect/tree-select.tsx
@@ -27,6 +27,7 @@ import { NodeProps } from '../Tree/interface';
 import useMergeValue from '../_util/hooks/useMergeValue';
 import cs from '../_util/classNames';
 import useMergeProps from '../_util/hooks/useMergeProps';
+import useMergeInputValue from './hook/useMergedInputValue';
 
 function isEmptyValue(value) {
   return (
@@ -66,8 +67,15 @@ const TreeSelect: ForwardRefRenderFunction<
   const [popupVisible, setPopupVisible] = useMergeValue<boolean>(false, {
     value: props.popupVisible,
   });
-  const [inputValue, setInputValue] = useState<string>();
-
+  const [inputValue, setInputValue] = useMergeInputValue<string>(
+    undefined, // Compatible with previous behavior 'undefined as default'
+    'inputValue' in props ? props.inputValue || '' : undefined
+  );
+  const onChangeInputValue = isFunction(props.onInputValueChange)
+    ? props.onInputValueChange
+    : (input) => {
+        setInputValue(input);
+      };
   const [value, setValue] = useStateValue(props, key2nodeProps, indeterminateKeys);
 
   const multiple = props.multiple || props.treeCheckable;
@@ -127,7 +135,7 @@ const TreeSelect: ForwardRefRenderFunction<
     }
 
     if (props.multiple && !retainInputValueWhileSelect) {
-      setInputValue('');
+      setInputValue(''); // @2.38.0 setInputValue does nothing while given inputValue prop
       handleSearch('');
     }
   };
@@ -200,6 +208,7 @@ const TreeSelect: ForwardRefRenderFunction<
           treeRef.current.scrollIntoView(target.value);
         }
       });
+    // @2.38.0 setInputValue does nothing while given inputValue prop
     inputValue && setInputValue('');
   }, [popupVisible]);
 
@@ -320,9 +329,7 @@ const TreeSelect: ForwardRefRenderFunction<
               onFocus={(e) => {
                 e && e.stopPropagation();
               }}
-              onChangeInputValue={(input) => {
-                setInputValue(input);
-              }}
+              onChangeInputValue={onChangeInputValue}
             />
           )}
     </Trigger>


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [x] New feature
- [ ] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context

<!-- Explain what problem does the PR solve -->
In many cases we may need this controlled value, like if you want to a controlled inputValue to update the renderTitle prop (highlight the hit keyword in filtered nodes' title). A more complexed case is that localStorage memorized searchValues provieded to directly modify the inputText(This is impossible to support now).I found that the TreeSelect doesn't support controlled inputValue given to inner Select as search key word like Select did. If you mean to do that, you may adopt a hack that using the onSearch api to update the "controlled" value, but this is a limited and non-standard way to "controll" a value, you can only get the value rather than controlled the value
<!-- Link to related open issues if applicable -->

## Solution

<!-- Describe how the problem is fixed in detail -->
Add inputValue prop to provide search value and onInputValueChange prop to update the search value.
## How is the change tested?
By 2 Unit test cases in another pull request. 

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->
<img width="750" alt="image" src="https://user-images.githubusercontent.com/64366842/179385252-45387fe7-0c58-43be-983f-9b47c65dad44.png">


## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|      TreeSelect     |      增加TreeSelect对inputValue和onInputValueChange的支持         |      Added treeselect support for inputValue and onInputValueChange         |         Closes #1119       |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->
## Checklist:

- [x] Test suite passes (`npm run test`)
- [x] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [x] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
On important thing should be notice is that if the inputValue is provided, showSearch is forced to be { retainInputValue: true, retainInputValueWhileSelect: true}, this is an expected behaviour, but the changelog/storybook should remind developer of that.