### PR TITLE
fix(Modal): bug caused when Modal was hidden immediately after mounting

### DIFF
--- a/components/Modal/modal.tsx
+++ b/components/Modal/modal.tsx
@@ -103,7 +103,7 @@ function Modal(baseProps: PropsWithChildren<ModalProps>, ref) {
 
   const modalWrapperRef = useRef<HTMLDivElement>(null);
   const contentWrapper = useRef<HTMLDivElement>(null);
-  const [wrapperVisible, setWrapperVisible] = useState(visible);
+  const [wrapperVisible, setWrapperVisible] = useState<boolean>();
   const [popupZIndex, setPopupZIndex] = useState<number>();
   const cursorPositionRef = useRef<CursorPositionType>(null);
   const haveOriginTransformOrigin = useRef<boolean>(false);


### PR DESCRIPTION
边缘case:

1. 初始化时设置 Modal 的 `visible` 为 true
2. 在 `useEfffect` 时再将 `visible` 设置为 false
3. 由于 `mountOnEnter` 导致动画实际没有触发
4. `wrapperVisible` 由初始化的 `visible` 决定 所以一直为 true
5. 造成页面上有一个 zIndex=1000 的蒙层，下面所有的事件都无法触发

相关issue #1160 