### PR TITLE
Fix(Select): Fix flickering "no data" placeholder

### DIFF
--- a/components/Select/select.tsx
+++ b/components/Select/select.tsx
@@ -550,7 +550,7 @@ function Select(baseProps: SelectProps, ref) {
     ) : null;
 
     // 无选项时的占位符元素
-    const eleNoOptionPlaceholder = (mergedNotFoundContent && allowCreate) ? (
+    const eleNoOptionPlaceholder = (mergedNotFoundContent && !allowCreate) ? (
       <div
         style={dropdownMenuStyle}
         className={cs(`${prefixCls}-popup-inner`, dropdownMenuClassName)}

--- a/components/Select/select.tsx
+++ b/components/Select/select.tsx
@@ -550,7 +550,7 @@ function Select(baseProps: SelectProps, ref) {
     ) : null;
 
     // 无选项时的占位符元素
-    const eleNoOptionPlaceholder = mergedNotFoundContent ? (
+    const eleNoOptionPlaceholder = (mergedNotFoundContent && allowCreate) ? (
       <div
         style={dropdownMenuStyle}
         className={cs(`${prefixCls}-popup-inner`, dropdownMenuClassName)}


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context

See  #1156

Note that this problem is only reproducible in NextJS

## Solution

When `allowCreate === true`, don't display the placeholder


## How is the change tested?

1. Build the changed library with `yarn build`
2. Pack with `yarn pack`
3. Use packed library in a nextjs project created with [arco-next-starter](https://github.com/jiahao-c/arco-next-starter)
4. Manually tested the updated `Select` component. No more flickering "no data" placeholder occurs.


## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|  Select |   修复 Select 在 `allowCreate` 时下拉框闪烁空状态的问题。  |  Fixed  flickering "no data" placeholder when `allowCreate` in Select. |  Close #1156   |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->
## Checklist:

- [x] Test suite passes (`npm run test`)
- [x] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [x] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
