### PR TITLE
fix: Carousel shouldn't slide to the first page when click the gap between indicators

### DIFF
--- a/components/Carousel/indicator.tsx
+++ b/components/Carousel/indicator.tsx
@@ -55,8 +55,9 @@ function CarouselIndicator(props: CarouselIndicatorProps, ref) {
           index !== activeIndex && onSelectIndex(index);
         }
       } else {
-        const index = +event.target.getAttribute('data-index');
-        !isNaN(index) && index !== activeIndex && onSelectIndex(index);
+        const dataIndex: string = event.target.getAttribute('data-index');
+        // Judge if data-index exists at first, event.target can be the wrapper of indicators
+        dataIndex && +dataIndex !== activeIndex && onSelectIndex(+dataIndex);
       }
     },
   };

--- a/components/Carousel/style/index.less
+++ b/components/Carousel/style/index.less
@@ -30,6 +30,7 @@
 
   &-item-current {
     z-index: 1;
+    position: relative;
   }
 
   &-slide {

--- a/stories/Carousel.story.tsx
+++ b/stories/Carousel.story.tsx
@@ -3,31 +3,37 @@ import React, { CSSProperties, useRef } from 'react';
 import { Carousel, Button } from '@self';
 import { CarouselHandle } from '@self/Carousel/interface';
 
-const baseStyle: CSSProperties = {
+const BG_OPACITY = 0.4;
+
+const BASE_STYLE: CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  height: 400,
   color: '#ffffff',
-  textAlign: 'center',
-  width: '100%',
-  lineHeight: '300px',
-  height: '100%',
 };
+
 const itemStyle1 = {
-  backgroundColor: 'rgba(0, 0, 0, 0.3)',
-  ...baseStyle,
+  backgroundColor: `rgba(0, 0, 0, ${BG_OPACITY})`,
+  ...BASE_STYLE,
 };
 
 const itemStyle2 = {
-  backgroundColor: 'rgba(255, 0, 0, 0.3)',
-  ...baseStyle,
+  backgroundColor: `rgba(255, 0, 0, ${BG_OPACITY})`,
+  ...BASE_STYLE,
+  height: 300,
 };
 
 const itemStyle3 = {
-  backgroundColor: 'rgba(0, 255, 0, 0.3)',
-  ...baseStyle,
+  backgroundColor: `rgba(0, 255, 0, ${BG_OPACITY})`,
+  ...BASE_STYLE,
+  height: 500,
 };
 
 const itemStyle4 = {
-  backgroundColor: 'rgba(0, 0, 255, 0.3)',
-  ...baseStyle,
+  backgroundColor: `rgba(0, 0, 255, ${BG_OPACITY})`,
+  ...BASE_STYLE,
+  height: 600,
 };
 
 function Demo1() {
@@ -62,7 +68,6 @@ function Demo1() {
         onChange={(index) => {
           refCurrentIndex.current = index;
         }}
-        style={{ width: '100%', height: 300, margin: '0 auto', fontSize: 16 }}
       >
         <div style={itemStyle1}>
           <h1>1</h1>

--- a/stories/tsconfig.json
+++ b/stories/tsconfig.json
@@ -4,8 +4,10 @@
     "strict": true,
     "baseUrl": "./",
     "paths": {
-      "@self": ["../components"],
-      "@self/icon": ["../icon"]
+      "@self": ["../es"],
+      "@self/*": ["../es/*"],
+      "@self/icon": ["../icon"],
+      "@self/icon/*": ["../icon/*"]
     }
   },
   "include": ["./**/*.tsx"]


### PR DESCRIPTION

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|  Carousel | 修复 `Carousel` 点击指示器中间的区域时会滑动到第一页的 bug。 |  Fixed the bug that `Carousel` would slide to the first page when clicking in the middle of indicators.  |   Close #1201   |
|  Carousel | 修复 `Carousel` 内的子元素无法撑起组件高度的 bug。 | Fixed the bug that child elements of `Carousel` could not fill up the height of the component.  |    |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->
## Checklist:

- [ ] Test suite passes (`npm run test`)
- [x] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [x] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
