### PR TITLE
修复暗黑模式下Tabs组件为type=capsule & disabled时仍有hover效果的问题

### DIFF
--- a/components/Tabs/style/index.less
+++ b/components/Tabs/style/index.less
@@ -711,10 +711,6 @@
         &-active {
           background-color: var(~'@{arco-cssvars-prefix}-color-fill-3');
         }
-
-        &:hover {
-          background-color: var(~'@{arco-cssvars-prefix}-color-fill-3');
-        }
       }
     }
   }


### PR DESCRIPTION
修复暗黑模式下Tabs组件为type=capsule & disabled时仍有hover效果的问题

![image](https://user-images.githubusercontent.com/78004597/183288828-ea589d30-98e7-4a94-a375-c4693a304d99.png)


- [ ] New feature
- [ ] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [x] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|     Tabs      |       去除深色模式下Tabs组件type=capsule的disabled hover效果        |     Remove the disabled hover effect of the Tabs component type=capsule in dark mode          |        none        |

## Checklist:

- [x] Test suite passes (`npm run test`)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

