### PR TITLE
fix(Cascader): options render incorrect when virtualList is enabled  

### DIFF
--- a/components/Cascader/panel/search-panel.tsx
+++ b/components/Cascader/panel/search-panel.tsx
@@ -161,6 +161,7 @@ const SearchPanel = <T extends OptionProps>(props: SearchPanelProps<T>) => {
 
   useEffect(() => {
     const target = refActiveItem.current;
+
     if (target && (isKeyboardHover.current || isFirstRender)) {
       scrollIntoView(target, {
         behavior: 'instant',
@@ -182,7 +183,6 @@ const SearchPanel = <T extends OptionProps>(props: SearchPanelProps<T>) => {
         style={style}
         data={options}
         isStaticItemHeight
-        itemKey="value"
         threshold={props.virtualListProps ? 100 : null}
         {...(isObject(props.virtualListProps) ? props.virtualListProps : {})}
         onMouseMove={() => {


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context

<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

## Solution

<!-- Describe how the problem is fixed in detail -->

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|        Cascader   |      修复 Cascader 组件的搜索面板存在 value 相同的选项时，开启虚拟滚动会出现选项渲染错乱的问题。         |      Fixed the issue that when virtual scrolling is enabled, when options with the same value exist in the search panel of the Cascader component, the options are rendered incorrectly.         |      Close: #1257           |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->
## Checklist:

- [ ] Test suite passes (`npm run test`)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
