### PR TITLE
fix: text ellipsis of Tag content

### DIFF
--- a/components/Cascader/__test__/__snapshots__/demo.test.ts.snap
+++ b/components/Cascader/__test__/__snapshots__/demo.test.ts.snap
@@ -565,20 +565,20 @@ exports[`renders Cascader/demo/disabled.md correctly 1`] = `
             >
               <div
                 class="arco-tag arco-tag-checked arco-tag-size-default arco-input-tag-tag arco-cascader-tag"
+                title="Beijing / Beijing / Dongcheng / Chaoyangmen"
               >
                 <span
-                  class="arco-input-tag-tag-content"
-                  title="Beijing / Beijing / Dongcheng / Chaoyangmen"
+                  class="arco-tag-content"
                 >
                   Beijing / Beijing / Dongcheng / Chaoyangmen
                 </span>
               </div>
               <div
                 class="arco-tag arco-tag-checked arco-tag-size-default arco-input-tag-tag arco-cascader-tag"
+                title="Beijing / Beijing / Dongcheng / Jianguomen"
               >
                 <span
-                  class="arco-input-tag-tag-content"
-                  title="Beijing / Beijing / Dongcheng / Jianguomen"
+                  class="arco-tag-content"
                 >
                   Beijing / Beijing / Dongcheng / Jianguomen
                 </span>
@@ -675,10 +675,10 @@ exports[`renders Cascader/demo/draggable.md correctly 1`] = `
             >
               <div
                 class="arco-tag arco-tag-checked arco-tag-size-default arco-input-tag-tag arco-cascader-tag"
+                title="Beijing / Beijing / Chaoyang / Datunli"
               >
                 <span
-                  class="arco-input-tag-tag-content"
-                  title="Beijing / Beijing / Chaoyang / Datunli"
+                  class="arco-tag-content"
                 >
                   Beijing / Beijing / Chaoyang / Datunli
                 </span>
@@ -908,10 +908,10 @@ exports[`renders Cascader/demo/filedNames.md correctly 1`] = `
           >
             <div
               class="arco-tag arco-tag-checked arco-tag-size-default arco-input-tag-tag arco-cascader-tag"
+              title="Beijing / Beijing / Chaoyang / Datunli"
             >
               <span
-                class="arco-input-tag-tag-content"
-                title="Beijing / Beijing / Chaoyang / Datunli"
+                class="arco-tag-content"
               >
                 Beijing / Beijing / Chaoyang / Datunli
               </span>
@@ -1098,10 +1098,10 @@ exports[`renders Cascader/demo/filter_option.md correctly 1`] = `
             >
               <div
                 class="arco-tag arco-tag-checked arco-tag-size-default arco-input-tag-tag arco-cascader-tag"
+                title="Beijing / Beijing / Chaoyang / Datunli"
               >
                 <span
-                  class="arco-input-tag-tag-content"
-                  title="Beijing / Beijing / Chaoyang / Datunli"
+                  class="arco-tag-content"
                 >
                   Beijing / Beijing / Chaoyang / Datunli
                 </span>
@@ -1289,10 +1289,10 @@ exports[`renders Cascader/demo/footer.md correctly 1`] = `
             >
               <div
                 class="arco-tag arco-tag-checked arco-tag-size-default arco-input-tag-tag arco-cascader-tag"
+                title="Beijing / Beijing / Chaoyang / Datunli"
               >
                 <span
-                  class="arco-input-tag-tag-content"
-                  title="Beijing / Beijing / Chaoyang / Datunli"
+                  class="arco-tag-content"
                 >
                   Beijing / Beijing / Chaoyang / Datunli
                 </span>
@@ -1607,10 +1607,10 @@ exports[`renders Cascader/demo/multiple.md correctly 1`] = `
             >
               <div
                 class="arco-tag arco-tag-checked arco-tag-size-default arco-input-tag-tag arco-cascader-tag"
+                title="Beijing / Beijing / Chaoyang / Datunli"
               >
                 <span
-                  class="arco-input-tag-tag-content"
-                  title="Beijing / Beijing / Chaoyang / Datunli"
+                  class="arco-tag-content"
                 >
                   Beijing / Beijing / Chaoyang / Datunli
                 </span>
@@ -1903,10 +1903,10 @@ exports[`renders Cascader/demo/render_option.md correctly 1`] = `
             >
               <div
                 class="arco-tag arco-tag-checked arco-tag-size-default arco-input-tag-tag arco-cascader-tag"
+                title="Beijing / Beijing / Chaoyang / Datunli"
               >
                 <span
-                  class="arco-input-tag-tag-content"
-                  title="Beijing / Beijing / Chaoyang / Datunli"
+                  class="arco-tag-content"
                 >
                   Beijing / Beijing / Chaoyang / Datunli
                 </span>
@@ -2077,10 +2077,10 @@ exports[`renders Cascader/demo/search.md correctly 1`] = `
             >
               <div
                 class="arco-tag arco-tag-checked arco-tag-size-default arco-input-tag-tag arco-cascader-tag"
+                title="Beijing / Beijing / Chaoyang / Datunli"
               >
                 <span
-                  class="arco-input-tag-tag-content"
-                  title="Beijing / Beijing / Chaoyang / Datunli"
+                  class="arco-tag-content"
                 >
                   Beijing / Beijing / Chaoyang / Datunli
                 </span>

--- a/components/Checkbox/__test__/__snapshots__/demo.test.ts.snap
+++ b/components/Checkbox/__test__/__snapshots__/demo.test.ts.snap
@@ -315,7 +315,11 @@ exports[`renders Checkbox/demo/custom_render.md correctly 1`] = `
         <div
           class="arco-tag arco-tag-arcoblue arco-tag-checked arco-tag-size-default"
         >
-          Beijing
+          <span
+            class="arco-tag-content"
+          >
+            Beijing
+          </span>
         </div>
       </label>
       <label
@@ -328,7 +332,11 @@ exports[`renders Checkbox/demo/custom_render.md correctly 1`] = `
         <div
           class="arco-tag arco-tag-checked arco-tag-size-default"
         >
-          Shanghai
+          <span
+            class="arco-tag-content"
+          >
+            Shanghai
+          </span>
         </div>
       </label>
       <label
@@ -341,7 +349,11 @@ exports[`renders Checkbox/demo/custom_render.md correctly 1`] = `
         <div
           class="arco-tag arco-tag-checked arco-tag-size-default"
         >
-          Guangzhou
+          <span
+            class="arco-tag-content"
+          >
+            Guangzhou
+          </span>
         </div>
       </label>
     </span>

--- a/components/ConfigProvider/__test__/__snapshots__/demo.test.ts.snap
+++ b/components/ConfigProvider/__test__/__snapshots__/demo.test.ts.snap
@@ -880,7 +880,11 @@ exports[`renders ConfigProvider/demo/component-config.md correctly 1`] = `
         <div
           class="arco-tag arco-tag-arcoblue arco-tag-checked arco-tag-size-large"
         >
-          ArcoDesign
+          <span
+            class="arco-tag-content"
+          >
+            ArcoDesign
+          </span>
         </div>
       </div>
       <div
@@ -890,7 +894,11 @@ exports[`renders ConfigProvider/demo/component-config.md correctly 1`] = `
         <div
           class="arco-tag arco-tag-arcoblue arco-tag-checked arco-tag-size-large"
         >
-          Design System
+          <span
+            class="arco-tag-content"
+          >
+            Design System
+          </span>
         </div>
       </div>
       <div
@@ -900,7 +908,11 @@ exports[`renders ConfigProvider/demo/component-config.md correctly 1`] = `
         <div
           class="arco-tag arco-tag-arcoblue arco-tag-checked arco-tag-size-large"
         >
-          Component
+          <span
+            class="arco-tag-content"
+          >
+            Component
+          </span>
         </div>
       </div>
       <div
@@ -909,7 +921,11 @@ exports[`renders ConfigProvider/demo/component-config.md correctly 1`] = `
         <div
           class="arco-tag arco-tag-arcoblue arco-tag-checked arco-tag-size-large"
         >
-          Design Lab
+          <span
+            class="arco-tag-content"
+          >
+            Design Lab
+          </span>
         </div>
       </div>
     </div>
@@ -1515,7 +1531,11 @@ exports[`renders ConfigProvider/demo/rtl.md correctly 1`] = `
           <div
             class="arco-tag arco-tag-red arco-tag-checked arco-tag-size-default arco-tag-rtl"
           >
-            red
+            <span
+              class="arco-tag-content"
+            >
+              red
+            </span>
             <span
               aria-label="Close"
               class="arco-icon-hover arco-tag-icon-hover arco-tag-close-btn"
@@ -1544,7 +1564,11 @@ exports[`renders ConfigProvider/demo/rtl.md correctly 1`] = `
           <div
             class="arco-tag arco-tag-arcoblue arco-tag-checked arco-tag-size-default arco-tag-rtl"
           >
-            arcoblue
+            <span
+              class="arco-tag-content"
+            >
+              arcoblue
+            </span>
             <span
               aria-label="Close"
               class="arco-icon-hover arco-tag-icon-hover arco-tag-close-btn"
@@ -1572,7 +1596,11 @@ exports[`renders ConfigProvider/demo/rtl.md correctly 1`] = `
           <div
             class="arco-tag arco-tag-green arco-tag-checked arco-tag-size-default arco-tag-rtl"
           >
-            green
+            <span
+              class="arco-tag-content"
+            >
+              green
+            </span>
             <span
               aria-label="Close"
               class="arco-icon-hover arco-tag-icon-hover arco-tag-close-btn"

--- a/components/DatePicker/__test__/__snapshots__/demo.test.ts.snap
+++ b/components/DatePicker/__test__/__snapshots__/demo.test.ts.snap
@@ -4288,7 +4288,11 @@ exports[`renders DatePicker/demo/timezone.md correctly 1`] = `
               <div
                 class="arco-tag arco-tag-gray arco-tag-checked arco-tag-size-default arco-tag-bordered"
               >
-                DatePicker
+                <span
+                  class="arco-tag-content"
+                >
+                  DatePicker
+                </span>
               </div>
             </div>
             <div
@@ -4363,7 +4367,11 @@ exports[`renders DatePicker/demo/timezone.md correctly 1`] = `
               <div
                 class="arco-tag arco-tag-gray arco-tag-checked arco-tag-size-default arco-tag-bordered"
               >
-                RangePicker
+                <span
+                  class="arco-tag-content"
+                >
+                  RangePicker
+                </span>
               </div>
             </div>
             <div
@@ -4679,7 +4687,11 @@ exports[`renders DatePicker/demo/utcOffset.md correctly 1`] = `
               <div
                 class="arco-tag arco-tag-gray arco-tag-checked arco-tag-size-default arco-tag-bordered"
               >
-                DatePicker
+                <span
+                  class="arco-tag-content"
+                >
+                  DatePicker
+                </span>
               </div>
             </div>
             <div
@@ -4754,7 +4766,11 @@ exports[`renders DatePicker/demo/utcOffset.md correctly 1`] = `
               <div
                 class="arco-tag arco-tag-gray arco-tag-checked arco-tag-size-default arco-tag-bordered"
               >
-                RangePicker
+                <span
+                  class="arco-tag-content"
+                >
+                  RangePicker
+                </span>
               </div>
             </div>
             <div

--- a/components/Form/__test__/__snapshots__/demo.test.ts.snap
+++ b/components/Form/__test__/__snapshots__/demo.test.ts.snap
@@ -814,10 +814,10 @@ exports[`renders Form/demo/control.md correctly 1`] = `
                       >
                         <div
                           class="arco-tag arco-tag-checked arco-tag-size-default arco-input-tag-tag arco-select-tag"
+                          title="b"
                         >
                           <span
-                            class="arco-input-tag-tag-content"
-                            title="b"
+                            class="arco-tag-content"
                           >
                             b
                           </span>
@@ -2669,10 +2669,10 @@ exports[`renders Form/demo/disabled.md correctly 1`] = `
                       >
                         <div
                           class="arco-tag arco-tag-checked arco-tag-size-default arco-input-tag-tag arco-select-tag"
+                          title="b"
                         >
                           <span
-                            class="arco-input-tag-tag-content"
-                            title="b"
+                            class="arco-tag-content"
                           >
                             b
                           </span>
@@ -4023,7 +4023,11 @@ exports[`renders Form/demo/form-provider.md correctly 1`] = `
           class="arco-tag arco-tag-arcoblue arco-tag-checked arco-tag-size-default"
           id="searchForm-email_input"
         >
-          email: null
+          <span
+            class="arco-tag-content"
+          >
+            email: null
+          </span>
         </div>
       </div>
       <div

--- a/components/InputTag/__test__/__snapshots__/demo.test.ts.snap
+++ b/components/InputTag/__test__/__snapshots__/demo.test.ts.snap
@@ -151,10 +151,10 @@ exports[`renders InputTag/demo/draggable.md correctly 1`] = `
         >
           <div
             class="arco-tag arco-tag-checked arco-tag-size-default arco-input-tag-tag"
+            title="a"
           >
             <span
-              class="arco-input-tag-tag-content"
-              title="a"
+              class="arco-tag-content"
             >
               a
             </span>
@@ -186,10 +186,10 @@ exports[`renders InputTag/demo/draggable.md correctly 1`] = `
         >
           <div
             class="arco-tag arco-tag-checked arco-tag-size-default arco-input-tag-tag"
+            title="b"
           >
             <span
-              class="arco-input-tag-tag-content"
-              title="b"
+              class="arco-tag-content"
             >
               b
             </span>
@@ -221,10 +221,10 @@ exports[`renders InputTag/demo/draggable.md correctly 1`] = `
         >
           <div
             class="arco-tag arco-tag-checked arco-tag-size-default arco-input-tag-tag"
+            title="c"
           >
             <span
-              class="arco-input-tag-tag-content"
-              title="c"
+              class="arco-tag-content"
             >
               c
             </span>
@@ -256,10 +256,10 @@ exports[`renders InputTag/demo/draggable.md correctly 1`] = `
         >
           <div
             class="arco-tag arco-tag-checked arco-tag-size-default arco-input-tag-tag"
+            title="d"
           >
             <span
-              class="arco-input-tag-tag-content"
-              title="d"
+              class="arco-tag-content"
             >
               d
             </span>
@@ -339,10 +339,10 @@ exports[`renders InputTag/demo/labelInValue.md correctly 1`] = `
     >
       <div
         class="arco-tag arco-tag-checked arco-tag-size-default arco-input-tag-tag"
+        title="a"
       >
         <span
-          class="arco-input-tag-tag-content"
-          title="a"
+          class="arco-tag-content"
         >
           a
         </span>
@@ -416,7 +416,11 @@ exports[`renders InputTag/demo/render-tag.md correctly 1`] = `
         class="arco-tag arco-tag-arcoblue arco-tag-checked arco-tag-size-default"
         style="margin:2px 6px 2px 0"
       >
-        arcoblue
+        <span
+          class="arco-tag-content"
+        >
+          arcoblue
+        </span>
         <span
           aria-label="Close"
           class="arco-icon-hover arco-tag-icon-hover arco-tag-close-btn"
@@ -441,7 +445,11 @@ exports[`renders InputTag/demo/render-tag.md correctly 1`] = `
         class="arco-tag arco-tag-orange arco-tag-checked arco-tag-size-default"
         style="margin:2px 6px 2px 0"
       >
-        orange
+        <span
+          class="arco-tag-content"
+        >
+          orange
+        </span>
         <span
           aria-label="Close"
           class="arco-icon-hover arco-tag-icon-hover arco-tag-close-btn"
@@ -466,7 +474,11 @@ exports[`renders InputTag/demo/render-tag.md correctly 1`] = `
         class="arco-tag arco-tag-lime arco-tag-checked arco-tag-size-default"
         style="margin:2px 6px 2px 0"
       >
-        lime
+        <span
+          class="arco-tag-content"
+        >
+          lime
+        </span>
         <span
           aria-label="Close"
           class="arco-icon-hover arco-tag-icon-hover arco-tag-close-btn"
@@ -626,10 +638,10 @@ exports[`renders InputTag/demo/size.md correctly 1`] = `
       >
         <div
           class="arco-tag arco-tag-checked arco-tag-size-default arco-input-tag-tag"
+          title="Beijing"
         >
           <span
-            class="arco-input-tag-tag-content"
-            title="Beijing"
+            class="arco-tag-content"
           >
             Beijing
           </span>
@@ -655,10 +667,10 @@ exports[`renders InputTag/demo/size.md correctly 1`] = `
         </div>
         <div
           class="arco-tag arco-tag-checked arco-tag-size-default arco-input-tag-tag"
+          title="Shanghai"
         >
           <span
-            class="arco-input-tag-tag-content"
-            title="Shanghai"
+            class="arco-tag-content"
           >
             Shanghai
           </span>

--- a/components/InputTag/input-tag.tsx
+++ b/components/InputTag/input-tag.tsx
@@ -231,14 +231,10 @@ function InputTag(baseProps: InputTagProps<string | ObjectValueType>, ref) {
         })}
         closable={closable}
         closeIcon={icon && icon.removeIcon}
+        title={typeof label === 'string' ? label : undefined}
         onClose={onClose}
       >
-        <span
-          title={typeof label === 'string' ? label : undefined}
-          className={`${prefixCls}-tag-content`}
-        >
-          {typeof label === 'string' ? label.replace(/\s/g, '\u00A0') : label}
-        </span>
+        {typeof label === 'string' ? label.replace(/\s/g, '\u00A0') : label}
       </Tag>
     );
   };

--- a/components/InputTag/style/index.less
+++ b/components/InputTag/style/index.less
@@ -148,14 +148,6 @@
       color: @input-tag-color-text_default;
       border-color: @input-tag-tag-color-border;
       background-color: @input-tag-tag-color-bg;
-      display: inline-flex;
-      align-items: center;
-
-      &-content {
-        flex: 1;
-        overflow: hidden;
-        text-overflow: ellipsis;
-      }
     }
 
     .@{prefix}-icon-hover:hover::before {

--- a/components/PageHeader/__test__/__snapshots__/demo.test.ts.snap
+++ b/components/PageHeader/__test__/__snapshots__/demo.test.ts.snap
@@ -473,7 +473,11 @@ exports[`renders PageHeader/demo/conplex.md correctly 1`] = `
               class="arco-tag arco-tag-red arco-tag-checked arco-tag-size-small"
               style="margin-left:8px"
             >
-              Default
+              <span
+                class="arco-tag-content"
+              >
+                Default
+              </span>
             </div>
           </div>
         </div>

--- a/components/ResizeBox/__test__/__snapshots__/demo.test.ts.snap
+++ b/components/ResizeBox/__test__/__snapshots__/demo.test.ts.snap
@@ -561,7 +561,11 @@ exports[`renders ResizeBox/demo/split.md correctly 1`] = `
         <div
           class="arco-tag arco-tag-arcoblue arco-tag-checked arco-tag-size-default"
         >
-          Fist
+          <span
+            class="arco-tag-content"
+          >
+            Fist
+          </span>
         </div>
       </div>
       <div
@@ -606,7 +610,11 @@ exports[`renders ResizeBox/demo/split.md correctly 1`] = `
         <div
           class="arco-tag arco-tag-green arco-tag-checked arco-tag-size-default"
         >
-          Second
+          <span
+            class="arco-tag-content"
+          >
+            Second
+          </span>
         </div>
       </div>
     </div>

--- a/components/Select/__test__/__snapshots__/demo.test.ts.snap
+++ b/components/Select/__test__/__snapshots__/demo.test.ts.snap
@@ -87,10 +87,10 @@ exports[`renders Select/demo/allow-create.md correctly 1`] = `
             >
               <div
                 class="arco-tag arco-tag-checked arco-tag-size-default arco-input-tag-tag arco-select-tag"
+                title="a10"
               >
                 <span
-                  class="arco-input-tag-tag-content"
-                  title="a10"
+                  class="arco-tag-content"
                 >
                   a10
                 </span>
@@ -116,10 +116,10 @@ exports[`renders Select/demo/allow-create.md correctly 1`] = `
               </div>
               <div
                 class="arco-tag arco-tag-checked arco-tag-size-default arco-input-tag-tag arco-select-tag"
+                title="b11"
               >
                 <span
-                  class="arco-input-tag-tag-content"
-                  title="b11"
+                  class="arco-tag-content"
                 >
                   b11
                 </span>
@@ -587,10 +587,10 @@ exports[`renders Select/demo/darggable.md correctly 1`] = `
             >
               <div
                 class="arco-tag arco-tag-checked arco-tag-size-default arco-input-tag-tag arco-select-tag"
+                title="Beijing"
               >
                 <span
-                  class="arco-input-tag-tag-content"
-                  title="Beijing"
+                  class="arco-tag-content"
                 >
                   Beijing
                 </span>
@@ -622,10 +622,10 @@ exports[`renders Select/demo/darggable.md correctly 1`] = `
             >
               <div
                 class="arco-tag arco-tag-checked arco-tag-size-default arco-input-tag-tag arco-select-tag"
+                title="Shanghai"
               >
                 <span
-                  class="arco-input-tag-tag-content"
-                  title="Shanghai"
+                  class="arco-tag-content"
                 >
                   Shanghai
                 </span>
@@ -657,10 +657,10 @@ exports[`renders Select/demo/darggable.md correctly 1`] = `
             >
               <div
                 class="arco-tag arco-tag-checked arco-tag-size-default arco-input-tag-tag arco-select-tag"
+                title="Guangzhou"
               >
                 <span
-                  class="arco-input-tag-tag-content"
-                  title="Guangzhou"
+                  class="arco-tag-content"
                 >
                   Guangzhou
                 </span>
@@ -937,10 +937,10 @@ exports[`renders Select/demo/multiple.md correctly 1`] = `
             >
               <div
                 class="arco-tag arco-tag-checked arco-tag-size-default arco-input-tag-tag arco-select-tag"
+                title="Beijing"
               >
                 <span
-                  class="arco-input-tag-tag-content"
-                  title="Beijing"
+                  class="arco-tag-content"
                 >
                   Beijing
                 </span>
@@ -966,10 +966,10 @@ exports[`renders Select/demo/multiple.md correctly 1`] = `
               </div>
               <div
                 class="arco-tag arco-tag-checked arco-tag-size-default arco-input-tag-tag arco-select-tag"
+                title="Shenzhen"
               >
                 <span
-                  class="arco-input-tag-tag-content"
-                  title="Shenzhen"
+                  class="arco-tag-content"
                 >
                   Shenzhen
                 </span>
@@ -1077,10 +1077,10 @@ exports[`renders Select/demo/multiple.md correctly 1`] = `
             >
               <div
                 class="arco-tag arco-tag-checked arco-tag-size-default arco-input-tag-tag arco-select-tag"
+                title="Beijing"
               >
                 <span
-                  class="arco-input-tag-tag-content"
-                  title="Beijing"
+                  class="arco-tag-content"
                 >
                   Beijing
                 </span>
@@ -1106,10 +1106,10 @@ exports[`renders Select/demo/multiple.md correctly 1`] = `
               </div>
               <div
                 class="arco-tag arco-tag-checked arco-tag-size-default arco-input-tag-tag arco-select-tag"
+                title="Shenzhen"
               >
                 <span
-                  class="arco-input-tag-tag-content"
-                  title="Shenzhen"
+                  class="arco-tag-content"
                 >
                   Shenzhen
                 </span>
@@ -1135,10 +1135,10 @@ exports[`renders Select/demo/multiple.md correctly 1`] = `
               </div>
               <div
                 class="arco-tag arco-tag-checked arco-tag-size-default arco-input-tag-tag arco-select-tag"
+                title="+1..."
               >
                 <span
-                  class="arco-input-tag-tag-content"
-                  title="+1..."
+                  class="arco-tag-content"
                 >
                   +1...
                 </span>
@@ -1227,10 +1227,10 @@ exports[`renders Select/demo/multiple.md correctly 1`] = `
             >
               <div
                 class="arco-tag arco-tag-checked arco-tag-size-default arco-input-tag-tag arco-select-tag"
+                title="Beijing"
               >
                 <span
-                  class="arco-input-tag-tag-content"
-                  title="Beijing"
+                  class="arco-tag-content"
                 >
                   Beijing
                 </span>
@@ -1256,10 +1256,10 @@ exports[`renders Select/demo/multiple.md correctly 1`] = `
               </div>
               <div
                 class="arco-tag arco-tag-checked arco-tag-size-default arco-input-tag-tag arco-select-tag"
+                title="Shenzhen"
               >
                 <span
-                  class="arco-input-tag-tag-content"
-                  title="Shenzhen"
+                  class="arco-tag-content"
                 >
                   Shenzhen
                 </span>
@@ -1285,10 +1285,10 @@ exports[`renders Select/demo/multiple.md correctly 1`] = `
               </div>
               <div
                 class="arco-tag arco-tag-checked arco-tag-size-default arco-input-tag-tag arco-select-tag"
+                title="+1 more"
               >
                 <span
-                  class="arco-input-tag-tag-content"
-                  title="+1 more"
+                  class="arco-tag-content"
                 >
                   +1 more
                 </span>
@@ -1711,10 +1711,10 @@ exports[`renders Select/demo/options.md correctly 1`] = `
             >
               <div
                 class="arco-tag arco-tag-checked arco-tag-size-default arco-input-tag-tag arco-select-tag"
+                title="Beijing"
               >
                 <span
-                  class="arco-input-tag-tag-content"
-                  title="Beijing"
+                  class="arco-tag-content"
                 >
                   Beijing
                 </span>
@@ -1740,10 +1740,10 @@ exports[`renders Select/demo/options.md correctly 1`] = `
               </div>
               <div
                 class="arco-tag arco-tag-checked arco-tag-size-default arco-input-tag-tag arco-select-tag"
+                title="Shanghai"
               >
                 <span
-                  class="arco-input-tag-tag-content"
-                  title="Shanghai"
+                  class="arco-tag-content"
                 >
                   Shanghai
                 </span>
@@ -2015,7 +2015,7 @@ exports[`renders Select/demo/render-format.md correctly 1`] = `
                 class="arco-tag arco-tag-checked arco-tag-size-default arco-input-tag-tag arco-select-tag"
               >
                 <span
-                  class="arco-input-tag-tag-content"
+                  class="arco-tag-content"
                 >
                   <span>
                     <svg
@@ -2059,7 +2059,7 @@ exports[`renders Select/demo/render-format.md correctly 1`] = `
                 class="arco-tag arco-tag-checked arco-tag-size-default arco-input-tag-tag arco-select-tag"
               >
                 <span
-                  class="arco-input-tag-tag-content"
+                  class="arco-tag-content"
                 >
                   <span>
                     <svg
@@ -2172,7 +2172,11 @@ exports[`renders Select/demo/render-tag.md correctly 1`] = `
                 class="arco-tag arco-tag-red arco-tag-checked arco-tag-size-default"
                 style="margin:2px 6px 2px 0"
               >
-                red
+                <span
+                  class="arco-tag-content"
+                >
+                  red
+                </span>
                 <span
                   aria-label="Close"
                   class="arco-icon-hover arco-tag-icon-hover arco-tag-close-btn"
@@ -2197,7 +2201,11 @@ exports[`renders Select/demo/render-tag.md correctly 1`] = `
                 class="arco-tag arco-tag-orangered arco-tag-checked arco-tag-size-default"
                 style="margin:2px 6px 2px 0"
               >
-                orangered
+                <span
+                  class="arco-tag-content"
+                >
+                  orangered
+                </span>
                 <span
                   aria-label="Close"
                   class="arco-icon-hover arco-tag-icon-hover arco-tag-close-btn"

--- a/components/Select/__test__/index.test.tsx
+++ b/components/Select/__test__/index.test.tsx
@@ -294,9 +294,9 @@ describe('Select', () => {
 
     expect(wrapper.find('.demo-1 .arco-tag')).toHaveLength(0);
     expect(wrapper.find('.demo-2 .arco-tag')).toHaveLength(2);
-    expect(wrapper.querySelector('.demo-3 .arco-select-view-value').innerHTML).toBe('One');
-    expect(wrapper.querySelector('.demo-4 .arco-input-tag-tag-content').innerHTML).toBe('One');
-    expect(wrapper.querySelector('.demo-5 .arco-input-tag-tag-content').innerHTML).toBe('One');
+    expect(wrapper.querySelector('.demo-3 .arco-select-view-value')).toHaveTextContent('One');
+    expect(wrapper.querySelector('.demo-4 .arco-tag')).toHaveTextContent('One');
+    expect(wrapper.querySelector('.demo-5 .arco-tag')).toHaveTextContent('One');
   });
 
   it('User creating option will not affect original options', async () => {

--- a/components/Space/__test__/__snapshots__/demo.test.ts.snap
+++ b/components/Space/__test__/__snapshots__/demo.test.ts.snap
@@ -137,7 +137,11 @@ exports[`renders Space/demo/basic.md correctly 1`] = `
     <div
       class="arco-tag arco-tag-arcoblue arco-tag-checked arco-tag-size-default"
     >
-      Tag
+      <span
+        class="arco-tag-content"
+      >
+        Tag
+      </span>
     </div>
   </div>
   <div

--- a/components/Tabs/__test__/__snapshots__/demo.test.ts.snap
+++ b/components/Tabs/__test__/__snapshots__/demo.test.ts.snap
@@ -651,10 +651,10 @@ exports[`renders Tabs/demo/extra.md correctly 1`] = `
           style="transform:translateX(0px);-webkit-transform:translateX(0px);-ms-transform:translateX(0px);-moz-transform:translateX(0px);-o-transform:translateX(0px)"
         >
           <div
-            aria-controls="arco-tabs-4-panel-0"
+            aria-controls="arco-tabs-3-panel-0"
             aria-selected="true"
             class="arco-tabs-header-title arco-tabs-header-title-active"
-            id="arco-tabs-4-tab-0"
+            id="arco-tabs-3-tab-0"
             role="tab"
             tabindex="0"
           >
@@ -665,11 +665,11 @@ exports[`renders Tabs/demo/extra.md correctly 1`] = `
             </span>
           </div>
           <div
-            aria-controls="arco-tabs-4-panel-1"
+            aria-controls="arco-tabs-3-panel-1"
             aria-disabled="true"
             aria-selected="false"
             class="arco-tabs-header-title arco-tabs-header-title-disabled"
-            id="arco-tabs-4-tab-1"
+            id="arco-tabs-3-tab-1"
             role="tab"
             tabindex="-1"
           >
@@ -680,10 +680,10 @@ exports[`renders Tabs/demo/extra.md correctly 1`] = `
             </span>
           </div>
           <div
-            aria-controls="arco-tabs-4-panel-2"
+            aria-controls="arco-tabs-3-panel-2"
             aria-selected="false"
             class="arco-tabs-header-title"
-            id="arco-tabs-4-tab-2"
+            id="arco-tabs-3-tab-2"
             role="tab"
             tabindex="0"
           >
@@ -709,6 +709,172 @@ exports[`renders Tabs/demo/extra.md correctly 1`] = `
             Action
           </span>
         </button>
+      </div>
+    </div>
+  </div>
+  <div
+    class="arco-tabs-content arco-tabs-content-horizontal"
+  >
+    <div
+      class="arco-tabs-content-inner"
+      style="margin-left:-0%"
+    >
+      <div
+        aria-labelledby="arco-tabs-3-tab-0"
+        class="arco-tabs-content-item arco-tabs-content-item-active"
+        id="arco-tabs-3-panel-0"
+        role="tabpanel"
+        tabindex="0"
+      >
+        <div
+          class="arco-tabs-pane"
+        >
+          <div
+            class="arco-typography"
+            style="text-align:center;margin-top:20px"
+          >
+            Content of Tab Panel 1
+          </div>
+        </div>
+      </div>
+      <div
+        aria-hidden="true"
+        aria-labelledby="arco-tabs-3-tab-1"
+        class="arco-tabs-content-item"
+        id="arco-tabs-3-panel-1"
+        role="tabpanel"
+        tabindex="-1"
+      />
+      <div
+        aria-hidden="true"
+        aria-labelledby="arco-tabs-3-tab-2"
+        class="arco-tabs-content-item"
+        id="arco-tabs-3-panel-2"
+        role="tabpanel"
+        tabindex="-1"
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`renders Tabs/demo/icon.md correctly 1`] = `
+<div
+  class="arco-tabs arco-tabs-horizontal arco-tabs-line arco-tabs-top arco-tabs-size-default"
+>
+  <div
+    class="arco-tabs-header-nav arco-tabs-header-nav-horizontal arco-tabs-header-nav-top arco-tabs-header-size-default arco-tabs-header-nav-line"
+  >
+    <div
+      class="arco-tabs-header-scroll"
+    >
+      <div
+        class="arco-tabs-header-wrapper"
+      >
+        <div
+          class="arco-tabs-header"
+          style="transform:translateX(0px);-webkit-transform:translateX(0px);-ms-transform:translateX(0px);-moz-transform:translateX(0px);-o-transform:translateX(0px)"
+        >
+          <div
+            aria-controls="arco-tabs-4-panel-0"
+            aria-selected="true"
+            class="arco-tabs-header-title arco-tabs-header-title-active"
+            id="arco-tabs-4-tab-0"
+            role="tab"
+            tabindex="0"
+          >
+            <span
+              class="arco-tabs-header-title-text"
+            >
+              <span>
+                <svg
+                  aria-hidden="true"
+                  class="arco-icon arco-icon-calendar"
+                  fill="none"
+                  focusable="false"
+                  stroke="currentColor"
+                  stroke-width="4"
+                  style="margin-right:6px"
+                  viewBox="0 0 48 48"
+                >
+                  <path
+                    d="M7 22h34M14 5v8m20-8v8M8 41h32a1 1 0 0 0 1-1V10a1 1 0 0 0-1-1H8a1 1 0 0 0-1 1v30a1 1 0 0 0 1 1Z"
+                  />
+                </svg>
+                Tab 1
+              </span>
+            </span>
+          </div>
+          <div
+            aria-controls="arco-tabs-4-panel-1"
+            aria-disabled="true"
+            aria-selected="false"
+            class="arco-tabs-header-title arco-tabs-header-title-disabled"
+            id="arco-tabs-4-tab-1"
+            role="tab"
+            tabindex="-1"
+          >
+            <span
+              class="arco-tabs-header-title-text"
+            >
+              <span>
+                <svg
+                  aria-hidden="true"
+                  class="arco-icon arco-icon-clock-circle"
+                  fill="none"
+                  focusable="false"
+                  stroke="currentColor"
+                  stroke-width="4"
+                  style="margin-right:6px"
+                  viewBox="0 0 48 48"
+                >
+                  <path
+                    d="M24 14v10h9.5m8.5 0c0 9.941-8.059 18-18 18S6 33.941 6 24 14.059 6 24 6s18 8.059 18 18Z"
+                  />
+                </svg>
+                Tab 2
+              </span>
+            </span>
+          </div>
+          <div
+            aria-controls="arco-tabs-4-panel-2"
+            aria-selected="false"
+            class="arco-tabs-header-title"
+            id="arco-tabs-4-tab-2"
+            role="tab"
+            tabindex="0"
+          >
+            <span
+              class="arco-tabs-header-title-text"
+            >
+              <span>
+                <svg
+                  aria-hidden="true"
+                  class="arco-icon arco-icon-user"
+                  fill="none"
+                  focusable="false"
+                  stroke="currentColor"
+                  stroke-width="4"
+                  style="margin-right:6px"
+                  viewBox="0 0 48 48"
+                >
+                  <path
+                    d="M7 37c0-4.97 4.03-8 9-8h16c4.97 0 9 3.03 9 8v3a1 1 0 0 1-1 1H8a1 1 0 0 1-1-1v-3Z"
+                  />
+                  <circle
+                    cx="24"
+                    cy="15"
+                    r="8"
+                  />
+                </svg>
+                Tab 3
+              </span>
+            </span>
+          </div>
+          <div
+            class="arco-tabs-header-ink"
+          />
+        </div>
       </div>
     </div>
   </div>
@@ -758,172 +924,6 @@ exports[`renders Tabs/demo/extra.md correctly 1`] = `
 </div>
 `;
 
-exports[`renders Tabs/demo/icon.md correctly 1`] = `
-<div
-  class="arco-tabs arco-tabs-horizontal arco-tabs-line arco-tabs-top arco-tabs-size-default"
->
-  <div
-    class="arco-tabs-header-nav arco-tabs-header-nav-horizontal arco-tabs-header-nav-top arco-tabs-header-size-default arco-tabs-header-nav-line"
-  >
-    <div
-      class="arco-tabs-header-scroll"
-    >
-      <div
-        class="arco-tabs-header-wrapper"
-      >
-        <div
-          class="arco-tabs-header"
-          style="transform:translateX(0px);-webkit-transform:translateX(0px);-ms-transform:translateX(0px);-moz-transform:translateX(0px);-o-transform:translateX(0px)"
-        >
-          <div
-            aria-controls="arco-tabs-5-panel-0"
-            aria-selected="true"
-            class="arco-tabs-header-title arco-tabs-header-title-active"
-            id="arco-tabs-5-tab-0"
-            role="tab"
-            tabindex="0"
-          >
-            <span
-              class="arco-tabs-header-title-text"
-            >
-              <span>
-                <svg
-                  aria-hidden="true"
-                  class="arco-icon arco-icon-calendar"
-                  fill="none"
-                  focusable="false"
-                  stroke="currentColor"
-                  stroke-width="4"
-                  style="margin-right:6px"
-                  viewBox="0 0 48 48"
-                >
-                  <path
-                    d="M7 22h34M14 5v8m20-8v8M8 41h32a1 1 0 0 0 1-1V10a1 1 0 0 0-1-1H8a1 1 0 0 0-1 1v30a1 1 0 0 0 1 1Z"
-                  />
-                </svg>
-                Tab 1
-              </span>
-            </span>
-          </div>
-          <div
-            aria-controls="arco-tabs-5-panel-1"
-            aria-disabled="true"
-            aria-selected="false"
-            class="arco-tabs-header-title arco-tabs-header-title-disabled"
-            id="arco-tabs-5-tab-1"
-            role="tab"
-            tabindex="-1"
-          >
-            <span
-              class="arco-tabs-header-title-text"
-            >
-              <span>
-                <svg
-                  aria-hidden="true"
-                  class="arco-icon arco-icon-clock-circle"
-                  fill="none"
-                  focusable="false"
-                  stroke="currentColor"
-                  stroke-width="4"
-                  style="margin-right:6px"
-                  viewBox="0 0 48 48"
-                >
-                  <path
-                    d="M24 14v10h9.5m8.5 0c0 9.941-8.059 18-18 18S6 33.941 6 24 14.059 6 24 6s18 8.059 18 18Z"
-                  />
-                </svg>
-                Tab 2
-              </span>
-            </span>
-          </div>
-          <div
-            aria-controls="arco-tabs-5-panel-2"
-            aria-selected="false"
-            class="arco-tabs-header-title"
-            id="arco-tabs-5-tab-2"
-            role="tab"
-            tabindex="0"
-          >
-            <span
-              class="arco-tabs-header-title-text"
-            >
-              <span>
-                <svg
-                  aria-hidden="true"
-                  class="arco-icon arco-icon-user"
-                  fill="none"
-                  focusable="false"
-                  stroke="currentColor"
-                  stroke-width="4"
-                  style="margin-right:6px"
-                  viewBox="0 0 48 48"
-                >
-                  <path
-                    d="M7 37c0-4.97 4.03-8 9-8h16c4.97 0 9 3.03 9 8v3a1 1 0 0 1-1 1H8a1 1 0 0 1-1-1v-3Z"
-                  />
-                  <circle
-                    cx="24"
-                    cy="15"
-                    r="8"
-                  />
-                </svg>
-                Tab 3
-              </span>
-            </span>
-          </div>
-          <div
-            class="arco-tabs-header-ink"
-          />
-        </div>
-      </div>
-    </div>
-  </div>
-  <div
-    class="arco-tabs-content arco-tabs-content-horizontal"
-  >
-    <div
-      class="arco-tabs-content-inner"
-      style="margin-left:-0%"
-    >
-      <div
-        aria-labelledby="arco-tabs-5-tab-0"
-        class="arco-tabs-content-item arco-tabs-content-item-active"
-        id="arco-tabs-5-panel-0"
-        role="tabpanel"
-        tabindex="0"
-      >
-        <div
-          class="arco-tabs-pane"
-        >
-          <div
-            class="arco-typography"
-            style="text-align:center;margin-top:20px"
-          >
-            Content of Tab Panel 1
-          </div>
-        </div>
-      </div>
-      <div
-        aria-hidden="true"
-        aria-labelledby="arco-tabs-5-tab-1"
-        class="arco-tabs-content-item"
-        id="arco-tabs-5-panel-1"
-        role="tabpanel"
-        tabindex="-1"
-      />
-      <div
-        aria-hidden="true"
-        aria-labelledby="arco-tabs-5-tab-2"
-        class="arco-tabs-content-item"
-        id="arco-tabs-5-panel-2"
-        role="tabpanel"
-        tabindex="-1"
-      />
-    </div>
-  </div>
-</div>
-`;
-
 exports[`renders Tabs/demo/inline.md correctly 1`] = `
 <div
   class="arco-tabs arco-tabs-vertical arco-tabs-line arco-tabs-left arco-tabs-size-default"
@@ -942,10 +942,10 @@ exports[`renders Tabs/demo/inline.md correctly 1`] = `
           style="transform:translateY(0px);-webkit-transform:translateY(0px);-ms-transform:translateY(0px);-moz-transform:translateY(0px);-o-transform:translateY(0px)"
         >
           <div
-            aria-controls="arco-tabs-6-panel-0"
+            aria-controls="arco-tabs-5-panel-0"
             aria-selected="true"
             class="arco-tabs-header-title arco-tabs-header-title-active"
-            id="arco-tabs-6-tab-0"
+            id="arco-tabs-5-tab-0"
             role="tab"
             tabindex="0"
           >
@@ -956,10 +956,10 @@ exports[`renders Tabs/demo/inline.md correctly 1`] = `
             </span>
           </div>
           <div
-            aria-controls="arco-tabs-6-panel-1"
+            aria-controls="arco-tabs-5-panel-1"
             aria-selected="false"
             class="arco-tabs-header-title"
-            id="arco-tabs-6-tab-1"
+            id="arco-tabs-5-tab-1"
             role="tab"
             tabindex="0"
           >
@@ -970,10 +970,10 @@ exports[`renders Tabs/demo/inline.md correctly 1`] = `
             </span>
           </div>
           <div
-            aria-controls="arco-tabs-6-panel-2"
+            aria-controls="arco-tabs-5-panel-2"
             aria-selected="false"
             class="arco-tabs-header-title"
-            id="arco-tabs-6-tab-2"
+            id="arco-tabs-5-tab-2"
             role="tab"
             tabindex="0"
           >
@@ -998,9 +998,9 @@ exports[`renders Tabs/demo/inline.md correctly 1`] = `
       style="margin-left:-0%"
     >
       <div
-        aria-labelledby="arco-tabs-6-tab-0"
+        aria-labelledby="arco-tabs-5-tab-0"
         class="arco-tabs-content-item arco-tabs-content-item-active"
-        id="arco-tabs-6-panel-0"
+        id="arco-tabs-5-panel-0"
         role="tabpanel"
         tabindex="0"
       >
@@ -1025,10 +1025,10 @@ exports[`renders Tabs/demo/inline.md correctly 1`] = `
                       style="transform:translateX(0px);-webkit-transform:translateX(0px);-ms-transform:translateX(0px);-moz-transform:translateX(0px);-o-transform:translateX(0px)"
                     >
                       <div
-                        aria-controls="arco-tabs-7-panel-0"
+                        aria-controls="arco-tabs-6-panel-0"
                         aria-selected="true"
                         class="arco-tabs-header-title arco-tabs-header-title-active"
-                        id="arco-tabs-7-tab-0"
+                        id="arco-tabs-6-tab-0"
                         role="tab"
                         tabindex="0"
                       >
@@ -1039,10 +1039,10 @@ exports[`renders Tabs/demo/inline.md correctly 1`] = `
                         </span>
                       </div>
                       <div
-                        aria-controls="arco-tabs-7-panel-1"
+                        aria-controls="arco-tabs-6-panel-1"
                         aria-selected="false"
                         class="arco-tabs-header-title"
-                        id="arco-tabs-7-tab-1"
+                        id="arco-tabs-6-tab-1"
                         role="tab"
                         tabindex="0"
                       >
@@ -1053,10 +1053,10 @@ exports[`renders Tabs/demo/inline.md correctly 1`] = `
                         </span>
                       </div>
                       <div
-                        aria-controls="arco-tabs-7-panel-2"
+                        aria-controls="arco-tabs-6-panel-2"
                         aria-selected="false"
                         class="arco-tabs-header-title"
-                        id="arco-tabs-7-tab-2"
+                        id="arco-tabs-6-tab-2"
                         role="tab"
                         tabindex="0"
                       >
@@ -1081,9 +1081,9 @@ exports[`renders Tabs/demo/inline.md correctly 1`] = `
                   style="margin-left:-0%"
                 >
                   <div
-                    aria-labelledby="arco-tabs-7-tab-0"
+                    aria-labelledby="arco-tabs-6-tab-0"
                     class="arco-tabs-content-item arco-tabs-content-item-active"
-                    id="arco-tabs-7-panel-0"
+                    id="arco-tabs-6-panel-0"
                     role="tabpanel"
                     tabindex="0"
                   >
@@ -1100,17 +1100,17 @@ exports[`renders Tabs/demo/inline.md correctly 1`] = `
                   </div>
                   <div
                     aria-hidden="true"
-                    aria-labelledby="arco-tabs-7-tab-1"
+                    aria-labelledby="arco-tabs-6-tab-1"
                     class="arco-tabs-content-item"
-                    id="arco-tabs-7-panel-1"
+                    id="arco-tabs-6-panel-1"
                     role="tabpanel"
                     tabindex="-1"
                   />
                   <div
                     aria-hidden="true"
-                    aria-labelledby="arco-tabs-7-tab-2"
+                    aria-labelledby="arco-tabs-6-tab-2"
                     class="arco-tabs-content-item"
-                    id="arco-tabs-7-panel-2"
+                    id="arco-tabs-6-panel-2"
                     role="tabpanel"
                     tabindex="-1"
                   />
@@ -1122,17 +1122,17 @@ exports[`renders Tabs/demo/inline.md correctly 1`] = `
       </div>
       <div
         aria-hidden="true"
-        aria-labelledby="arco-tabs-6-tab-1"
+        aria-labelledby="arco-tabs-5-tab-1"
         class="arco-tabs-content-item"
-        id="arco-tabs-6-panel-1"
+        id="arco-tabs-5-panel-1"
         role="tabpanel"
         tabindex="-1"
       />
       <div
         aria-hidden="true"
-        aria-labelledby="arco-tabs-6-tab-2"
+        aria-labelledby="arco-tabs-5-tab-2"
         class="arco-tabs-content-item"
-        id="arco-tabs-6-panel-2"
+        id="arco-tabs-5-panel-2"
         role="tabpanel"
         tabindex="-1"
       />
@@ -1222,10 +1222,10 @@ exports[`renders Tabs/demo/position.md correctly 1`] = `
             style="transform:translateX(0px);-webkit-transform:translateX(0px);-ms-transform:translateX(0px);-moz-transform:translateX(0px);-o-transform:translateX(0px)"
           >
             <div
-              aria-controls="arco-tabs-8-panel-0"
+              aria-controls="arco-tabs-7-panel-0"
               aria-selected="true"
               class="arco-tabs-header-title arco-tabs-header-title-active"
-              id="arco-tabs-8-tab-0"
+              id="arco-tabs-7-tab-0"
               role="tab"
               tabindex="0"
             >
@@ -1236,10 +1236,10 @@ exports[`renders Tabs/demo/position.md correctly 1`] = `
               </span>
             </div>
             <div
-              aria-controls="arco-tabs-8-panel-1"
+              aria-controls="arco-tabs-7-panel-1"
               aria-selected="false"
               class="arco-tabs-header-title"
-              id="arco-tabs-8-tab-1"
+              id="arco-tabs-7-tab-1"
               role="tab"
               tabindex="0"
             >
@@ -1250,10 +1250,10 @@ exports[`renders Tabs/demo/position.md correctly 1`] = `
               </span>
             </div>
             <div
-              aria-controls="arco-tabs-8-panel-2"
+              aria-controls="arco-tabs-7-panel-2"
               aria-selected="false"
               class="arco-tabs-header-title"
-              id="arco-tabs-8-tab-2"
+              id="arco-tabs-7-tab-2"
               role="tab"
               tabindex="0"
             >
@@ -1278,9 +1278,9 @@ exports[`renders Tabs/demo/position.md correctly 1`] = `
         style="margin-left:-0%"
       >
         <div
-          aria-labelledby="arco-tabs-8-tab-0"
+          aria-labelledby="arco-tabs-7-tab-0"
           class="arco-tabs-content-item arco-tabs-content-item-active"
-          id="arco-tabs-8-panel-0"
+          id="arco-tabs-7-panel-0"
           role="tabpanel"
           tabindex="0"
         >
@@ -1297,17 +1297,17 @@ exports[`renders Tabs/demo/position.md correctly 1`] = `
         </div>
         <div
           aria-hidden="true"
-          aria-labelledby="arco-tabs-8-tab-1"
+          aria-labelledby="arco-tabs-7-tab-1"
           class="arco-tabs-content-item"
-          id="arco-tabs-8-panel-1"
+          id="arco-tabs-7-panel-1"
           role="tabpanel"
           tabindex="-1"
         />
         <div
           aria-hidden="true"
-          aria-labelledby="arco-tabs-8-tab-2"
+          aria-labelledby="arco-tabs-7-tab-2"
           class="arco-tabs-content-item"
-          id="arco-tabs-8-panel-2"
+          id="arco-tabs-7-panel-2"
           role="tabpanel"
           tabindex="-1"
         />
@@ -1489,10 +1489,10 @@ exports[`renders Tabs/demo/scroll.md correctly 1`] = `
             style="transform:translateX(0px);-webkit-transform:translateX(0px);-ms-transform:translateX(0px);-moz-transform:translateX(0px);-o-transform:translateX(0px)"
           >
             <div
-              aria-controls="arco-tabs-10-panel-0"
+              aria-controls="arco-tabs-8-panel-0"
               aria-selected="true"
               class="arco-tabs-header-title arco-tabs-header-title-active"
-              id="arco-tabs-10-tab-0"
+              id="arco-tabs-8-tab-0"
               role="tab"
               tabindex="0"
             >
@@ -1503,10 +1503,10 @@ exports[`renders Tabs/demo/scroll.md correctly 1`] = `
               </span>
             </div>
             <div
-              aria-controls="arco-tabs-10-panel-1"
+              aria-controls="arco-tabs-8-panel-1"
               aria-selected="false"
               class="arco-tabs-header-title"
-              id="arco-tabs-10-tab-1"
+              id="arco-tabs-8-tab-1"
               role="tab"
               tabindex="0"
             >
@@ -1517,10 +1517,10 @@ exports[`renders Tabs/demo/scroll.md correctly 1`] = `
               </span>
             </div>
             <div
-              aria-controls="arco-tabs-10-panel-2"
+              aria-controls="arco-tabs-8-panel-2"
               aria-selected="false"
               class="arco-tabs-header-title"
-              id="arco-tabs-10-tab-2"
+              id="arco-tabs-8-tab-2"
               role="tab"
               tabindex="0"
             >
@@ -1531,10 +1531,10 @@ exports[`renders Tabs/demo/scroll.md correctly 1`] = `
               </span>
             </div>
             <div
-              aria-controls="arco-tabs-10-panel-3"
+              aria-controls="arco-tabs-8-panel-3"
               aria-selected="false"
               class="arco-tabs-header-title"
-              id="arco-tabs-10-tab-3"
+              id="arco-tabs-8-tab-3"
               role="tab"
               tabindex="0"
             >
@@ -1545,10 +1545,10 @@ exports[`renders Tabs/demo/scroll.md correctly 1`] = `
               </span>
             </div>
             <div
-              aria-controls="arco-tabs-10-panel-4"
+              aria-controls="arco-tabs-8-panel-4"
               aria-selected="false"
               class="arco-tabs-header-title"
-              id="arco-tabs-10-tab-4"
+              id="arco-tabs-8-tab-4"
               role="tab"
               tabindex="0"
             >
@@ -1559,10 +1559,10 @@ exports[`renders Tabs/demo/scroll.md correctly 1`] = `
               </span>
             </div>
             <div
-              aria-controls="arco-tabs-10-panel-5"
+              aria-controls="arco-tabs-8-panel-5"
               aria-selected="false"
               class="arco-tabs-header-title"
-              id="arco-tabs-10-tab-5"
+              id="arco-tabs-8-tab-5"
               role="tab"
               tabindex="0"
             >
@@ -1573,10 +1573,10 @@ exports[`renders Tabs/demo/scroll.md correctly 1`] = `
               </span>
             </div>
             <div
-              aria-controls="arco-tabs-10-panel-6"
+              aria-controls="arco-tabs-8-panel-6"
               aria-selected="false"
               class="arco-tabs-header-title"
-              id="arco-tabs-10-tab-6"
+              id="arco-tabs-8-tab-6"
               role="tab"
               tabindex="0"
             >
@@ -1587,10 +1587,10 @@ exports[`renders Tabs/demo/scroll.md correctly 1`] = `
               </span>
             </div>
             <div
-              aria-controls="arco-tabs-10-panel-7"
+              aria-controls="arco-tabs-8-panel-7"
               aria-selected="false"
               class="arco-tabs-header-title"
-              id="arco-tabs-10-tab-7"
+              id="arco-tabs-8-tab-7"
               role="tab"
               tabindex="0"
             >
@@ -1601,10 +1601,10 @@ exports[`renders Tabs/demo/scroll.md correctly 1`] = `
               </span>
             </div>
             <div
-              aria-controls="arco-tabs-10-panel-8"
+              aria-controls="arco-tabs-8-panel-8"
               aria-selected="false"
               class="arco-tabs-header-title"
-              id="arco-tabs-10-tab-8"
+              id="arco-tabs-8-tab-8"
               role="tab"
               tabindex="0"
             >
@@ -1615,10 +1615,10 @@ exports[`renders Tabs/demo/scroll.md correctly 1`] = `
               </span>
             </div>
             <div
-              aria-controls="arco-tabs-10-panel-9"
+              aria-controls="arco-tabs-8-panel-9"
               aria-selected="false"
               class="arco-tabs-header-title"
-              id="arco-tabs-10-tab-9"
+              id="arco-tabs-8-tab-9"
               role="tab"
               tabindex="0"
             >
@@ -1629,10 +1629,10 @@ exports[`renders Tabs/demo/scroll.md correctly 1`] = `
               </span>
             </div>
             <div
-              aria-controls="arco-tabs-10-panel-10"
+              aria-controls="arco-tabs-8-panel-10"
               aria-selected="false"
               class="arco-tabs-header-title"
-              id="arco-tabs-10-tab-10"
+              id="arco-tabs-8-tab-10"
               role="tab"
               tabindex="0"
             >
@@ -1643,10 +1643,10 @@ exports[`renders Tabs/demo/scroll.md correctly 1`] = `
               </span>
             </div>
             <div
-              aria-controls="arco-tabs-10-panel-11"
+              aria-controls="arco-tabs-8-panel-11"
               aria-selected="false"
               class="arco-tabs-header-title"
-              id="arco-tabs-10-tab-11"
+              id="arco-tabs-8-tab-11"
               role="tab"
               tabindex="0"
             >
@@ -1657,10 +1657,10 @@ exports[`renders Tabs/demo/scroll.md correctly 1`] = `
               </span>
             </div>
             <div
-              aria-controls="arco-tabs-10-panel-12"
+              aria-controls="arco-tabs-8-panel-12"
               aria-selected="false"
               class="arco-tabs-header-title"
-              id="arco-tabs-10-tab-12"
+              id="arco-tabs-8-tab-12"
               role="tab"
               tabindex="0"
             >
@@ -1671,10 +1671,10 @@ exports[`renders Tabs/demo/scroll.md correctly 1`] = `
               </span>
             </div>
             <div
-              aria-controls="arco-tabs-10-panel-13"
+              aria-controls="arco-tabs-8-panel-13"
               aria-selected="false"
               class="arco-tabs-header-title"
-              id="arco-tabs-10-tab-13"
+              id="arco-tabs-8-tab-13"
               role="tab"
               tabindex="0"
             >
@@ -1685,10 +1685,10 @@ exports[`renders Tabs/demo/scroll.md correctly 1`] = `
               </span>
             </div>
             <div
-              aria-controls="arco-tabs-10-panel-14"
+              aria-controls="arco-tabs-8-panel-14"
               aria-selected="false"
               class="arco-tabs-header-title"
-              id="arco-tabs-10-tab-14"
+              id="arco-tabs-8-tab-14"
               role="tab"
               tabindex="0"
             >
@@ -1699,10 +1699,10 @@ exports[`renders Tabs/demo/scroll.md correctly 1`] = `
               </span>
             </div>
             <div
-              aria-controls="arco-tabs-10-panel-15"
+              aria-controls="arco-tabs-8-panel-15"
               aria-selected="false"
               class="arco-tabs-header-title"
-              id="arco-tabs-10-tab-15"
+              id="arco-tabs-8-tab-15"
               role="tab"
               tabindex="0"
             >
@@ -1713,10 +1713,10 @@ exports[`renders Tabs/demo/scroll.md correctly 1`] = `
               </span>
             </div>
             <div
-              aria-controls="arco-tabs-10-panel-16"
+              aria-controls="arco-tabs-8-panel-16"
               aria-selected="false"
               class="arco-tabs-header-title"
-              id="arco-tabs-10-tab-16"
+              id="arco-tabs-8-tab-16"
               role="tab"
               tabindex="0"
             >
@@ -1727,10 +1727,10 @@ exports[`renders Tabs/demo/scroll.md correctly 1`] = `
               </span>
             </div>
             <div
-              aria-controls="arco-tabs-10-panel-17"
+              aria-controls="arco-tabs-8-panel-17"
               aria-selected="false"
               class="arco-tabs-header-title"
-              id="arco-tabs-10-tab-17"
+              id="arco-tabs-8-tab-17"
               role="tab"
               tabindex="0"
             >
@@ -1741,10 +1741,10 @@ exports[`renders Tabs/demo/scroll.md correctly 1`] = `
               </span>
             </div>
             <div
-              aria-controls="arco-tabs-10-panel-18"
+              aria-controls="arco-tabs-8-panel-18"
               aria-selected="false"
               class="arco-tabs-header-title"
-              id="arco-tabs-10-tab-18"
+              id="arco-tabs-8-tab-18"
               role="tab"
               tabindex="0"
             >
@@ -1755,10 +1755,10 @@ exports[`renders Tabs/demo/scroll.md correctly 1`] = `
               </span>
             </div>
             <div
-              aria-controls="arco-tabs-10-panel-19"
+              aria-controls="arco-tabs-8-panel-19"
               aria-selected="false"
               class="arco-tabs-header-title"
-              id="arco-tabs-10-tab-19"
+              id="arco-tabs-8-tab-19"
               role="tab"
               tabindex="0"
             >
@@ -1769,10 +1769,10 @@ exports[`renders Tabs/demo/scroll.md correctly 1`] = `
               </span>
             </div>
             <div
-              aria-controls="arco-tabs-10-panel-20"
+              aria-controls="arco-tabs-8-panel-20"
               aria-selected="false"
               class="arco-tabs-header-title"
-              id="arco-tabs-10-tab-20"
+              id="arco-tabs-8-tab-20"
               role="tab"
               tabindex="0"
             >
@@ -1783,10 +1783,10 @@ exports[`renders Tabs/demo/scroll.md correctly 1`] = `
               </span>
             </div>
             <div
-              aria-controls="arco-tabs-10-panel-21"
+              aria-controls="arco-tabs-8-panel-21"
               aria-selected="false"
               class="arco-tabs-header-title"
-              id="arco-tabs-10-tab-21"
+              id="arco-tabs-8-tab-21"
               role="tab"
               tabindex="0"
             >
@@ -1797,10 +1797,10 @@ exports[`renders Tabs/demo/scroll.md correctly 1`] = `
               </span>
             </div>
             <div
-              aria-controls="arco-tabs-10-panel-22"
+              aria-controls="arco-tabs-8-panel-22"
               aria-selected="false"
               class="arco-tabs-header-title"
-              id="arco-tabs-10-tab-22"
+              id="arco-tabs-8-tab-22"
               role="tab"
               tabindex="0"
             >
@@ -1811,10 +1811,10 @@ exports[`renders Tabs/demo/scroll.md correctly 1`] = `
               </span>
             </div>
             <div
-              aria-controls="arco-tabs-10-panel-23"
+              aria-controls="arco-tabs-8-panel-23"
               aria-selected="false"
               class="arco-tabs-header-title"
-              id="arco-tabs-10-tab-23"
+              id="arco-tabs-8-tab-23"
               role="tab"
               tabindex="0"
             >
@@ -1825,10 +1825,10 @@ exports[`renders Tabs/demo/scroll.md correctly 1`] = `
               </span>
             </div>
             <div
-              aria-controls="arco-tabs-10-panel-24"
+              aria-controls="arco-tabs-8-panel-24"
               aria-selected="false"
               class="arco-tabs-header-title"
-              id="arco-tabs-10-tab-24"
+              id="arco-tabs-8-tab-24"
               role="tab"
               tabindex="0"
             >
@@ -1839,10 +1839,10 @@ exports[`renders Tabs/demo/scroll.md correctly 1`] = `
               </span>
             </div>
             <div
-              aria-controls="arco-tabs-10-panel-25"
+              aria-controls="arco-tabs-8-panel-25"
               aria-selected="false"
               class="arco-tabs-header-title"
-              id="arco-tabs-10-tab-25"
+              id="arco-tabs-8-tab-25"
               role="tab"
               tabindex="0"
             >
@@ -1853,10 +1853,10 @@ exports[`renders Tabs/demo/scroll.md correctly 1`] = `
               </span>
             </div>
             <div
-              aria-controls="arco-tabs-10-panel-26"
+              aria-controls="arco-tabs-8-panel-26"
               aria-selected="false"
               class="arco-tabs-header-title"
-              id="arco-tabs-10-tab-26"
+              id="arco-tabs-8-tab-26"
               role="tab"
               tabindex="0"
             >
@@ -1867,10 +1867,10 @@ exports[`renders Tabs/demo/scroll.md correctly 1`] = `
               </span>
             </div>
             <div
-              aria-controls="arco-tabs-10-panel-27"
+              aria-controls="arco-tabs-8-panel-27"
               aria-selected="false"
               class="arco-tabs-header-title"
-              id="arco-tabs-10-tab-27"
+              id="arco-tabs-8-tab-27"
               role="tab"
               tabindex="0"
             >
@@ -1881,10 +1881,10 @@ exports[`renders Tabs/demo/scroll.md correctly 1`] = `
               </span>
             </div>
             <div
-              aria-controls="arco-tabs-10-panel-28"
+              aria-controls="arco-tabs-8-panel-28"
               aria-selected="false"
               class="arco-tabs-header-title"
-              id="arco-tabs-10-tab-28"
+              id="arco-tabs-8-tab-28"
               role="tab"
               tabindex="0"
             >
@@ -1895,10 +1895,10 @@ exports[`renders Tabs/demo/scroll.md correctly 1`] = `
               </span>
             </div>
             <div
-              aria-controls="arco-tabs-10-panel-29"
+              aria-controls="arco-tabs-8-panel-29"
               aria-selected="false"
               class="arco-tabs-header-title"
-              id="arco-tabs-10-tab-29"
+              id="arco-tabs-8-tab-29"
               role="tab"
               tabindex="0"
             >
@@ -1923,9 +1923,9 @@ exports[`renders Tabs/demo/scroll.md correctly 1`] = `
         style="margin-left:-0%"
       >
         <div
-          aria-labelledby="arco-tabs-10-tab-0"
+          aria-labelledby="arco-tabs-8-tab-0"
           class="arco-tabs-content-item arco-tabs-content-item-active"
-          id="arco-tabs-10-panel-0"
+          id="arco-tabs-8-panel-0"
           role="tabpanel"
           tabindex="0"
         >
@@ -1941,233 +1941,233 @@ exports[`renders Tabs/demo/scroll.md correctly 1`] = `
         </div>
         <div
           aria-hidden="true"
-          aria-labelledby="arco-tabs-10-tab-1"
+          aria-labelledby="arco-tabs-8-tab-1"
           class="arco-tabs-content-item"
-          id="arco-tabs-10-panel-1"
+          id="arco-tabs-8-panel-1"
           role="tabpanel"
           tabindex="-1"
         />
         <div
           aria-hidden="true"
-          aria-labelledby="arco-tabs-10-tab-2"
+          aria-labelledby="arco-tabs-8-tab-2"
           class="arco-tabs-content-item"
-          id="arco-tabs-10-panel-2"
+          id="arco-tabs-8-panel-2"
           role="tabpanel"
           tabindex="-1"
         />
         <div
           aria-hidden="true"
-          aria-labelledby="arco-tabs-10-tab-3"
+          aria-labelledby="arco-tabs-8-tab-3"
           class="arco-tabs-content-item"
-          id="arco-tabs-10-panel-3"
+          id="arco-tabs-8-panel-3"
           role="tabpanel"
           tabindex="-1"
         />
         <div
           aria-hidden="true"
-          aria-labelledby="arco-tabs-10-tab-4"
+          aria-labelledby="arco-tabs-8-tab-4"
           class="arco-tabs-content-item"
-          id="arco-tabs-10-panel-4"
+          id="arco-tabs-8-panel-4"
           role="tabpanel"
           tabindex="-1"
         />
         <div
           aria-hidden="true"
-          aria-labelledby="arco-tabs-10-tab-5"
+          aria-labelledby="arco-tabs-8-tab-5"
           class="arco-tabs-content-item"
-          id="arco-tabs-10-panel-5"
+          id="arco-tabs-8-panel-5"
           role="tabpanel"
           tabindex="-1"
         />
         <div
           aria-hidden="true"
-          aria-labelledby="arco-tabs-10-tab-6"
+          aria-labelledby="arco-tabs-8-tab-6"
           class="arco-tabs-content-item"
-          id="arco-tabs-10-panel-6"
+          id="arco-tabs-8-panel-6"
           role="tabpanel"
           tabindex="-1"
         />
         <div
           aria-hidden="true"
-          aria-labelledby="arco-tabs-10-tab-7"
+          aria-labelledby="arco-tabs-8-tab-7"
           class="arco-tabs-content-item"
-          id="arco-tabs-10-panel-7"
+          id="arco-tabs-8-panel-7"
           role="tabpanel"
           tabindex="-1"
         />
         <div
           aria-hidden="true"
-          aria-labelledby="arco-tabs-10-tab-8"
+          aria-labelledby="arco-tabs-8-tab-8"
           class="arco-tabs-content-item"
-          id="arco-tabs-10-panel-8"
+          id="arco-tabs-8-panel-8"
           role="tabpanel"
           tabindex="-1"
         />
         <div
           aria-hidden="true"
-          aria-labelledby="arco-tabs-10-tab-9"
+          aria-labelledby="arco-tabs-8-tab-9"
           class="arco-tabs-content-item"
-          id="arco-tabs-10-panel-9"
+          id="arco-tabs-8-panel-9"
           role="tabpanel"
           tabindex="-1"
         />
         <div
           aria-hidden="true"
-          aria-labelledby="arco-tabs-10-tab-10"
+          aria-labelledby="arco-tabs-8-tab-10"
           class="arco-tabs-content-item"
-          id="arco-tabs-10-panel-10"
+          id="arco-tabs-8-panel-10"
           role="tabpanel"
           tabindex="-1"
         />
         <div
           aria-hidden="true"
-          aria-labelledby="arco-tabs-10-tab-11"
+          aria-labelledby="arco-tabs-8-tab-11"
           class="arco-tabs-content-item"
-          id="arco-tabs-10-panel-11"
+          id="arco-tabs-8-panel-11"
           role="tabpanel"
           tabindex="-1"
         />
         <div
           aria-hidden="true"
-          aria-labelledby="arco-tabs-10-tab-12"
+          aria-labelledby="arco-tabs-8-tab-12"
           class="arco-tabs-content-item"
-          id="arco-tabs-10-panel-12"
+          id="arco-tabs-8-panel-12"
           role="tabpanel"
           tabindex="-1"
         />
         <div
           aria-hidden="true"
-          aria-labelledby="arco-tabs-10-tab-13"
+          aria-labelledby="arco-tabs-8-tab-13"
           class="arco-tabs-content-item"
-          id="arco-tabs-10-panel-13"
+          id="arco-tabs-8-panel-13"
           role="tabpanel"
           tabindex="-1"
         />
         <div
           aria-hidden="true"
-          aria-labelledby="arco-tabs-10-tab-14"
+          aria-labelledby="arco-tabs-8-tab-14"
           class="arco-tabs-content-item"
-          id="arco-tabs-10-panel-14"
+          id="arco-tabs-8-panel-14"
           role="tabpanel"
           tabindex="-1"
         />
         <div
           aria-hidden="true"
-          aria-labelledby="arco-tabs-10-tab-15"
+          aria-labelledby="arco-tabs-8-tab-15"
           class="arco-tabs-content-item"
-          id="arco-tabs-10-panel-15"
+          id="arco-tabs-8-panel-15"
           role="tabpanel"
           tabindex="-1"
         />
         <div
           aria-hidden="true"
-          aria-labelledby="arco-tabs-10-tab-16"
+          aria-labelledby="arco-tabs-8-tab-16"
           class="arco-tabs-content-item"
-          id="arco-tabs-10-panel-16"
+          id="arco-tabs-8-panel-16"
           role="tabpanel"
           tabindex="-1"
         />
         <div
           aria-hidden="true"
-          aria-labelledby="arco-tabs-10-tab-17"
+          aria-labelledby="arco-tabs-8-tab-17"
           class="arco-tabs-content-item"
-          id="arco-tabs-10-panel-17"
+          id="arco-tabs-8-panel-17"
           role="tabpanel"
           tabindex="-1"
         />
         <div
           aria-hidden="true"
-          aria-labelledby="arco-tabs-10-tab-18"
+          aria-labelledby="arco-tabs-8-tab-18"
           class="arco-tabs-content-item"
-          id="arco-tabs-10-panel-18"
+          id="arco-tabs-8-panel-18"
           role="tabpanel"
           tabindex="-1"
         />
         <div
           aria-hidden="true"
-          aria-labelledby="arco-tabs-10-tab-19"
+          aria-labelledby="arco-tabs-8-tab-19"
           class="arco-tabs-content-item"
-          id="arco-tabs-10-panel-19"
+          id="arco-tabs-8-panel-19"
           role="tabpanel"
           tabindex="-1"
         />
         <div
           aria-hidden="true"
-          aria-labelledby="arco-tabs-10-tab-20"
+          aria-labelledby="arco-tabs-8-tab-20"
           class="arco-tabs-content-item"
-          id="arco-tabs-10-panel-20"
+          id="arco-tabs-8-panel-20"
           role="tabpanel"
           tabindex="-1"
         />
         <div
           aria-hidden="true"
-          aria-labelledby="arco-tabs-10-tab-21"
+          aria-labelledby="arco-tabs-8-tab-21"
           class="arco-tabs-content-item"
-          id="arco-tabs-10-panel-21"
+          id="arco-tabs-8-panel-21"
           role="tabpanel"
           tabindex="-1"
         />
         <div
           aria-hidden="true"
-          aria-labelledby="arco-tabs-10-tab-22"
+          aria-labelledby="arco-tabs-8-tab-22"
           class="arco-tabs-content-item"
-          id="arco-tabs-10-panel-22"
+          id="arco-tabs-8-panel-22"
           role="tabpanel"
           tabindex="-1"
         />
         <div
           aria-hidden="true"
-          aria-labelledby="arco-tabs-10-tab-23"
+          aria-labelledby="arco-tabs-8-tab-23"
           class="arco-tabs-content-item"
-          id="arco-tabs-10-panel-23"
+          id="arco-tabs-8-panel-23"
           role="tabpanel"
           tabindex="-1"
         />
         <div
           aria-hidden="true"
-          aria-labelledby="arco-tabs-10-tab-24"
+          aria-labelledby="arco-tabs-8-tab-24"
           class="arco-tabs-content-item"
-          id="arco-tabs-10-panel-24"
+          id="arco-tabs-8-panel-24"
           role="tabpanel"
           tabindex="-1"
         />
         <div
           aria-hidden="true"
-          aria-labelledby="arco-tabs-10-tab-25"
+          aria-labelledby="arco-tabs-8-tab-25"
           class="arco-tabs-content-item"
-          id="arco-tabs-10-panel-25"
+          id="arco-tabs-8-panel-25"
           role="tabpanel"
           tabindex="-1"
         />
         <div
           aria-hidden="true"
-          aria-labelledby="arco-tabs-10-tab-26"
+          aria-labelledby="arco-tabs-8-tab-26"
           class="arco-tabs-content-item"
-          id="arco-tabs-10-panel-26"
+          id="arco-tabs-8-panel-26"
           role="tabpanel"
           tabindex="-1"
         />
         <div
           aria-hidden="true"
-          aria-labelledby="arco-tabs-10-tab-27"
+          aria-labelledby="arco-tabs-8-tab-27"
           class="arco-tabs-content-item"
-          id="arco-tabs-10-panel-27"
+          id="arco-tabs-8-panel-27"
           role="tabpanel"
           tabindex="-1"
         />
         <div
           aria-hidden="true"
-          aria-labelledby="arco-tabs-10-tab-28"
+          aria-labelledby="arco-tabs-8-tab-28"
           class="arco-tabs-content-item"
-          id="arco-tabs-10-panel-28"
+          id="arco-tabs-8-panel-28"
           role="tabpanel"
           tabindex="-1"
         />
         <div
           aria-hidden="true"
-          aria-labelledby="arco-tabs-10-tab-29"
+          aria-labelledby="arco-tabs-8-tab-29"
           class="arco-tabs-content-item"
-          id="arco-tabs-10-panel-29"
+          id="arco-tabs-8-panel-29"
           role="tabpanel"
           tabindex="-1"
         />
@@ -2305,10 +2305,10 @@ exports[`renders Tabs/demo/scrollPosition.md correctly 1`] = `
             style="transform:translateX(0px);-webkit-transform:translateX(0px);-ms-transform:translateX(0px);-moz-transform:translateX(0px);-o-transform:translateX(0px)"
           >
             <div
-              aria-controls="arco-tabs-11-panel-0"
+              aria-controls="arco-tabs-9-panel-0"
               aria-selected="true"
               class="arco-tabs-header-title arco-tabs-header-title-active"
-              id="arco-tabs-11-tab-0"
+              id="arco-tabs-9-tab-0"
               role="tab"
               tabindex="0"
             >
@@ -2319,10 +2319,10 @@ exports[`renders Tabs/demo/scrollPosition.md correctly 1`] = `
               </span>
             </div>
             <div
-              aria-controls="arco-tabs-11-panel-1"
+              aria-controls="arco-tabs-9-panel-1"
               aria-selected="false"
               class="arco-tabs-header-title"
-              id="arco-tabs-11-tab-1"
+              id="arco-tabs-9-tab-1"
               role="tab"
               tabindex="0"
             >
@@ -2333,10 +2333,10 @@ exports[`renders Tabs/demo/scrollPosition.md correctly 1`] = `
               </span>
             </div>
             <div
-              aria-controls="arco-tabs-11-panel-2"
+              aria-controls="arco-tabs-9-panel-2"
               aria-selected="false"
               class="arco-tabs-header-title"
-              id="arco-tabs-11-tab-2"
+              id="arco-tabs-9-tab-2"
               role="tab"
               tabindex="0"
             >
@@ -2347,10 +2347,10 @@ exports[`renders Tabs/demo/scrollPosition.md correctly 1`] = `
               </span>
             </div>
             <div
-              aria-controls="arco-tabs-11-panel-3"
+              aria-controls="arco-tabs-9-panel-3"
               aria-selected="false"
               class="arco-tabs-header-title"
-              id="arco-tabs-11-tab-3"
+              id="arco-tabs-9-tab-3"
               role="tab"
               tabindex="0"
             >
@@ -2361,10 +2361,10 @@ exports[`renders Tabs/demo/scrollPosition.md correctly 1`] = `
               </span>
             </div>
             <div
-              aria-controls="arco-tabs-11-panel-4"
+              aria-controls="arco-tabs-9-panel-4"
               aria-selected="false"
               class="arco-tabs-header-title"
-              id="arco-tabs-11-tab-4"
+              id="arco-tabs-9-tab-4"
               role="tab"
               tabindex="0"
             >
@@ -2375,10 +2375,10 @@ exports[`renders Tabs/demo/scrollPosition.md correctly 1`] = `
               </span>
             </div>
             <div
-              aria-controls="arco-tabs-11-panel-5"
+              aria-controls="arco-tabs-9-panel-5"
               aria-selected="false"
               class="arco-tabs-header-title"
-              id="arco-tabs-11-tab-5"
+              id="arco-tabs-9-tab-5"
               role="tab"
               tabindex="0"
             >
@@ -2389,10 +2389,10 @@ exports[`renders Tabs/demo/scrollPosition.md correctly 1`] = `
               </span>
             </div>
             <div
-              aria-controls="arco-tabs-11-panel-6"
+              aria-controls="arco-tabs-9-panel-6"
               aria-selected="false"
               class="arco-tabs-header-title"
-              id="arco-tabs-11-tab-6"
+              id="arco-tabs-9-tab-6"
               role="tab"
               tabindex="0"
             >
@@ -2403,10 +2403,10 @@ exports[`renders Tabs/demo/scrollPosition.md correctly 1`] = `
               </span>
             </div>
             <div
-              aria-controls="arco-tabs-11-panel-7"
+              aria-controls="arco-tabs-9-panel-7"
               aria-selected="false"
               class="arco-tabs-header-title"
-              id="arco-tabs-11-tab-7"
+              id="arco-tabs-9-tab-7"
               role="tab"
               tabindex="0"
             >
@@ -2417,10 +2417,10 @@ exports[`renders Tabs/demo/scrollPosition.md correctly 1`] = `
               </span>
             </div>
             <div
-              aria-controls="arco-tabs-11-panel-8"
+              aria-controls="arco-tabs-9-panel-8"
               aria-selected="false"
               class="arco-tabs-header-title"
-              id="arco-tabs-11-tab-8"
+              id="arco-tabs-9-tab-8"
               role="tab"
               tabindex="0"
             >
@@ -2431,10 +2431,10 @@ exports[`renders Tabs/demo/scrollPosition.md correctly 1`] = `
               </span>
             </div>
             <div
-              aria-controls="arco-tabs-11-panel-9"
+              aria-controls="arco-tabs-9-panel-9"
               aria-selected="false"
               class="arco-tabs-header-title"
-              id="arco-tabs-11-tab-9"
+              id="arco-tabs-9-tab-9"
               role="tab"
               tabindex="0"
             >
@@ -2445,10 +2445,10 @@ exports[`renders Tabs/demo/scrollPosition.md correctly 1`] = `
               </span>
             </div>
             <div
-              aria-controls="arco-tabs-11-panel-10"
+              aria-controls="arco-tabs-9-panel-10"
               aria-selected="false"
               class="arco-tabs-header-title"
-              id="arco-tabs-11-tab-10"
+              id="arco-tabs-9-tab-10"
               role="tab"
               tabindex="0"
             >
@@ -2459,10 +2459,10 @@ exports[`renders Tabs/demo/scrollPosition.md correctly 1`] = `
               </span>
             </div>
             <div
-              aria-controls="arco-tabs-11-panel-11"
+              aria-controls="arco-tabs-9-panel-11"
               aria-selected="false"
               class="arco-tabs-header-title"
-              id="arco-tabs-11-tab-11"
+              id="arco-tabs-9-tab-11"
               role="tab"
               tabindex="0"
             >
@@ -2473,10 +2473,10 @@ exports[`renders Tabs/demo/scrollPosition.md correctly 1`] = `
               </span>
             </div>
             <div
-              aria-controls="arco-tabs-11-panel-12"
+              aria-controls="arco-tabs-9-panel-12"
               aria-selected="false"
               class="arco-tabs-header-title"
-              id="arco-tabs-11-tab-12"
+              id="arco-tabs-9-tab-12"
               role="tab"
               tabindex="0"
             >
@@ -2487,10 +2487,10 @@ exports[`renders Tabs/demo/scrollPosition.md correctly 1`] = `
               </span>
             </div>
             <div
-              aria-controls="arco-tabs-11-panel-13"
+              aria-controls="arco-tabs-9-panel-13"
               aria-selected="false"
               class="arco-tabs-header-title"
-              id="arco-tabs-11-tab-13"
+              id="arco-tabs-9-tab-13"
               role="tab"
               tabindex="0"
             >
@@ -2501,10 +2501,10 @@ exports[`renders Tabs/demo/scrollPosition.md correctly 1`] = `
               </span>
             </div>
             <div
-              aria-controls="arco-tabs-11-panel-14"
+              aria-controls="arco-tabs-9-panel-14"
               aria-selected="false"
               class="arco-tabs-header-title"
-              id="arco-tabs-11-tab-14"
+              id="arco-tabs-9-tab-14"
               role="tab"
               tabindex="0"
             >
@@ -2515,10 +2515,10 @@ exports[`renders Tabs/demo/scrollPosition.md correctly 1`] = `
               </span>
             </div>
             <div
-              aria-controls="arco-tabs-11-panel-15"
+              aria-controls="arco-tabs-9-panel-15"
               aria-selected="false"
               class="arco-tabs-header-title"
-              id="arco-tabs-11-tab-15"
+              id="arco-tabs-9-tab-15"
               role="tab"
               tabindex="0"
             >
@@ -2529,10 +2529,10 @@ exports[`renders Tabs/demo/scrollPosition.md correctly 1`] = `
               </span>
             </div>
             <div
-              aria-controls="arco-tabs-11-panel-16"
+              aria-controls="arco-tabs-9-panel-16"
               aria-selected="false"
               class="arco-tabs-header-title"
-              id="arco-tabs-11-tab-16"
+              id="arco-tabs-9-tab-16"
               role="tab"
               tabindex="0"
             >
@@ -2543,10 +2543,10 @@ exports[`renders Tabs/demo/scrollPosition.md correctly 1`] = `
               </span>
             </div>
             <div
-              aria-controls="arco-tabs-11-panel-17"
+              aria-controls="arco-tabs-9-panel-17"
               aria-selected="false"
               class="arco-tabs-header-title"
-              id="arco-tabs-11-tab-17"
+              id="arco-tabs-9-tab-17"
               role="tab"
               tabindex="0"
             >
@@ -2557,10 +2557,10 @@ exports[`renders Tabs/demo/scrollPosition.md correctly 1`] = `
               </span>
             </div>
             <div
-              aria-controls="arco-tabs-11-panel-18"
+              aria-controls="arco-tabs-9-panel-18"
               aria-selected="false"
               class="arco-tabs-header-title"
-              id="arco-tabs-11-tab-18"
+              id="arco-tabs-9-tab-18"
               role="tab"
               tabindex="0"
             >
@@ -2571,10 +2571,10 @@ exports[`renders Tabs/demo/scrollPosition.md correctly 1`] = `
               </span>
             </div>
             <div
-              aria-controls="arco-tabs-11-panel-19"
+              aria-controls="arco-tabs-9-panel-19"
               aria-selected="false"
               class="arco-tabs-header-title"
-              id="arco-tabs-11-tab-19"
+              id="arco-tabs-9-tab-19"
               role="tab"
               tabindex="0"
             >
@@ -2585,10 +2585,10 @@ exports[`renders Tabs/demo/scrollPosition.md correctly 1`] = `
               </span>
             </div>
             <div
-              aria-controls="arco-tabs-11-panel-20"
+              aria-controls="arco-tabs-9-panel-20"
               aria-selected="false"
               class="arco-tabs-header-title"
-              id="arco-tabs-11-tab-20"
+              id="arco-tabs-9-tab-20"
               role="tab"
               tabindex="0"
             >
@@ -2599,10 +2599,10 @@ exports[`renders Tabs/demo/scrollPosition.md correctly 1`] = `
               </span>
             </div>
             <div
-              aria-controls="arco-tabs-11-panel-21"
+              aria-controls="arco-tabs-9-panel-21"
               aria-selected="false"
               class="arco-tabs-header-title"
-              id="arco-tabs-11-tab-21"
+              id="arco-tabs-9-tab-21"
               role="tab"
               tabindex="0"
             >
@@ -2613,10 +2613,10 @@ exports[`renders Tabs/demo/scrollPosition.md correctly 1`] = `
               </span>
             </div>
             <div
-              aria-controls="arco-tabs-11-panel-22"
+              aria-controls="arco-tabs-9-panel-22"
               aria-selected="false"
               class="arco-tabs-header-title"
-              id="arco-tabs-11-tab-22"
+              id="arco-tabs-9-tab-22"
               role="tab"
               tabindex="0"
             >
@@ -2627,10 +2627,10 @@ exports[`renders Tabs/demo/scrollPosition.md correctly 1`] = `
               </span>
             </div>
             <div
-              aria-controls="arco-tabs-11-panel-23"
+              aria-controls="arco-tabs-9-panel-23"
               aria-selected="false"
               class="arco-tabs-header-title"
-              id="arco-tabs-11-tab-23"
+              id="arco-tabs-9-tab-23"
               role="tab"
               tabindex="0"
             >
@@ -2641,10 +2641,10 @@ exports[`renders Tabs/demo/scrollPosition.md correctly 1`] = `
               </span>
             </div>
             <div
-              aria-controls="arco-tabs-11-panel-24"
+              aria-controls="arco-tabs-9-panel-24"
               aria-selected="false"
               class="arco-tabs-header-title"
-              id="arco-tabs-11-tab-24"
+              id="arco-tabs-9-tab-24"
               role="tab"
               tabindex="0"
             >
@@ -2655,10 +2655,10 @@ exports[`renders Tabs/demo/scrollPosition.md correctly 1`] = `
               </span>
             </div>
             <div
-              aria-controls="arco-tabs-11-panel-25"
+              aria-controls="arco-tabs-9-panel-25"
               aria-selected="false"
               class="arco-tabs-header-title"
-              id="arco-tabs-11-tab-25"
+              id="arco-tabs-9-tab-25"
               role="tab"
               tabindex="0"
             >
@@ -2669,10 +2669,10 @@ exports[`renders Tabs/demo/scrollPosition.md correctly 1`] = `
               </span>
             </div>
             <div
-              aria-controls="arco-tabs-11-panel-26"
+              aria-controls="arco-tabs-9-panel-26"
               aria-selected="false"
               class="arco-tabs-header-title"
-              id="arco-tabs-11-tab-26"
+              id="arco-tabs-9-tab-26"
               role="tab"
               tabindex="0"
             >
@@ -2683,10 +2683,10 @@ exports[`renders Tabs/demo/scrollPosition.md correctly 1`] = `
               </span>
             </div>
             <div
-              aria-controls="arco-tabs-11-panel-27"
+              aria-controls="arco-tabs-9-panel-27"
               aria-selected="false"
               class="arco-tabs-header-title"
-              id="arco-tabs-11-tab-27"
+              id="arco-tabs-9-tab-27"
               role="tab"
               tabindex="0"
             >
@@ -2697,10 +2697,10 @@ exports[`renders Tabs/demo/scrollPosition.md correctly 1`] = `
               </span>
             </div>
             <div
-              aria-controls="arco-tabs-11-panel-28"
+              aria-controls="arco-tabs-9-panel-28"
               aria-selected="false"
               class="arco-tabs-header-title"
-              id="arco-tabs-11-tab-28"
+              id="arco-tabs-9-tab-28"
               role="tab"
               tabindex="0"
             >
@@ -2711,10 +2711,10 @@ exports[`renders Tabs/demo/scrollPosition.md correctly 1`] = `
               </span>
             </div>
             <div
-              aria-controls="arco-tabs-11-panel-29"
+              aria-controls="arco-tabs-9-panel-29"
               aria-selected="false"
               class="arco-tabs-header-title"
-              id="arco-tabs-11-tab-29"
+              id="arco-tabs-9-tab-29"
               role="tab"
               tabindex="0"
             >
@@ -2739,9 +2739,9 @@ exports[`renders Tabs/demo/scrollPosition.md correctly 1`] = `
         style="margin-left:-0%"
       >
         <div
-          aria-labelledby="arco-tabs-11-tab-0"
+          aria-labelledby="arco-tabs-9-tab-0"
           class="arco-tabs-content-item arco-tabs-content-item-active"
-          id="arco-tabs-11-panel-0"
+          id="arco-tabs-9-panel-0"
           role="tabpanel"
           tabindex="0"
         >
@@ -2757,233 +2757,233 @@ exports[`renders Tabs/demo/scrollPosition.md correctly 1`] = `
         </div>
         <div
           aria-hidden="true"
-          aria-labelledby="arco-tabs-11-tab-1"
+          aria-labelledby="arco-tabs-9-tab-1"
           class="arco-tabs-content-item"
-          id="arco-tabs-11-panel-1"
+          id="arco-tabs-9-panel-1"
           role="tabpanel"
           tabindex="-1"
         />
         <div
           aria-hidden="true"
-          aria-labelledby="arco-tabs-11-tab-2"
+          aria-labelledby="arco-tabs-9-tab-2"
           class="arco-tabs-content-item"
-          id="arco-tabs-11-panel-2"
+          id="arco-tabs-9-panel-2"
           role="tabpanel"
           tabindex="-1"
         />
         <div
           aria-hidden="true"
-          aria-labelledby="arco-tabs-11-tab-3"
+          aria-labelledby="arco-tabs-9-tab-3"
           class="arco-tabs-content-item"
-          id="arco-tabs-11-panel-3"
+          id="arco-tabs-9-panel-3"
           role="tabpanel"
           tabindex="-1"
         />
         <div
           aria-hidden="true"
-          aria-labelledby="arco-tabs-11-tab-4"
+          aria-labelledby="arco-tabs-9-tab-4"
           class="arco-tabs-content-item"
-          id="arco-tabs-11-panel-4"
+          id="arco-tabs-9-panel-4"
           role="tabpanel"
           tabindex="-1"
         />
         <div
           aria-hidden="true"
-          aria-labelledby="arco-tabs-11-tab-5"
+          aria-labelledby="arco-tabs-9-tab-5"
           class="arco-tabs-content-item"
-          id="arco-tabs-11-panel-5"
+          id="arco-tabs-9-panel-5"
           role="tabpanel"
           tabindex="-1"
         />
         <div
           aria-hidden="true"
-          aria-labelledby="arco-tabs-11-tab-6"
+          aria-labelledby="arco-tabs-9-tab-6"
           class="arco-tabs-content-item"
-          id="arco-tabs-11-panel-6"
+          id="arco-tabs-9-panel-6"
           role="tabpanel"
           tabindex="-1"
         />
         <div
           aria-hidden="true"
-          aria-labelledby="arco-tabs-11-tab-7"
+          aria-labelledby="arco-tabs-9-tab-7"
           class="arco-tabs-content-item"
-          id="arco-tabs-11-panel-7"
+          id="arco-tabs-9-panel-7"
           role="tabpanel"
           tabindex="-1"
         />
         <div
           aria-hidden="true"
-          aria-labelledby="arco-tabs-11-tab-8"
+          aria-labelledby="arco-tabs-9-tab-8"
           class="arco-tabs-content-item"
-          id="arco-tabs-11-panel-8"
+          id="arco-tabs-9-panel-8"
           role="tabpanel"
           tabindex="-1"
         />
         <div
           aria-hidden="true"
-          aria-labelledby="arco-tabs-11-tab-9"
+          aria-labelledby="arco-tabs-9-tab-9"
           class="arco-tabs-content-item"
-          id="arco-tabs-11-panel-9"
+          id="arco-tabs-9-panel-9"
           role="tabpanel"
           tabindex="-1"
         />
         <div
           aria-hidden="true"
-          aria-labelledby="arco-tabs-11-tab-10"
+          aria-labelledby="arco-tabs-9-tab-10"
           class="arco-tabs-content-item"
-          id="arco-tabs-11-panel-10"
+          id="arco-tabs-9-panel-10"
           role="tabpanel"
           tabindex="-1"
         />
         <div
           aria-hidden="true"
-          aria-labelledby="arco-tabs-11-tab-11"
+          aria-labelledby="arco-tabs-9-tab-11"
           class="arco-tabs-content-item"
-          id="arco-tabs-11-panel-11"
+          id="arco-tabs-9-panel-11"
           role="tabpanel"
           tabindex="-1"
         />
         <div
           aria-hidden="true"
-          aria-labelledby="arco-tabs-11-tab-12"
+          aria-labelledby="arco-tabs-9-tab-12"
           class="arco-tabs-content-item"
-          id="arco-tabs-11-panel-12"
+          id="arco-tabs-9-panel-12"
           role="tabpanel"
           tabindex="-1"
         />
         <div
           aria-hidden="true"
-          aria-labelledby="arco-tabs-11-tab-13"
+          aria-labelledby="arco-tabs-9-tab-13"
           class="arco-tabs-content-item"
-          id="arco-tabs-11-panel-13"
+          id="arco-tabs-9-panel-13"
           role="tabpanel"
           tabindex="-1"
         />
         <div
           aria-hidden="true"
-          aria-labelledby="arco-tabs-11-tab-14"
+          aria-labelledby="arco-tabs-9-tab-14"
           class="arco-tabs-content-item"
-          id="arco-tabs-11-panel-14"
+          id="arco-tabs-9-panel-14"
           role="tabpanel"
           tabindex="-1"
         />
         <div
           aria-hidden="true"
-          aria-labelledby="arco-tabs-11-tab-15"
+          aria-labelledby="arco-tabs-9-tab-15"
           class="arco-tabs-content-item"
-          id="arco-tabs-11-panel-15"
+          id="arco-tabs-9-panel-15"
           role="tabpanel"
           tabindex="-1"
         />
         <div
           aria-hidden="true"
-          aria-labelledby="arco-tabs-11-tab-16"
+          aria-labelledby="arco-tabs-9-tab-16"
           class="arco-tabs-content-item"
-          id="arco-tabs-11-panel-16"
+          id="arco-tabs-9-panel-16"
           role="tabpanel"
           tabindex="-1"
         />
         <div
           aria-hidden="true"
-          aria-labelledby="arco-tabs-11-tab-17"
+          aria-labelledby="arco-tabs-9-tab-17"
           class="arco-tabs-content-item"
-          id="arco-tabs-11-panel-17"
+          id="arco-tabs-9-panel-17"
           role="tabpanel"
           tabindex="-1"
         />
         <div
           aria-hidden="true"
-          aria-labelledby="arco-tabs-11-tab-18"
+          aria-labelledby="arco-tabs-9-tab-18"
           class="arco-tabs-content-item"
-          id="arco-tabs-11-panel-18"
+          id="arco-tabs-9-panel-18"
           role="tabpanel"
           tabindex="-1"
         />
         <div
           aria-hidden="true"
-          aria-labelledby="arco-tabs-11-tab-19"
+          aria-labelledby="arco-tabs-9-tab-19"
           class="arco-tabs-content-item"
-          id="arco-tabs-11-panel-19"
+          id="arco-tabs-9-panel-19"
           role="tabpanel"
           tabindex="-1"
         />
         <div
           aria-hidden="true"
-          aria-labelledby="arco-tabs-11-tab-20"
+          aria-labelledby="arco-tabs-9-tab-20"
           class="arco-tabs-content-item"
-          id="arco-tabs-11-panel-20"
+          id="arco-tabs-9-panel-20"
           role="tabpanel"
           tabindex="-1"
         />
         <div
           aria-hidden="true"
-          aria-labelledby="arco-tabs-11-tab-21"
+          aria-labelledby="arco-tabs-9-tab-21"
           class="arco-tabs-content-item"
-          id="arco-tabs-11-panel-21"
+          id="arco-tabs-9-panel-21"
           role="tabpanel"
           tabindex="-1"
         />
         <div
           aria-hidden="true"
-          aria-labelledby="arco-tabs-11-tab-22"
+          aria-labelledby="arco-tabs-9-tab-22"
           class="arco-tabs-content-item"
-          id="arco-tabs-11-panel-22"
+          id="arco-tabs-9-panel-22"
           role="tabpanel"
           tabindex="-1"
         />
         <div
           aria-hidden="true"
-          aria-labelledby="arco-tabs-11-tab-23"
+          aria-labelledby="arco-tabs-9-tab-23"
           class="arco-tabs-content-item"
-          id="arco-tabs-11-panel-23"
+          id="arco-tabs-9-panel-23"
           role="tabpanel"
           tabindex="-1"
         />
         <div
           aria-hidden="true"
-          aria-labelledby="arco-tabs-11-tab-24"
+          aria-labelledby="arco-tabs-9-tab-24"
           class="arco-tabs-content-item"
-          id="arco-tabs-11-panel-24"
+          id="arco-tabs-9-panel-24"
           role="tabpanel"
           tabindex="-1"
         />
         <div
           aria-hidden="true"
-          aria-labelledby="arco-tabs-11-tab-25"
+          aria-labelledby="arco-tabs-9-tab-25"
           class="arco-tabs-content-item"
-          id="arco-tabs-11-panel-25"
+          id="arco-tabs-9-panel-25"
           role="tabpanel"
           tabindex="-1"
         />
         <div
           aria-hidden="true"
-          aria-labelledby="arco-tabs-11-tab-26"
+          aria-labelledby="arco-tabs-9-tab-26"
           class="arco-tabs-content-item"
-          id="arco-tabs-11-panel-26"
+          id="arco-tabs-9-panel-26"
           role="tabpanel"
           tabindex="-1"
         />
         <div
           aria-hidden="true"
-          aria-labelledby="arco-tabs-11-tab-27"
+          aria-labelledby="arco-tabs-9-tab-27"
           class="arco-tabs-content-item"
-          id="arco-tabs-11-panel-27"
+          id="arco-tabs-9-panel-27"
           role="tabpanel"
           tabindex="-1"
         />
         <div
           aria-hidden="true"
-          aria-labelledby="arco-tabs-11-tab-28"
+          aria-labelledby="arco-tabs-9-tab-28"
           class="arco-tabs-content-item"
-          id="arco-tabs-11-panel-28"
+          id="arco-tabs-9-panel-28"
           role="tabpanel"
           tabindex="-1"
         />
         <div
           aria-hidden="true"
-          aria-labelledby="arco-tabs-11-tab-29"
+          aria-labelledby="arco-tabs-9-tab-29"
           class="arco-tabs-content-item"
-          id="arco-tabs-11-panel-29"
+          id="arco-tabs-9-panel-29"
           role="tabpanel"
           tabindex="-1"
         />
@@ -3245,10 +3245,10 @@ exports[`renders Tabs/demo/size.md correctly 1`] = `
             style="transform:translateX(0px);-webkit-transform:translateX(0px);-ms-transform:translateX(0px);-moz-transform:translateX(0px);-o-transform:translateX(0px)"
           >
             <div
-              aria-controls="arco-tabs-12-panel-0"
+              aria-controls="arco-tabs-10-panel-0"
               aria-selected="true"
               class="arco-tabs-header-title arco-tabs-header-title-active"
-              id="arco-tabs-12-tab-0"
+              id="arco-tabs-10-tab-0"
               role="tab"
               tabindex="0"
             >
@@ -3259,11 +3259,11 @@ exports[`renders Tabs/demo/size.md correctly 1`] = `
               </span>
             </div>
             <div
-              aria-controls="arco-tabs-12-panel-1"
+              aria-controls="arco-tabs-10-panel-1"
               aria-disabled="true"
               aria-selected="false"
               class="arco-tabs-header-title arco-tabs-header-title-disabled"
-              id="arco-tabs-12-tab-1"
+              id="arco-tabs-10-tab-1"
               role="tab"
               tabindex="-1"
             >
@@ -3274,10 +3274,10 @@ exports[`renders Tabs/demo/size.md correctly 1`] = `
               </span>
             </div>
             <div
-              aria-controls="arco-tabs-12-panel-2"
+              aria-controls="arco-tabs-10-panel-2"
               aria-selected="false"
               class="arco-tabs-header-title"
-              id="arco-tabs-12-tab-2"
+              id="arco-tabs-10-tab-2"
               role="tab"
               tabindex="0"
             >
@@ -3288,10 +3288,10 @@ exports[`renders Tabs/demo/size.md correctly 1`] = `
               </span>
             </div>
             <div
-              aria-controls="arco-tabs-12-panel-3"
+              aria-controls="arco-tabs-10-panel-3"
               aria-selected="false"
               class="arco-tabs-header-title"
-              id="arco-tabs-12-tab-3"
+              id="arco-tabs-10-tab-3"
               role="tab"
               tabindex="0"
             >
@@ -3316,9 +3316,9 @@ exports[`renders Tabs/demo/size.md correctly 1`] = `
         style="margin-left:-0%"
       >
         <div
-          aria-labelledby="arco-tabs-12-tab-0"
+          aria-labelledby="arco-tabs-10-tab-0"
           class="arco-tabs-content-item arco-tabs-content-item-active"
-          id="arco-tabs-12-panel-0"
+          id="arco-tabs-10-panel-0"
           role="tabpanel"
           tabindex="0"
         >
@@ -3335,25 +3335,25 @@ exports[`renders Tabs/demo/size.md correctly 1`] = `
         </div>
         <div
           aria-hidden="true"
-          aria-labelledby="arco-tabs-12-tab-1"
+          aria-labelledby="arco-tabs-10-tab-1"
           class="arco-tabs-content-item"
-          id="arco-tabs-12-panel-1"
+          id="arco-tabs-10-panel-1"
           role="tabpanel"
           tabindex="-1"
         />
         <div
           aria-hidden="true"
-          aria-labelledby="arco-tabs-12-tab-2"
+          aria-labelledby="arco-tabs-10-tab-2"
           class="arco-tabs-content-item"
-          id="arco-tabs-12-panel-2"
+          id="arco-tabs-10-panel-2"
           role="tabpanel"
           tabindex="-1"
         />
         <div
           aria-hidden="true"
-          aria-labelledby="arco-tabs-12-tab-3"
+          aria-labelledby="arco-tabs-10-tab-3"
           class="arco-tabs-content-item"
-          id="arco-tabs-12-panel-3"
+          id="arco-tabs-10-panel-3"
           role="tabpanel"
           tabindex="-1"
         />
@@ -3514,10 +3514,10 @@ exports[`renders Tabs/demo/type.md correctly 1`] = `
             style="transform:translateX(0px);-webkit-transform:translateX(0px);-ms-transform:translateX(0px);-moz-transform:translateX(0px);-o-transform:translateX(0px)"
           >
             <div
-              aria-controls="arco-tabs-13-panel-0"
+              aria-controls="arco-tabs-11-panel-0"
               aria-selected="true"
               class="arco-tabs-header-title arco-tabs-header-title-active"
-              id="arco-tabs-13-tab-0"
+              id="arco-tabs-11-tab-0"
               role="tab"
               tabindex="0"
             >
@@ -3528,11 +3528,11 @@ exports[`renders Tabs/demo/type.md correctly 1`] = `
               </span>
             </div>
             <div
-              aria-controls="arco-tabs-13-panel-1"
+              aria-controls="arco-tabs-11-panel-1"
               aria-disabled="true"
               aria-selected="false"
               class="arco-tabs-header-title arco-tabs-header-title-disabled"
-              id="arco-tabs-13-tab-1"
+              id="arco-tabs-11-tab-1"
               role="tab"
               tabindex="-1"
             >
@@ -3543,10 +3543,10 @@ exports[`renders Tabs/demo/type.md correctly 1`] = `
               </span>
             </div>
             <div
-              aria-controls="arco-tabs-13-panel-2"
+              aria-controls="arco-tabs-11-panel-2"
               aria-selected="false"
               class="arco-tabs-header-title"
-              id="arco-tabs-13-tab-2"
+              id="arco-tabs-11-tab-2"
               role="tab"
               tabindex="0"
             >
@@ -3557,10 +3557,10 @@ exports[`renders Tabs/demo/type.md correctly 1`] = `
               </span>
             </div>
             <div
-              aria-controls="arco-tabs-13-panel-3"
+              aria-controls="arco-tabs-11-panel-3"
               aria-selected="false"
               class="arco-tabs-header-title"
-              id="arco-tabs-13-tab-3"
+              id="arco-tabs-11-tab-3"
               role="tab"
               tabindex="0"
             >
@@ -3585,9 +3585,9 @@ exports[`renders Tabs/demo/type.md correctly 1`] = `
         style="margin-left:-0%"
       >
         <div
-          aria-labelledby="arco-tabs-13-tab-0"
+          aria-labelledby="arco-tabs-11-tab-0"
           class="arco-tabs-content-item arco-tabs-content-item-active"
-          id="arco-tabs-13-panel-0"
+          id="arco-tabs-11-panel-0"
           role="tabpanel"
           tabindex="0"
         >
@@ -3604,25 +3604,25 @@ exports[`renders Tabs/demo/type.md correctly 1`] = `
         </div>
         <div
           aria-hidden="true"
-          aria-labelledby="arco-tabs-13-tab-1"
+          aria-labelledby="arco-tabs-11-tab-1"
           class="arco-tabs-content-item"
-          id="arco-tabs-13-panel-1"
+          id="arco-tabs-11-panel-1"
           role="tabpanel"
           tabindex="-1"
         />
         <div
           aria-hidden="true"
-          aria-labelledby="arco-tabs-13-tab-2"
+          aria-labelledby="arco-tabs-11-tab-2"
           class="arco-tabs-content-item"
-          id="arco-tabs-13-panel-2"
+          id="arco-tabs-11-panel-2"
           role="tabpanel"
           tabindex="-1"
         />
         <div
           aria-hidden="true"
-          aria-labelledby="arco-tabs-13-tab-3"
+          aria-labelledby="arco-tabs-11-tab-3"
           class="arco-tabs-content-item"
-          id="arco-tabs-13-panel-3"
+          id="arco-tabs-11-panel-3"
           role="tabpanel"
           tabindex="-1"
         />

--- a/components/Tag/__test__/__snapshots__/demo.test.ts.snap
+++ b/components/Tag/__test__/__snapshots__/demo.test.ts.snap
@@ -11,7 +11,11 @@ exports[`renders Tag/demo/active.md correctly 1`] = `
     <div
       class="arco-tag arco-tag-checked arco-tag-size-default"
     >
-      Tag 1
+      <span
+        class="arco-tag-content"
+      >
+        Tag 1
+      </span>
     </div>
   </div>
   <div
@@ -21,7 +25,11 @@ exports[`renders Tag/demo/active.md correctly 1`] = `
     <div
       class="arco-tag arco-tag-checked arco-tag-size-default"
     >
-      Tag 2
+      <span
+        class="arco-tag-content"
+      >
+        Tag 2
+      </span>
       <span
         aria-label="Close"
         class="arco-icon-hover arco-tag-icon-hover arco-tag-close-btn"
@@ -50,7 +58,11 @@ exports[`renders Tag/demo/active.md correctly 1`] = `
     <div
       class="arco-tag arco-tag-checked arco-tag-size-default"
     >
-      Tag 3
+      <span
+        class="arco-tag-content"
+      >
+        Tag 3
+      </span>
       <span
         aria-label="Close"
         class="arco-icon-hover arco-tag-icon-hover arco-tag-close-btn"
@@ -96,7 +108,11 @@ exports[`renders Tag/demo/active.md correctly 1`] = `
           />
         </svg>
       </span>
-      Add Tag
+      <span
+        class="arco-tag-content"
+      >
+        Add Tag
+      </span>
     </div>
   </div>
 </div>
@@ -113,7 +129,11 @@ exports[`renders Tag/demo/basic.md correctly 1`] = `
     <div
       class="arco-tag arco-tag-checked arco-tag-size-default"
     >
-      Default
+      <span
+        class="arco-tag-content"
+      >
+        Default
+      </span>
     </div>
   </div>
   <div
@@ -123,7 +143,11 @@ exports[`renders Tag/demo/basic.md correctly 1`] = `
     <div
       class="arco-tag arco-tag-checked arco-tag-size-default"
     >
-      Tag 1
+      <span
+        class="arco-tag-content"
+      >
+        Tag 1
+      </span>
     </div>
   </div>
   <div
@@ -133,7 +157,11 @@ exports[`renders Tag/demo/basic.md correctly 1`] = `
     <div
       class="arco-tag arco-tag-checked arco-tag-size-default"
     >
-      Tag 2
+      <span
+        class="arco-tag-content"
+      >
+        Tag 2
+      </span>
     </div>
   </div>
   <div
@@ -163,7 +191,11 @@ exports[`renders Tag/demo/basic.md correctly 1`] = `
           />
         </svg>
       </span>
-      Complete
+      <span
+        class="arco-tag-content"
+      >
+        Complete
+      </span>
     </div>
   </div>
 </div>
@@ -180,7 +212,11 @@ exports[`renders Tag/demo/bordered.md correctly 1`] = `
     <div
       class="arco-tag arco-tag-checked arco-tag-size-default arco-tag-bordered"
     >
-      Default
+      <span
+        class="arco-tag-content"
+      >
+        Default
+      </span>
     </div>
   </div>
   <div
@@ -190,7 +226,11 @@ exports[`renders Tag/demo/bordered.md correctly 1`] = `
     <div
       class="arco-tag arco-tag-red arco-tag-checked arco-tag-size-default arco-tag-bordered"
     >
-      red
+      <span
+        class="arco-tag-content"
+      >
+        red
+      </span>
     </div>
   </div>
   <div
@@ -200,7 +240,11 @@ exports[`renders Tag/demo/bordered.md correctly 1`] = `
     <div
       class="arco-tag arco-tag-orangered arco-tag-checked arco-tag-size-default arco-tag-bordered"
     >
-      orangered
+      <span
+        class="arco-tag-content"
+      >
+        orangered
+      </span>
     </div>
   </div>
   <div
@@ -210,7 +254,11 @@ exports[`renders Tag/demo/bordered.md correctly 1`] = `
     <div
       class="arco-tag arco-tag-orange arco-tag-checked arco-tag-size-default arco-tag-bordered"
     >
-      orange
+      <span
+        class="arco-tag-content"
+      >
+        orange
+      </span>
     </div>
   </div>
   <div
@@ -220,7 +268,11 @@ exports[`renders Tag/demo/bordered.md correctly 1`] = `
     <div
       class="arco-tag arco-tag-gold arco-tag-checked arco-tag-size-default arco-tag-bordered"
     >
-      gold
+      <span
+        class="arco-tag-content"
+      >
+        gold
+      </span>
     </div>
   </div>
   <div
@@ -230,7 +282,11 @@ exports[`renders Tag/demo/bordered.md correctly 1`] = `
     <div
       class="arco-tag arco-tag-lime arco-tag-checked arco-tag-size-default arco-tag-bordered"
     >
-      lime
+      <span
+        class="arco-tag-content"
+      >
+        lime
+      </span>
     </div>
   </div>
   <div
@@ -240,7 +296,11 @@ exports[`renders Tag/demo/bordered.md correctly 1`] = `
     <div
       class="arco-tag arco-tag-green arco-tag-checked arco-tag-size-default arco-tag-bordered"
     >
-      green
+      <span
+        class="arco-tag-content"
+      >
+        green
+      </span>
     </div>
   </div>
   <div
@@ -250,7 +310,11 @@ exports[`renders Tag/demo/bordered.md correctly 1`] = `
     <div
       class="arco-tag arco-tag-cyan arco-tag-checked arco-tag-size-default arco-tag-bordered"
     >
-      cyan
+      <span
+        class="arco-tag-content"
+      >
+        cyan
+      </span>
     </div>
   </div>
   <div
@@ -260,7 +324,11 @@ exports[`renders Tag/demo/bordered.md correctly 1`] = `
     <div
       class="arco-tag arco-tag-blue arco-tag-checked arco-tag-size-default arco-tag-bordered"
     >
-      blue
+      <span
+        class="arco-tag-content"
+      >
+        blue
+      </span>
     </div>
   </div>
   <div
@@ -270,7 +338,11 @@ exports[`renders Tag/demo/bordered.md correctly 1`] = `
     <div
       class="arco-tag arco-tag-arcoblue arco-tag-checked arco-tag-size-default arco-tag-bordered"
     >
-      arcoblue
+      <span
+        class="arco-tag-content"
+      >
+        arcoblue
+      </span>
     </div>
   </div>
   <div
@@ -280,7 +352,11 @@ exports[`renders Tag/demo/bordered.md correctly 1`] = `
     <div
       class="arco-tag arco-tag-purple arco-tag-checked arco-tag-size-default arco-tag-bordered"
     >
-      purple
+      <span
+        class="arco-tag-content"
+      >
+        purple
+      </span>
     </div>
   </div>
   <div
@@ -290,7 +366,11 @@ exports[`renders Tag/demo/bordered.md correctly 1`] = `
     <div
       class="arco-tag arco-tag-pinkpurple arco-tag-checked arco-tag-size-default arco-tag-bordered"
     >
-      pinkpurple
+      <span
+        class="arco-tag-content"
+      >
+        pinkpurple
+      </span>
     </div>
   </div>
   <div
@@ -300,7 +380,11 @@ exports[`renders Tag/demo/bordered.md correctly 1`] = `
     <div
       class="arco-tag arco-tag-magenta arco-tag-checked arco-tag-size-default arco-tag-bordered"
     >
-      magenta
+      <span
+        class="arco-tag-content"
+      >
+        magenta
+      </span>
     </div>
   </div>
   <div
@@ -310,7 +394,11 @@ exports[`renders Tag/demo/bordered.md correctly 1`] = `
     <div
       class="arco-tag arco-tag-gray arco-tag-checked arco-tag-size-default arco-tag-bordered"
     >
-      gray
+      <span
+        class="arco-tag-content"
+      >
+        gray
+      </span>
     </div>
   </div>
 </div>
@@ -327,7 +415,11 @@ exports[`renders Tag/demo/check.md correctly 1`] = `
     <div
       class="arco-tag arco-tag-checkable arco-tag-size-default"
     >
-      Awesome
+      <span
+        class="arco-tag-content"
+      >
+        Awesome
+      </span>
     </div>
   </div>
   <div
@@ -337,7 +429,11 @@ exports[`renders Tag/demo/check.md correctly 1`] = `
     <div
       class="arco-tag arco-tag-red arco-tag-checkable arco-tag-checked arco-tag-size-default"
     >
-      Toutiao
+      <span
+        class="arco-tag-content"
+      >
+        Toutiao
+      </span>
     </div>
   </div>
   <div
@@ -346,7 +442,11 @@ exports[`renders Tag/demo/check.md correctly 1`] = `
     <div
       class="arco-tag arco-tag-arcoblue arco-tag-checkable arco-tag-checked arco-tag-size-default"
     >
-      Lark
+      <span
+        class="arco-tag-content"
+      >
+        Lark
+      </span>
     </div>
   </div>
 </div>
@@ -358,7 +458,11 @@ exports[`renders Tag/demo/close.md correctly 1`] = `
     class="arco-tag arco-tag-checked arco-tag-size-default"
     style="margin:0 24px"
   >
-    Tag
+    <span
+      class="arco-tag-content"
+    >
+      Tag
+    </span>
     <span
       aria-label="Close"
       class="arco-icon-hover arco-tag-icon-hover arco-tag-close-btn"
@@ -399,7 +503,11 @@ exports[`renders Tag/demo/close.md correctly 1`] = `
         />
       </svg>
     </span>
-    Tag
+    <span
+      class="arco-tag-content"
+    >
+      Tag
+    </span>
     <span
       aria-label="Close"
       class="arco-icon-hover arco-tag-icon-hover arco-tag-close-btn"
@@ -447,7 +555,11 @@ exports[`renders Tag/demo/close-async.md correctly 1`] = `
 <div
   class="arco-tag arco-tag-checked arco-tag-size-default"
 >
-  Tag 1
+  <span
+    class="arco-tag-content"
+  >
+    Tag 1
+  </span>
   <span
     aria-label="Close"
     class="arco-icon-hover arco-tag-icon-hover arco-tag-close-btn"
@@ -476,7 +588,11 @@ exports[`renders Tag/demo/color.md correctly 1`] = `
     class="arco-tag arco-tag-red arco-tag-checked arco-tag-size-default"
     style="margin:0 16px 16px 0"
   >
-    red
+    <span
+      class="arco-tag-content"
+    >
+      red
+    </span>
     <span
       aria-label="Close"
       class="arco-icon-hover arco-tag-icon-hover arco-tag-close-btn"
@@ -501,7 +617,11 @@ exports[`renders Tag/demo/color.md correctly 1`] = `
     class="arco-tag arco-tag-orangered arco-tag-checked arco-tag-size-default"
     style="margin:0 16px 16px 0"
   >
-    orangered
+    <span
+      class="arco-tag-content"
+    >
+      orangered
+    </span>
     <span
       aria-label="Close"
       class="arco-icon-hover arco-tag-icon-hover arco-tag-close-btn"
@@ -526,7 +646,11 @@ exports[`renders Tag/demo/color.md correctly 1`] = `
     class="arco-tag arco-tag-orange arco-tag-checked arco-tag-size-default"
     style="margin:0 16px 16px 0"
   >
-    orange
+    <span
+      class="arco-tag-content"
+    >
+      orange
+    </span>
     <span
       aria-label="Close"
       class="arco-icon-hover arco-tag-icon-hover arco-tag-close-btn"
@@ -551,7 +675,11 @@ exports[`renders Tag/demo/color.md correctly 1`] = `
     class="arco-tag arco-tag-gold arco-tag-checked arco-tag-size-default"
     style="margin:0 16px 16px 0"
   >
-    gold
+    <span
+      class="arco-tag-content"
+    >
+      gold
+    </span>
     <span
       aria-label="Close"
       class="arco-icon-hover arco-tag-icon-hover arco-tag-close-btn"
@@ -576,7 +704,11 @@ exports[`renders Tag/demo/color.md correctly 1`] = `
     class="arco-tag arco-tag-lime arco-tag-checked arco-tag-size-default"
     style="margin:0 16px 16px 0"
   >
-    lime
+    <span
+      class="arco-tag-content"
+    >
+      lime
+    </span>
     <span
       aria-label="Close"
       class="arco-icon-hover arco-tag-icon-hover arco-tag-close-btn"
@@ -601,7 +733,11 @@ exports[`renders Tag/demo/color.md correctly 1`] = `
     class="arco-tag arco-tag-green arco-tag-checked arco-tag-size-default"
     style="margin:0 16px 16px 0"
   >
-    green
+    <span
+      class="arco-tag-content"
+    >
+      green
+    </span>
     <span
       aria-label="Close"
       class="arco-icon-hover arco-tag-icon-hover arco-tag-close-btn"
@@ -626,7 +762,11 @@ exports[`renders Tag/demo/color.md correctly 1`] = `
     class="arco-tag arco-tag-cyan arco-tag-checked arco-tag-size-default"
     style="margin:0 16px 16px 0"
   >
-    cyan
+    <span
+      class="arco-tag-content"
+    >
+      cyan
+    </span>
     <span
       aria-label="Close"
       class="arco-icon-hover arco-tag-icon-hover arco-tag-close-btn"
@@ -651,7 +791,11 @@ exports[`renders Tag/demo/color.md correctly 1`] = `
     class="arco-tag arco-tag-blue arco-tag-checked arco-tag-size-default"
     style="margin:0 16px 16px 0"
   >
-    blue
+    <span
+      class="arco-tag-content"
+    >
+      blue
+    </span>
     <span
       aria-label="Close"
       class="arco-icon-hover arco-tag-icon-hover arco-tag-close-btn"
@@ -676,7 +820,11 @@ exports[`renders Tag/demo/color.md correctly 1`] = `
     class="arco-tag arco-tag-arcoblue arco-tag-checked arco-tag-size-default"
     style="margin:0 16px 16px 0"
   >
-    arcoblue
+    <span
+      class="arco-tag-content"
+    >
+      arcoblue
+    </span>
     <span
       aria-label="Close"
       class="arco-icon-hover arco-tag-icon-hover arco-tag-close-btn"
@@ -701,7 +849,11 @@ exports[`renders Tag/demo/color.md correctly 1`] = `
     class="arco-tag arco-tag-purple arco-tag-checked arco-tag-size-default"
     style="margin:0 16px 16px 0"
   >
-    purple
+    <span
+      class="arco-tag-content"
+    >
+      purple
+    </span>
     <span
       aria-label="Close"
       class="arco-icon-hover arco-tag-icon-hover arco-tag-close-btn"
@@ -726,7 +878,11 @@ exports[`renders Tag/demo/color.md correctly 1`] = `
     class="arco-tag arco-tag-pinkpurple arco-tag-checked arco-tag-size-default"
     style="margin:0 16px 16px 0"
   >
-    pinkpurple
+    <span
+      class="arco-tag-content"
+    >
+      pinkpurple
+    </span>
     <span
       aria-label="Close"
       class="arco-icon-hover arco-tag-icon-hover arco-tag-close-btn"
@@ -751,7 +907,11 @@ exports[`renders Tag/demo/color.md correctly 1`] = `
     class="arco-tag arco-tag-magenta arco-tag-checked arco-tag-size-default"
     style="margin:0 16px 16px 0"
   >
-    magenta
+    <span
+      class="arco-tag-content"
+    >
+      magenta
+    </span>
     <span
       aria-label="Close"
       class="arco-icon-hover arco-tag-icon-hover arco-tag-close-btn"
@@ -776,7 +936,11 @@ exports[`renders Tag/demo/color.md correctly 1`] = `
     class="arco-tag arco-tag-gray arco-tag-checked arco-tag-size-default"
     style="margin:0 16px 16px 0"
   >
-    gray
+    <span
+      class="arco-tag-content"
+    >
+      gray
+    </span>
     <span
       aria-label="Close"
       class="arco-icon-hover arco-tag-icon-hover arco-tag-close-btn"
@@ -806,7 +970,11 @@ exports[`renders Tag/demo/color.md correctly 1`] = `
     class="arco-tag arco-tag-checked arco-tag-size-default arco-tag-custom-color"
     style="margin:0 16px 16px 0;background-color:#f53f3f;border-color:#f53f3f"
   >
-    #f53f3f
+    <span
+      class="arco-tag-content"
+    >
+      #f53f3f
+    </span>
     <span
       aria-label="Close"
       class="arco-icon-hover arco-tag-icon-hover arco-tag-close-btn"
@@ -831,7 +999,11 @@ exports[`renders Tag/demo/color.md correctly 1`] = `
     class="arco-tag arco-tag-checked arco-tag-size-default arco-tag-custom-color"
     style="margin:0 16px 16px 0;background-color:#7816ff;border-color:#7816ff"
   >
-    #7816ff
+    <span
+      class="arco-tag-content"
+    >
+      #7816ff
+    </span>
     <span
       aria-label="Close"
       class="arco-icon-hover arco-tag-icon-hover arco-tag-close-btn"
@@ -856,7 +1028,11 @@ exports[`renders Tag/demo/color.md correctly 1`] = `
     class="arco-tag arco-tag-checked arco-tag-size-default arco-tag-custom-color"
     style="margin:0 16px 16px 0;background-color:#00b42a;border-color:#00b42a"
   >
-    #00b42a
+    <span
+      class="arco-tag-content"
+    >
+      #00b42a
+    </span>
     <span
       aria-label="Close"
       class="arco-icon-hover arco-tag-icon-hover arco-tag-close-btn"
@@ -881,7 +1057,11 @@ exports[`renders Tag/demo/color.md correctly 1`] = `
     class="arco-tag arco-tag-checked arco-tag-size-default arco-tag-custom-color"
     style="margin:0 16px 16px 0;background-color:#165dff;border-color:#165dff"
   >
-    #165dff
+    <span
+      class="arco-tag-content"
+    >
+      #165dff
+    </span>
     <span
       aria-label="Close"
       class="arco-icon-hover arco-tag-icon-hover arco-tag-close-btn"
@@ -906,7 +1086,11 @@ exports[`renders Tag/demo/color.md correctly 1`] = `
     class="arco-tag arco-tag-checked arco-tag-size-default arco-tag-custom-color"
     style="margin:0 16px 16px 0;background-color:#ff7d00;border-color:#ff7d00"
   >
-    #ff7d00
+    <span
+      class="arco-tag-content"
+    >
+      #ff7d00
+    </span>
     <span
       aria-label="Close"
       class="arco-icon-hover arco-tag-icon-hover arco-tag-close-btn"
@@ -931,7 +1115,11 @@ exports[`renders Tag/demo/color.md correctly 1`] = `
     class="arco-tag arco-tag-checked arco-tag-size-default arco-tag-custom-color"
     style="margin:0 16px 16px 0;background-color:#eb0aa4;border-color:#eb0aa4"
   >
-    #eb0aa4
+    <span
+      class="arco-tag-content"
+    >
+      #eb0aa4
+    </span>
     <span
       aria-label="Close"
       class="arco-icon-hover arco-tag-icon-hover arco-tag-close-btn"
@@ -956,7 +1144,11 @@ exports[`renders Tag/demo/color.md correctly 1`] = `
     class="arco-tag arco-tag-checked arco-tag-size-default arco-tag-custom-color"
     style="margin:0 16px 16px 0;background-color:#7bc616;border-color:#7bc616"
   >
-    #7bc616
+    <span
+      class="arco-tag-content"
+    >
+      #7bc616
+    </span>
     <span
       aria-label="Close"
       class="arco-icon-hover arco-tag-icon-hover arco-tag-close-btn"
@@ -981,7 +1173,11 @@ exports[`renders Tag/demo/color.md correctly 1`] = `
     class="arco-tag arco-tag-checked arco-tag-size-default arco-tag-custom-color"
     style="margin:0 16px 16px 0;background-color:#86909c;border-color:#86909c"
   >
-    #86909c
+    <span
+      class="arco-tag-content"
+    >
+      #86909c
+    </span>
     <span
       aria-label="Close"
       class="arco-icon-hover arco-tag-icon-hover arco-tag-close-btn"
@@ -1006,7 +1202,11 @@ exports[`renders Tag/demo/color.md correctly 1`] = `
     class="arco-tag arco-tag-checked arco-tag-size-default arco-tag-custom-color"
     style="margin:0 16px 16px 0;background-color:#b71de8;border-color:#b71de8"
   >
-    #b71de8
+    <span
+      class="arco-tag-content"
+    >
+      #b71de8
+    </span>
     <span
       aria-label="Close"
       class="arco-icon-hover arco-tag-icon-hover arco-tag-close-btn"
@@ -1031,7 +1231,11 @@ exports[`renders Tag/demo/color.md correctly 1`] = `
     class="arco-tag arco-tag-checked arco-tag-size-default arco-tag-custom-color"
     style="margin:0 16px 16px 0;background-color:#0fc6c2;border-color:#0fc6c2"
   >
-    #0fc6c2
+    <span
+      class="arco-tag-content"
+    >
+      #0fc6c2
+    </span>
     <span
       aria-label="Close"
       class="arco-icon-hover arco-tag-icon-hover arco-tag-close-btn"
@@ -1056,7 +1260,11 @@ exports[`renders Tag/demo/color.md correctly 1`] = `
     class="arco-tag arco-tag-checked arco-tag-size-default arco-tag-custom-color"
     style="margin:0 16px 16px 0;background-color:#ffb400;border-color:#ffb400"
   >
-    #ffb400
+    <span
+      class="arco-tag-content"
+    >
+      #ffb400
+    </span>
     <span
       aria-label="Close"
       class="arco-icon-hover arco-tag-icon-hover arco-tag-close-btn"
@@ -1081,7 +1289,11 @@ exports[`renders Tag/demo/color.md correctly 1`] = `
     class="arco-tag arco-tag-checked arco-tag-size-default arco-tag-custom-color"
     style="margin:0 16px 16px 0;background-color:#168cff;border-color:#168cff"
   >
-    #168cff
+    <span
+      class="arco-tag-content"
+    >
+      #168cff
+    </span>
     <span
       aria-label="Close"
       class="arco-icon-hover arco-tag-icon-hover arco-tag-close-btn"
@@ -1106,7 +1318,11 @@ exports[`renders Tag/demo/color.md correctly 1`] = `
     class="arco-tag arco-tag-checked arco-tag-size-default arco-tag-custom-color"
     style="margin:0 16px 16px 0;background-color:#ff5722;border-color:#ff5722"
   >
-    #ff5722
+    <span
+      class="arco-tag-content"
+    >
+      #ff5722
+    </span>
     <span
       aria-label="Close"
       class="arco-icon-hover arco-tag-icon-hover arco-tag-close-btn"
@@ -1160,7 +1376,11 @@ exports[`renders Tag/demo/icon.md correctly 1`] = `
           />
         </svg>
       </span>
-      Github
+      <span
+        class="arco-tag-content"
+      >
+        Github
+      </span>
     </div>
   </div>
   <div
@@ -1189,7 +1409,11 @@ exports[`renders Tag/demo/icon.md correctly 1`] = `
           />
         </svg>
       </span>
-      Gitlab
+      <span
+        class="arco-tag-content"
+      >
+        Gitlab
+      </span>
     </div>
   </div>
   <div
@@ -1218,7 +1442,11 @@ exports[`renders Tag/demo/icon.md correctly 1`] = `
           />
         </svg>
       </span>
-      Twitter
+      <span
+        class="arco-tag-content"
+      >
+        Twitter
+      </span>
     </div>
   </div>
   <div
@@ -1246,7 +1474,11 @@ exports[`renders Tag/demo/icon.md correctly 1`] = `
           />
         </svg>
       </span>
-      Facebook
+      <span
+        class="arco-tag-content"
+      >
+        Facebook
+      </span>
     </div>
   </div>
 </div>
@@ -1263,7 +1495,11 @@ exports[`renders Tag/demo/size.md correctly 1`] = `
     <div
       class="arco-tag arco-tag-checked arco-tag-size-large"
     >
-      Large
+      <span
+        class="arco-tag-content"
+      >
+        Large
+      </span>
       <span
         aria-label="Close"
         class="arco-icon-hover arco-tag-icon-hover arco-tag-close-btn"
@@ -1292,7 +1528,11 @@ exports[`renders Tag/demo/size.md correctly 1`] = `
     <div
       class="arco-tag arco-tag-checked arco-tag-size-medium"
     >
-      Medium
+      <span
+        class="arco-tag-content"
+      >
+        Medium
+      </span>
       <span
         aria-label="Close"
         class="arco-icon-hover arco-tag-icon-hover arco-tag-close-btn"
@@ -1321,7 +1561,11 @@ exports[`renders Tag/demo/size.md correctly 1`] = `
     <div
       class="arco-tag arco-tag-checked arco-tag-size-default"
     >
-      default
+      <span
+        class="arco-tag-content"
+      >
+        default
+      </span>
       <span
         aria-label="Close"
         class="arco-icon-hover arco-tag-icon-hover arco-tag-close-btn"
@@ -1349,7 +1593,11 @@ exports[`renders Tag/demo/size.md correctly 1`] = `
     <div
       class="arco-tag arco-tag-checked arco-tag-size-small"
     >
-      small
+      <span
+        class="arco-tag-content"
+      >
+        small
+      </span>
       <span
         aria-label="Close"
         class="arco-icon-hover arco-tag-icon-hover arco-tag-close-btn"

--- a/components/Tag/__test__/__snapshots__/index.test.tsx.snap
+++ b/components/Tag/__test__/__snapshots__/index.test.tsx.snap
@@ -3,24 +3,40 @@
 exports[`ConfigProvider componentConfig.Tag default 1`] = `
 <div
   class="arco-tag arco-tag-checked arco-tag-size-default"
-/>
+>
+  <span
+    class="arco-tag-content"
+  />
+</div>
 `;
 
 exports[`ConfigProvider componentConfig.Tag set className globally 1`] = `
 <div
   class="arco-tag arco-tag-checked arco-tag-size-default global-default-class"
-/>
+>
+  <span
+    class="arco-tag-content"
+  />
+</div>
 `;
 
 exports[`ConfigProvider componentConfig.Tag set className globally and component set className itself. 1`] = `
 <div
   class="arco-tag arco-tag-checked arco-tag-size-default component-class"
-/>
+>
+  <span
+    class="arco-tag-content"
+  />
+</div>
 `;
 
 exports[`ConfigProvider componentConfig.Tag set data-* property 1`] = `
 <div
   class="arco-tag arco-tag-checked arco-tag-size-default"
   data-test-name="Tag"
-/>
+>
+  <span
+    class="arco-tag-content"
+  />
+</div>
 `;

--- a/components/Tag/index.tsx
+++ b/components/Tag/index.tsx
@@ -123,7 +123,7 @@ function Tag(baseProps: TagProps, ref) {
   return (
     <div ref={ref} style={colorStyle} className={classNames} {...otherProps}>
       {icon && <span className={`${prefixCls}-icon`}>{icon}</span>}
-      {children}
+      <span className={`${prefixCls}-content`}>{children}</span>
       {closable && !loading && closeIcon !== null && (
         <IconHover
           prefix={prefixCls}

--- a/components/Tag/style/index.less
+++ b/components/Tag/style/index.less
@@ -8,25 +8,28 @@
 
 .@{tag-prefix-cls} {
   display: inline-flex;
-  height: @tag-size-default;
-  line-height: @tag-size-default - @tag-border-width * 2 - @tag-padding-vertical * 2;
-  padding: @tag-padding-vertical @tag-padding-horizontal;
-  border-radius: @tag-border-radius;
-  color: @tag-default-color-text;
-  font-size: @tag-size-default-font-size;
-  border: @tag-border-width @tag-border-type transparent;
-  box-sizing: border-box;
-  font-weight: @tag-text-font-weight;
-  vertical-align: middle;
   align-items: center;
-  .text-ellipsis();
+  box-sizing: border-box;
+  height: @tag-size-default;
+  padding: @tag-padding-vertical @tag-padding-horizontal;
+  border: @tag-border-width @tag-border-type transparent;
+  border-radius: @tag-border-radius;
+  font-size: @tag-size-default-font-size;
+  font-weight: @tag-text-font-weight;
+  line-height: @tag-size-default - @tag-border-width * 2 - @tag-padding-vertical * 2;
+  color: @tag-default-color-text;
 
   .icon-hover(
     @tag-prefix-cls,
     12px,
-    16px,
+    16px
   );
   .icon-hover-bg(@tag-prefix-cls, @tag-default-color-bg_hover);
+
+  &-content {
+    flex: 1;
+    .text-ellipsis();
+  }
 
   &-checkable {
     cursor: pointer;

--- a/components/TreeSelect/__test__/__snapshots__/demo.test.ts.snap
+++ b/components/TreeSelect/__test__/__snapshots__/demo.test.ts.snap
@@ -136,10 +136,10 @@ exports[`renders TreeSelect/demo/checkable.md correctly 1`] = `
           >
             <div
               class="arco-tag arco-tag-checked arco-tag-size-default arco-input-tag-tag arco-tree-select-tag"
+              title="Leaf 0-1-2"
             >
               <span
-                class="arco-input-tag-tag-content"
-                title="Leaf 0-1-2"
+                class="arco-tag-content"
               >
                 Leaf 0-1-2
               </span>
@@ -295,10 +295,10 @@ exports[`renders TreeSelect/demo/checkedStrategy.md correctly 1`] = `
           >
             <div
               class="arco-tag arco-tag-checked arco-tag-size-default arco-input-tag-tag arco-tree-select-tag"
+              title="Leaf 0-0-1"
             >
               <span
-                class="arco-input-tag-tag-content"
-                title="Leaf 0-0-1"
+                class="arco-tag-content"
               >
                 Leaf 0-0-1
               </span>
@@ -324,10 +324,10 @@ exports[`renders TreeSelect/demo/checkedStrategy.md correctly 1`] = `
             </div>
             <div
               class="arco-tag arco-tag-checked arco-tag-size-default arco-input-tag-tag arco-tree-select-tag"
+              title="Leaf 0-0-2-1"
             >
               <span
-                class="arco-input-tag-tag-content"
-                title="Leaf 0-0-2-1"
+                class="arco-tag-content"
               >
                 Leaf 0-0-2-1
               </span>

--- a/components/Trigger/__test__/__snapshots__/demo.test.ts.snap
+++ b/components/Trigger/__test__/__snapshots__/demo.test.ts.snap
@@ -36,10 +36,10 @@ exports[`renders Trigger/demo/alignPoint.md correctly 1`] = `
             >
               <div
                 class="arco-tag arco-tag-checked arco-tag-size-default arco-input-tag-tag arco-select-tag"
+                title="click"
               >
                 <span
-                  class="arco-input-tag-tag-content"
-                  title="click"
+                  class="arco-tag-content"
                 >
                   click
                 </span>


### PR DESCRIPTION

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context

在给 `Tag` 设定了宽度之后，文字省略会失效。

![image](https://user-images.githubusercontent.com/29861850/184300862-2b03f0d1-168a-4cc2-a0fa-39ad8d00b8f6.png)

问题原因 [参考](https://css-tricks.com/flexbox-truncated-text/) 。

## Solution

有两种解决思路：

* 使用 `span` 对用户传入的内容进行包裹，各种情况表现如下：

![image](https://user-images.githubusercontent.com/29861850/184300598-430233e7-b482-4e57-b1ba-552960857591.png)

* 不修改 DOM 结构，使用 `display: inline-block`，但在带有图标的情况下，图标会被挤出可视区域。

![image](https://user-images.githubusercontent.com/29861850/184301320-54391ad2-afe4-4e12-94a2-b01d20fc15cc.png)

综合来看，第一种方案的效果最好，但会增加一层 DOM 结构。

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|  Tag  |  修复 `Tag` 组件文本内容超出后未显示省略号的 bug。 |  Fix the bug that the ellipsis is not displayed after the `Tag` component text content exceeds.    |   Close #1262  |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->
## Checklist:

- [x] Test suite passes (`npm run test`)
- [x] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [x] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)
