### PR TITLE
fix: TreeSelect在设置 retainInputValueWhileSelect 为 false 的时候无条件重新渲染树

### DIFF
--- a/components/TreeSelect/tree-select.tsx
+++ b/components/TreeSelect/tree-select.tsx
@@ -154,8 +154,12 @@ const TreeSelect: ForwardRefRenderFunction<
     if (isObject(props.showSearch)) {
       retainInputValueWhileSelect = props.showSearch.retainInputValueWhileSelect !== false;
     }
-
-    if (props.multiple && !retainInputValueWhileSelect) {
+    if (
+      props.multiple &&
+      !retainInputValueWhileSelect &&
+      refOnInputChangeCallbackValue.current !== '' &&
+      refOnInputChangeCallbackValue.current !== undefined
+    ) {
       tryUpdateInputValue('', 'optionChecked');
       handleSearch('');
     }


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context

<!-- Explain what problem does the PR solve -->
在TreeSelect在设置showSearch={{ retainInputValueWhileSelect: false }}和multiple并且不输入任何内容的情况下打开下拉框，选择任意选项都会稳定触发重新搜索树。
<!-- Link to related open issues if applicable -->
#1271 
## Solution
限制resetInputValue的触发条件，防止在没有值（undefined | ''）的情况下触发无必要的重新搜索。
<!-- Describe how the problem is fixed in detail -->

## How is the change tested?
原有用例测试、自测
<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|       TreeSelect    |         修复TreeSelect在设置retainInputValueWhileSelect 为 false 的时候无条件重新渲染树      |       Fix TreeSelect unconditionally re-renders the tree when setting retainInputValueWhileSelect to false        |       Close: #1271          |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->
## Checklist:

- [x] Test suite passes (`npm run test`)
- [x] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [x] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
