### PR TITLE
style: Select use the same ArrowIcon in both single/multiple mode

### DIFF
--- a/components/Cascader/__test__/__snapshots__/demo.test.ts.snap
+++ b/components/Cascader/__test__/__snapshots__/demo.test.ts.snap
@@ -154,20 +154,19 @@ exports[`renders Cascader/demo/change_on_select.md correctly 1`] = `
           class="arco-cascader-suffix"
         >
           <div
-            class="arco-cascader-expand-icon"
+            class="arco-cascader-arrow-icon"
           >
             <svg
               aria-hidden="true"
-              class="arco-icon arco-icon-expand"
+              class="arco-icon arco-icon-down"
               fill="none"
               focusable="false"
               stroke="currentColor"
               stroke-width="4"
-              style="transform:rotate(-45deg)"
               viewBox="0 0 48 48"
             >
               <path
-                d="M7 26v14c0 .552.444 1 .996 1H22m19-19V8c0-.552-.444-1-.996-1H26"
+                d="M39.6 17.443 24.043 33 8.487 17.443"
               />
             </svg>
           </div>
@@ -220,20 +219,19 @@ exports[`renders Cascader/demo/change_on_select.md correctly 1`] = `
           class="arco-cascader-suffix"
         >
           <div
-            class="arco-cascader-expand-icon"
+            class="arco-cascader-arrow-icon"
           >
             <svg
               aria-hidden="true"
-              class="arco-icon arco-icon-expand"
+              class="arco-icon arco-icon-down"
               fill="none"
               focusable="false"
               stroke="currentColor"
               stroke-width="4"
-              style="transform:rotate(-45deg)"
               viewBox="0 0 48 48"
             >
               <path
-                d="M7 26v14c0 .552.444 1 .996 1H22m19-19V8c0-.552-.444-1-.996-1H26"
+                d="M39.6 17.443 24.043 33 8.487 17.443"
               />
             </svg>
           </div>
@@ -354,20 +352,19 @@ exports[`renders Cascader/demo/control.md correctly 1`] = `
           class="arco-cascader-suffix"
         >
           <div
-            class="arco-cascader-expand-icon"
+            class="arco-cascader-arrow-icon"
           >
             <svg
               aria-hidden="true"
-              class="arco-icon arco-icon-expand"
+              class="arco-icon arco-icon-down"
               fill="none"
               focusable="false"
               stroke="currentColor"
               stroke-width="4"
-              style="transform:rotate(-45deg)"
               viewBox="0 0 48 48"
             >
               <path
-                d="M7 26v14c0 .552.444 1 .996 1H22m19-19V8c0-.552-.444-1-.996-1H26"
+                d="M39.6 17.443 24.043 33 8.487 17.443"
               />
             </svg>
           </div>
@@ -420,20 +417,19 @@ exports[`renders Cascader/demo/control.md correctly 1`] = `
           class="arco-cascader-suffix"
         >
           <div
-            class="arco-cascader-expand-icon"
+            class="arco-cascader-arrow-icon"
           >
             <svg
               aria-hidden="true"
-              class="arco-icon arco-icon-expand"
+              class="arco-icon arco-icon-down"
               fill="none"
               focusable="false"
               stroke="currentColor"
               stroke-width="4"
-              style="transform:rotate(-45deg)"
               viewBox="0 0 48 48"
             >
               <path
-                d="M7 26v14c0 .552.444 1 .996 1H22m19-19V8c0-.552-.444-1-.996-1H26"
+                d="M39.6 17.443 24.043 33 8.487 17.443"
               />
             </svg>
           </div>
@@ -516,20 +512,19 @@ exports[`renders Cascader/demo/disabled.md correctly 1`] = `
             </svg>
           </span>
           <div
-            class="arco-cascader-expand-icon"
+            class="arco-cascader-arrow-icon"
           >
             <svg
               aria-hidden="true"
-              class="arco-icon arco-icon-expand"
+              class="arco-icon arco-icon-down"
               fill="none"
               focusable="false"
               stroke="currentColor"
               stroke-width="4"
-              style="transform:rotate(-45deg)"
               viewBox="0 0 48 48"
             >
               <path
-                d="M7 26v14c0 .552.444 1 .996 1H22m19-19V8c0-.552-.444-1-.996-1H26"
+                d="M39.6 17.443 24.043 33 8.487 17.443"
               />
             </svg>
           </div>
@@ -617,20 +612,19 @@ exports[`renders Cascader/demo/disabled.md correctly 1`] = `
             </svg>
           </span>
           <div
-            class="arco-cascader-expand-icon"
+            class="arco-cascader-arrow-icon"
           >
             <svg
               aria-hidden="true"
-              class="arco-icon arco-icon-expand"
+              class="arco-icon arco-icon-down"
               fill="none"
               focusable="false"
               stroke="currentColor"
               stroke-width="4"
-              style="transform:rotate(-45deg)"
               viewBox="0 0 48 48"
             >
               <path
-                d="M7 26v14c0 .552.444 1 .996 1H22m19-19V8c0-.552-.444-1-.996-1H26"
+                d="M39.6 17.443 24.043 33 8.487 17.443"
               />
             </svg>
           </div>
@@ -745,20 +739,19 @@ exports[`renders Cascader/demo/draggable.md correctly 1`] = `
         </svg>
       </span>
       <div
-        class="arco-cascader-expand-icon"
+        class="arco-cascader-arrow-icon"
       >
         <svg
           aria-hidden="true"
-          class="arco-icon arco-icon-expand"
+          class="arco-icon arco-icon-down"
           fill="none"
           focusable="false"
           stroke="currentColor"
           stroke-width="4"
-          style="transform:rotate(-45deg)"
           viewBox="0 0 48 48"
         >
           <path
-            d="M7 26v14c0 .552.444 1 .996 1H22m19-19V8c0-.552-.444-1-.996-1H26"
+            d="M39.6 17.443 24.043 33 8.487 17.443"
           />
         </svg>
       </div>
@@ -971,20 +964,19 @@ exports[`renders Cascader/demo/filedNames.md correctly 1`] = `
           </svg>
         </span>
         <div
-          class="arco-cascader-expand-icon"
+          class="arco-cascader-arrow-icon"
         >
           <svg
             aria-hidden="true"
-            class="arco-icon arco-icon-expand"
+            class="arco-icon arco-icon-down"
             fill="none"
             focusable="false"
             stroke="currentColor"
             stroke-width="4"
-            style="transform:rotate(-45deg)"
             viewBox="0 0 48 48"
           >
             <path
-              d="M7 26v14c0 .552.444 1 .996 1H22m19-19V8c0-.552-.444-1-.996-1H26"
+              d="M39.6 17.443 24.043 33 8.487 17.443"
             />
           </svg>
         </div>
@@ -1051,20 +1043,19 @@ exports[`renders Cascader/demo/filter_option.md correctly 1`] = `
             </svg>
           </span>
           <div
-            class="arco-cascader-expand-icon"
+            class="arco-cascader-arrow-icon"
           >
             <svg
               aria-hidden="true"
-              class="arco-icon arco-icon-expand"
+              class="arco-icon arco-icon-down"
               fill="none"
               focusable="false"
               stroke="currentColor"
               stroke-width="4"
-              style="transform:rotate(-45deg)"
               viewBox="0 0 48 48"
             >
               <path
-                d="M7 26v14c0 .552.444 1 .996 1H22m19-19V8c0-.552-.444-1-.996-1H26"
+                d="M39.6 17.443 24.043 33 8.487 17.443"
               />
             </svg>
           </div>
@@ -1162,20 +1153,19 @@ exports[`renders Cascader/demo/filter_option.md correctly 1`] = `
             </svg>
           </span>
           <div
-            class="arco-cascader-expand-icon"
+            class="arco-cascader-arrow-icon"
           >
             <svg
               aria-hidden="true"
-              class="arco-icon arco-icon-expand"
+              class="arco-icon arco-icon-down"
               fill="none"
               focusable="false"
               stroke="currentColor"
               stroke-width="4"
-              style="transform:rotate(-45deg)"
               viewBox="0 0 48 48"
             >
               <path
-                d="M7 26v14c0 .552.444 1 .996 1H22m19-19V8c0-.552-.444-1-.996-1H26"
+                d="M39.6 17.443 24.043 33 8.487 17.443"
               />
             </svg>
           </div>
@@ -1243,20 +1233,19 @@ exports[`renders Cascader/demo/footer.md correctly 1`] = `
             </svg>
           </span>
           <div
-            class="arco-cascader-expand-icon"
+            class="arco-cascader-arrow-icon"
           >
             <svg
               aria-hidden="true"
-              class="arco-icon arco-icon-expand"
+              class="arco-icon arco-icon-down"
               fill="none"
               focusable="false"
               stroke="currentColor"
               stroke-width="4"
-              style="transform:rotate(-45deg)"
               viewBox="0 0 48 48"
             >
               <path
-                d="M7 26v14c0 .552.444 1 .996 1H22m19-19V8c0-.552-.444-1-.996-1H26"
+                d="M39.6 17.443 24.043 33 8.487 17.443"
               />
             </svg>
           </div>
@@ -1354,20 +1343,19 @@ exports[`renders Cascader/demo/footer.md correctly 1`] = `
             </svg>
           </span>
           <div
-            class="arco-cascader-expand-icon"
+            class="arco-cascader-arrow-icon"
           >
             <svg
               aria-hidden="true"
-              class="arco-icon arco-icon-expand"
+              class="arco-icon arco-icon-down"
               fill="none"
               focusable="false"
               stroke="currentColor"
               stroke-width="4"
-              style="transform:rotate(-45deg)"
               viewBox="0 0 48 48"
             >
               <path
-                d="M7 26v14c0 .552.444 1 .996 1H22m19-19V8c0-.552-.444-1-.996-1H26"
+                d="M39.6 17.443 24.043 33 8.487 17.443"
               />
             </svg>
           </div>
@@ -1488,20 +1476,19 @@ exports[`renders Cascader/demo/loadmore.md correctly 1`] = `
           class="arco-cascader-suffix"
         >
           <div
-            class="arco-cascader-expand-icon"
+            class="arco-cascader-arrow-icon"
           >
             <svg
               aria-hidden="true"
-              class="arco-icon arco-icon-expand"
+              class="arco-icon arco-icon-down"
               fill="none"
               focusable="false"
               stroke="currentColor"
               stroke-width="4"
-              style="transform:rotate(-45deg)"
               viewBox="0 0 48 48"
             >
               <path
-                d="M7 26v14c0 .552.444 1 .996 1H22m19-19V8c0-.552-.444-1-.996-1H26"
+                d="M39.6 17.443 24.043 33 8.487 17.443"
               />
             </svg>
           </div>
@@ -1554,20 +1541,19 @@ exports[`renders Cascader/demo/loadmore.md correctly 1`] = `
           class="arco-cascader-suffix"
         >
           <div
-            class="arco-cascader-expand-icon"
+            class="arco-cascader-arrow-icon"
           >
             <svg
               aria-hidden="true"
-              class="arco-icon arco-icon-expand"
+              class="arco-icon arco-icon-down"
               fill="none"
               focusable="false"
               stroke="currentColor"
               stroke-width="4"
-              style="transform:rotate(-45deg)"
               viewBox="0 0 48 48"
             >
               <path
-                d="M7 26v14c0 .552.444 1 .996 1H22m19-19V8c0-.552-.444-1-.996-1H26"
+                d="M39.6 17.443 24.043 33 8.487 17.443"
               />
             </svg>
           </div>
@@ -1656,20 +1642,19 @@ exports[`renders Cascader/demo/multiple.md correctly 1`] = `
           class="arco-cascader-suffix"
         >
           <div
-            class="arco-cascader-expand-icon"
+            class="arco-cascader-arrow-icon"
           >
             <svg
               aria-hidden="true"
-              class="arco-icon arco-icon-expand"
+              class="arco-icon arco-icon-down"
               fill="none"
               focusable="false"
               stroke="currentColor"
               stroke-width="4"
-              style="transform:rotate(-45deg)"
               viewBox="0 0 48 48"
             >
               <path
-                d="M7 26v14c0 .552.444 1 .996 1H22m19-19V8c0-.552-.444-1-.996-1H26"
+                d="M39.6 17.443 24.043 33 8.487 17.443"
               />
             </svg>
           </div>
@@ -1722,20 +1707,19 @@ exports[`renders Cascader/demo/multiple.md correctly 1`] = `
           class="arco-cascader-suffix"
         >
           <div
-            class="arco-cascader-expand-icon"
+            class="arco-cascader-arrow-icon"
           >
             <svg
               aria-hidden="true"
-              class="arco-icon arco-icon-expand"
+              class="arco-icon arco-icon-down"
               fill="none"
               focusable="false"
               stroke="currentColor"
               stroke-width="4"
-              style="transform:rotate(-45deg)"
               viewBox="0 0 48 48"
             >
               <path
-                d="M7 26v14c0 .552.444 1 .996 1H22m19-19V8c0-.552-.444-1-.996-1H26"
+                d="M39.6 17.443 24.043 33 8.487 17.443"
               />
             </svg>
           </div>
@@ -1823,20 +1807,19 @@ exports[`renders Cascader/demo/onSearch.md correctly 1`] = `
             class="arco-cascader-suffix"
           >
             <div
-              class="arco-cascader-expand-icon"
+              class="arco-cascader-arrow-icon"
             >
               <svg
                 aria-hidden="true"
-                class="arco-icon arco-icon-expand"
+                class="arco-icon arco-icon-down"
                 fill="none"
                 focusable="false"
                 stroke="currentColor"
                 stroke-width="4"
-                style="transform:rotate(-45deg)"
                 viewBox="0 0 48 48"
               >
                 <path
-                  d="M7 26v14c0 .552.444 1 .996 1H22m19-19V8c0-.552-.444-1-.996-1H26"
+                  d="M39.6 17.443 24.043 33 8.487 17.443"
                 />
               </svg>
             </div>
@@ -1889,20 +1872,19 @@ exports[`renders Cascader/demo/onSearch.md correctly 1`] = `
             class="arco-cascader-suffix"
           >
             <div
-              class="arco-cascader-expand-icon"
+              class="arco-cascader-arrow-icon"
             >
               <svg
                 aria-hidden="true"
-                class="arco-icon arco-icon-expand"
+                class="arco-icon arco-icon-down"
                 fill="none"
                 focusable="false"
                 stroke="currentColor"
                 stroke-width="4"
-                style="transform:rotate(-45deg)"
                 viewBox="0 0 48 48"
               >
                 <path
-                  d="M7 26v14c0 .552.444 1 .996 1H22m19-19V8c0-.552-.444-1-.996-1H26"
+                  d="M39.6 17.443 24.043 33 8.487 17.443"
                 />
               </svg>
             </div>
@@ -1954,20 +1936,19 @@ exports[`renders Cascader/demo/render_option.md correctly 1`] = `
           class="arco-cascader-suffix"
         >
           <div
-            class="arco-cascader-expand-icon"
+            class="arco-cascader-arrow-icon"
           >
             <svg
               aria-hidden="true"
-              class="arco-icon arco-icon-expand"
+              class="arco-icon arco-icon-down"
               fill="none"
               focusable="false"
               stroke="currentColor"
               stroke-width="4"
-              style="transform:rotate(-45deg)"
               viewBox="0 0 48 48"
             >
               <path
-                d="M7 26v14c0 .552.444 1 .996 1H22m19-19V8c0-.552-.444-1-.996-1H26"
+                d="M39.6 17.443 24.043 33 8.487 17.443"
               />
             </svg>
           </div>
@@ -2048,20 +2029,19 @@ exports[`renders Cascader/demo/render_option.md correctly 1`] = `
           class="arco-cascader-suffix"
         >
           <div
-            class="arco-cascader-expand-icon"
+            class="arco-cascader-arrow-icon"
           >
             <svg
               aria-hidden="true"
-              class="arco-icon arco-icon-expand"
+              class="arco-icon arco-icon-down"
               fill="none"
               focusable="false"
               stroke="currentColor"
               stroke-width="4"
-              style="transform:rotate(-45deg)"
               viewBox="0 0 48 48"
             >
               <path
-                d="M7 26v14c0 .552.444 1 .996 1H22m19-19V8c0-.552-.444-1-.996-1H26"
+                d="M39.6 17.443 24.043 33 8.487 17.443"
               />
             </svg>
           </div>
@@ -2129,20 +2109,19 @@ exports[`renders Cascader/demo/search.md correctly 1`] = `
             </svg>
           </span>
           <div
-            class="arco-cascader-expand-icon"
+            class="arco-cascader-arrow-icon"
           >
             <svg
               aria-hidden="true"
-              class="arco-icon arco-icon-expand"
+              class="arco-icon arco-icon-down"
               fill="none"
               focusable="false"
               stroke="currentColor"
               stroke-width="4"
-              style="transform:rotate(-45deg)"
               viewBox="0 0 48 48"
             >
               <path
-                d="M7 26v14c0 .552.444 1 .996 1H22m19-19V8c0-.552-.444-1-.996-1H26"
+                d="M39.6 17.443 24.043 33 8.487 17.443"
               />
             </svg>
           </div>
@@ -2240,20 +2219,19 @@ exports[`renders Cascader/demo/search.md correctly 1`] = `
             </svg>
           </span>
           <div
-            class="arco-cascader-expand-icon"
+            class="arco-cascader-arrow-icon"
           >
             <svg
               aria-hidden="true"
-              class="arco-icon arco-icon-expand"
+              class="arco-icon arco-icon-down"
               fill="none"
               focusable="false"
               stroke="currentColor"
               stroke-width="4"
-              style="transform:rotate(-45deg)"
               viewBox="0 0 48 48"
             >
               <path
-                d="M7 26v14c0 .552.444 1 .996 1H22m19-19V8c0-.552-.444-1-.996-1H26"
+                d="M39.6 17.443 24.043 33 8.487 17.443"
               />
             </svg>
           </div>
@@ -2334,20 +2312,19 @@ exports[`renders Cascader/demo/showEmptyChildren.md correctly 1`] = `
         class="arco-cascader-suffix"
       >
         <div
-          class="arco-cascader-expand-icon"
+          class="arco-cascader-arrow-icon"
         >
           <svg
             aria-hidden="true"
-            class="arco-icon arco-icon-expand"
+            class="arco-icon arco-icon-down"
             fill="none"
             focusable="false"
             stroke="currentColor"
             stroke-width="4"
-            style="transform:rotate(-45deg)"
             viewBox="0 0 48 48"
           >
             <path
-              d="M7 26v14c0 .552.444 1 .996 1H22m19-19V8c0-.552-.444-1-.996-1H26"
+              d="M39.6 17.443 24.043 33 8.487 17.443"
             />
           </svg>
         </div>
@@ -2515,20 +2492,19 @@ exports[`renders Cascader/demo/size.md correctly 1`] = `
           class="arco-cascader-suffix"
         >
           <div
-            class="arco-cascader-expand-icon"
+            class="arco-cascader-arrow-icon"
           >
             <svg
               aria-hidden="true"
-              class="arco-icon arco-icon-expand"
+              class="arco-icon arco-icon-down"
               fill="none"
               focusable="false"
               stroke="currentColor"
               stroke-width="4"
-              style="transform:rotate(-45deg)"
               viewBox="0 0 48 48"
             >
               <path
-                d="M7 26v14c0 .552.444 1 .996 1H22m19-19V8c0-.552-.444-1-.996-1H26"
+                d="M39.6 17.443 24.043 33 8.487 17.443"
               />
             </svg>
           </div>

--- a/components/Form/__test__/__snapshots__/demo.test.ts.snap
+++ b/components/Form/__test__/__snapshots__/demo.test.ts.snap
@@ -566,20 +566,19 @@ exports[`renders Form/demo/control.md correctly 1`] = `
                     class="arco-cascader-suffix"
                   >
                     <div
-                      class="arco-cascader-expand-icon"
+                      class="arco-cascader-arrow-icon"
                     >
                       <svg
                         aria-hidden="true"
-                        class="arco-icon arco-icon-expand"
+                        class="arco-icon arco-icon-down"
                         fill="none"
                         focusable="false"
                         stroke="currentColor"
                         stroke-width="4"
-                        style="transform:rotate(-45deg)"
                         viewBox="0 0 48 48"
                       >
                         <path
-                          d="M7 26v14c0 .552.444 1 .996 1H22m19-19V8c0-.552-.444-1-.996-1H26"
+                          d="M39.6 17.443 24.043 33 8.487 17.443"
                         />
                       </svg>
                     </div>
@@ -859,20 +858,19 @@ exports[`renders Form/demo/control.md correctly 1`] = `
                     class="arco-select-suffix"
                   >
                     <div
-                      class="arco-select-expand-icon"
+                      class="arco-select-arrow-icon"
                     >
                       <svg
                         aria-hidden="true"
-                        class="arco-icon arco-icon-expand"
+                        class="arco-icon arco-icon-down"
                         fill="none"
                         focusable="false"
                         stroke="currentColor"
                         stroke-width="4"
-                        style="transform:rotate(-45deg)"
                         viewBox="0 0 48 48"
                       >
                         <path
-                          d="M7 26v14c0 .552.444 1 .996 1H22m19-19V8c0-.552-.444-1-.996-1H26"
+                          d="M39.6 17.443 24.043 33 8.487 17.443"
                         />
                       </svg>
                     </div>
@@ -2418,20 +2416,19 @@ exports[`renders Form/demo/disabled.md correctly 1`] = `
                     class="arco-cascader-suffix"
                   >
                     <div
-                      class="arco-cascader-expand-icon"
+                      class="arco-cascader-arrow-icon"
                     >
                       <svg
                         aria-hidden="true"
-                        class="arco-icon arco-icon-expand"
+                        class="arco-icon arco-icon-down"
                         fill="none"
                         focusable="false"
                         stroke="currentColor"
                         stroke-width="4"
-                        style="transform:rotate(-45deg)"
                         viewBox="0 0 48 48"
                       >
                         <path
-                          d="M7 26v14c0 .552.444 1 .996 1H22m19-19V8c0-.552-.444-1-.996-1H26"
+                          d="M39.6 17.443 24.043 33 8.487 17.443"
                         />
                       </svg>
                     </div>
@@ -2696,20 +2693,19 @@ exports[`renders Form/demo/disabled.md correctly 1`] = `
                     class="arco-select-suffix"
                   >
                     <div
-                      class="arco-select-expand-icon"
+                      class="arco-select-arrow-icon"
                     >
                       <svg
                         aria-hidden="true"
-                        class="arco-icon arco-icon-expand"
+                        class="arco-icon arco-icon-down"
                         fill="none"
                         focusable="false"
                         stroke="currentColor"
                         stroke-width="4"
-                        style="transform:rotate(-45deg)"
                         viewBox="0 0 48 48"
                       >
                         <path
-                          d="M7 26v14c0 .552.444 1 .996 1H22m19-19V8c0-.552-.444-1-.996-1H26"
+                          d="M39.6 17.443 24.043 33 8.487 17.443"
                         />
                       </svg>
                     </div>
@@ -7248,20 +7244,19 @@ exports[`renders Form/demo/size.md correctly 1`] = `
                     class="arco-cascader-suffix"
                   >
                     <div
-                      class="arco-cascader-expand-icon"
+                      class="arco-cascader-arrow-icon"
                     >
                       <svg
                         aria-hidden="true"
-                        class="arco-icon arco-icon-expand"
+                        class="arco-icon arco-icon-down"
                         fill="none"
                         focusable="false"
                         stroke="currentColor"
                         stroke-width="4"
-                        style="transform:rotate(-45deg)"
                         viewBox="0 0 48 48"
                       >
                         <path
-                          d="M7 26v14c0 .552.444 1 .996 1H22m19-19V8c0-.552-.444-1-.996-1H26"
+                          d="M39.6 17.443 24.043 33 8.487 17.443"
                         />
                       </svg>
                     </div>
@@ -7462,20 +7457,19 @@ exports[`renders Form/demo/size.md correctly 1`] = `
                     class="arco-select-suffix"
                   >
                     <div
-                      class="arco-select-expand-icon"
+                      class="arco-select-arrow-icon"
                     >
                       <svg
                         aria-hidden="true"
-                        class="arco-icon arco-icon-expand"
+                        class="arco-icon arco-icon-down"
                         fill="none"
                         focusable="false"
                         stroke="currentColor"
                         stroke-width="4"
-                        style="transform:rotate(-45deg)"
                         viewBox="0 0 48 48"
                       >
                         <path
-                          d="M7 26v14c0 .552.444 1 .996 1H22m19-19V8c0-.552-.444-1-.996-1H26"
+                          d="M39.6 17.443 24.043 33 8.487 17.443"
                         />
                       </svg>
                     </div>
@@ -8997,20 +8991,19 @@ exports[`renders Form/demo/validate-status.md correctly 1`] = `
                     class="arco-select-suffix"
                   >
                     <div
-                      class="arco-select-expand-icon"
+                      class="arco-select-arrow-icon"
                     >
                       <svg
                         aria-hidden="true"
-                        class="arco-icon arco-icon-expand"
+                        class="arco-icon arco-icon-down"
                         fill="none"
                         focusable="false"
                         stroke="currentColor"
                         stroke-width="4"
-                        style="transform:rotate(-45deg)"
                         viewBox="0 0 48 48"
                       >
                         <path
-                          d="M7 26v14c0 .552.444 1 .996 1H22m19-19V8c0-.552-.444-1-.996-1H26"
+                          d="M39.6 17.443 24.043 33 8.487 17.443"
                         />
                       </svg>
                     </div>

--- a/components/Input/__test__/__snapshots__/demo.test.ts.snap
+++ b/components/Input/__test__/__snapshots__/demo.test.ts.snap
@@ -135,20 +135,19 @@ exports[`renders Input/demo/addon.md correctly 1`] = `
                     class="arco-select-suffix"
                   >
                     <div
-                      class="arco-select-expand-icon"
+                      class="arco-select-arrow-icon"
                     >
                       <svg
                         aria-hidden="true"
-                        class="arco-icon arco-icon-expand"
+                        class="arco-icon arco-icon-down"
                         fill="none"
                         focusable="false"
                         stroke="currentColor"
                         stroke-width="4"
-                        style="transform:rotate(-45deg)"
                         viewBox="0 0 48 48"
                       >
                         <path
-                          d="M7 26v14c0 .552.444 1 .996 1H22m19-19V8c0-.552-.444-1-.996-1H26"
+                          d="M39.6 17.443 24.043 33 8.487 17.443"
                         />
                       </svg>
                     </div>
@@ -253,20 +252,19 @@ exports[`renders Input/demo/group.md correctly 1`] = `
               class="arco-select-suffix"
             >
               <div
-                class="arco-select-expand-icon"
+                class="arco-select-arrow-icon"
               >
                 <svg
                   aria-hidden="true"
-                  class="arco-icon arco-icon-expand"
+                  class="arco-icon arco-icon-down"
                   fill="none"
                   focusable="false"
                   stroke="currentColor"
                   stroke-width="4"
-                  style="transform:rotate(-45deg)"
                   viewBox="0 0 48 48"
                 >
                   <path
-                    d="M7 26v14c0 .552.444 1 .996 1H22m19-19V8c0-.552-.444-1-.996-1H26"
+                    d="M39.6 17.443 24.043 33 8.487 17.443"
                   />
                 </svg>
               </div>
@@ -319,20 +317,19 @@ exports[`renders Input/demo/group.md correctly 1`] = `
               class="arco-select-suffix"
             >
               <div
-                class="arco-select-expand-icon"
+                class="arco-select-arrow-icon"
               >
                 <svg
                   aria-hidden="true"
-                  class="arco-icon arco-icon-expand"
+                  class="arco-icon arco-icon-down"
                   fill="none"
                   focusable="false"
                   stroke="currentColor"
                   stroke-width="4"
-                  style="transform:rotate(-45deg)"
                   viewBox="0 0 48 48"
                 >
                   <path
-                    d="M7 26v14c0 .552.444 1 .996 1H22m19-19V8c0-.552-.444-1-.996-1H26"
+                    d="M39.6 17.443 24.043 33 8.487 17.443"
                   />
                 </svg>
               </div>
@@ -414,20 +411,19 @@ exports[`renders Input/demo/group.md correctly 1`] = `
               class="arco-select-suffix"
             >
               <div
-                class="arco-select-expand-icon"
+                class="arco-select-arrow-icon"
               >
                 <svg
                   aria-hidden="true"
-                  class="arco-icon arco-icon-expand"
+                  class="arco-icon arco-icon-down"
                   fill="none"
                   focusable="false"
                   stroke="currentColor"
                   stroke-width="4"
-                  style="transform:rotate(-45deg)"
                   viewBox="0 0 48 48"
                 >
                   <path
-                    d="M7 26v14c0 .552.444 1 .996 1H22m19-19V8c0-.552-.444-1-.996-1H26"
+                    d="M39.6 17.443 24.043 33 8.487 17.443"
                   />
                 </svg>
               </div>

--- a/components/InputTag/input-tag.tsx
+++ b/components/InputTag/input-tag.tsx
@@ -260,6 +260,7 @@ function InputTag(baseProps: InputTagProps<string | ObjectValueType>, ref) {
     ) : null;
 
   const hasSuffix = !!(clearIcon || suffix);
+  const disableInputComponent = disabled || disableInput;
 
   // CSSTransition needs to be a direct child of TransitionGroup, otherwise the animation will NOT work
   // https://github.com/arco-design/arco-design/issues/622
@@ -289,7 +290,7 @@ function InputTag(baseProps: InputTagProps<string | ObjectValueType>, ref) {
         <InputComponent
           autoComplete="off"
           size={size}
-          disabled={disabled || disableInput}
+          disabled={disableInputComponent}
           readOnly={readOnly}
           ref={inputRef}
           autoFocus={autoFocus}
@@ -304,7 +305,7 @@ function InputTag(baseProps: InputTagProps<string | ObjectValueType>, ref) {
             await tryAddInputValueToTag();
           }}
           onFocus={(e) => {
-            if (!disabled && !readOnly) {
+            if (!disableInputComponent && !readOnly) {
               setFocused(true);
               onFocus && onFocus(e);
             }

--- a/components/InputTag/style/index.less
+++ b/components/InputTag/style/index.less
@@ -99,6 +99,10 @@
     cursor: inherit;
     color: inherit;
 
+    &[disabled] {
+      width: 0 !important;
+    }
+
     &-mirror {
       position: absolute;
       top: 0;

--- a/components/Select/__test__/__snapshots__/demo.test.ts.snap
+++ b/components/Select/__test__/__snapshots__/demo.test.ts.snap
@@ -38,20 +38,19 @@ exports[`renders Select/demo/allow-create.md correctly 1`] = `
           class="arco-select-suffix"
         >
           <div
-            class="arco-select-expand-icon"
+            class="arco-select-arrow-icon"
           >
             <svg
               aria-hidden="true"
-              class="arco-icon arco-icon-expand"
+              class="arco-icon arco-icon-down"
               fill="none"
               focusable="false"
               stroke="currentColor"
               stroke-width="4"
-              style="transform:rotate(-45deg)"
               viewBox="0 0 48 48"
             >
               <path
-                d="M7 26v14c0 .552.444 1 .996 1H22m19-19V8c0-.552-.444-1-.996-1H26"
+                d="M39.6 17.443 24.043 33 8.487 17.443"
               />
             </svg>
           </div>
@@ -159,20 +158,19 @@ exports[`renders Select/demo/allow-create.md correctly 1`] = `
             </svg>
           </span>
           <div
-            class="arco-select-expand-icon"
+            class="arco-select-arrow-icon"
           >
             <svg
               aria-hidden="true"
-              class="arco-icon arco-icon-expand"
+              class="arco-icon arco-icon-down"
               fill="none"
               focusable="false"
               stroke="currentColor"
               stroke-width="4"
-              style="transform:rotate(-45deg)"
               viewBox="0 0 48 48"
             >
               <path
-                d="M7 26v14c0 .552.444 1 .996 1H22m19-19V8c0-.552-.444-1-.996-1H26"
+                d="M39.6 17.443 24.043 33 8.487 17.443"
               />
             </svg>
           </div>
@@ -226,20 +224,19 @@ exports[`renders Select/demo/async-data.md correctly 1`] = `
       class="arco-select-suffix"
     >
       <div
-        class="arco-select-expand-icon"
+        class="arco-select-arrow-icon"
       >
         <svg
           aria-hidden="true"
-          class="arco-icon arco-icon-expand"
+          class="arco-icon arco-icon-down"
           fill="none"
           focusable="false"
           stroke="currentColor"
           stroke-width="4"
-          style="transform:rotate(-45deg)"
           viewBox="0 0 48 48"
         >
           <path
-            d="M7 26v14c0 .552.444 1 .996 1H22m19-19V8c0-.552-.444-1-.996-1H26"
+            d="M39.6 17.443 24.043 33 8.487 17.443"
           />
         </svg>
       </div>
@@ -713,20 +710,19 @@ exports[`renders Select/demo/darggable.md correctly 1`] = `
       class="arco-select-suffix"
     >
       <div
-        class="arco-select-expand-icon"
+        class="arco-select-arrow-icon"
       >
         <svg
           aria-hidden="true"
-          class="arco-icon arco-icon-expand"
+          class="arco-icon arco-icon-down"
           fill="none"
           focusable="false"
           stroke="currentColor"
           stroke-width="4"
-          style="transform:rotate(-45deg)"
           viewBox="0 0 48 48"
         >
           <path
-            d="M7 26v14c0 .552.444 1 .996 1H22m19-19V8c0-.552-.444-1-.996-1H26"
+            d="M39.6 17.443 24.043 33 8.487 17.443"
           />
         </svg>
       </div>
@@ -820,20 +816,19 @@ exports[`renders Select/demo/group.md correctly 1`] = `
         class="arco-select-suffix"
       >
         <div
-          class="arco-select-expand-icon"
+          class="arco-select-arrow-icon"
         >
           <svg
             aria-hidden="true"
-            class="arco-icon arco-icon-expand"
+            class="arco-icon arco-icon-down"
             fill="none"
             focusable="false"
             stroke="currentColor"
             stroke-width="4"
-            style="transform:rotate(-45deg)"
             viewBox="0 0 48 48"
           >
             <path
-              d="M7 26v14c0 .552.444 1 .996 1H22m19-19V8c0-.552-.444-1-.996-1H26"
+              d="M39.6 17.443 24.043 33 8.487 17.443"
             />
           </svg>
         </div>
@@ -886,20 +881,19 @@ exports[`renders Select/demo/hide-selected-option.md correctly 1`] = `
       class="arco-select-suffix"
     >
       <div
-        class="arco-select-expand-icon"
+        class="arco-select-arrow-icon"
       >
         <svg
           aria-hidden="true"
-          class="arco-icon arco-icon-expand"
+          class="arco-icon arco-icon-down"
           fill="none"
           focusable="false"
           stroke="currentColor"
           stroke-width="4"
-          style="transform:rotate(-45deg)"
           viewBox="0 0 48 48"
         >
           <path
-            d="M7 26v14c0 .552.444 1 .996 1H22m19-19V8c0-.552-.444-1-.996-1H26"
+            d="M39.6 17.443 24.043 33 8.487 17.443"
           />
         </svg>
       </div>
@@ -1033,20 +1027,19 @@ exports[`renders Select/demo/multiple.md correctly 1`] = `
             </svg>
           </span>
           <div
-            class="arco-select-expand-icon"
+            class="arco-select-arrow-icon"
           >
             <svg
               aria-hidden="true"
-              class="arco-icon arco-icon-expand"
+              class="arco-icon arco-icon-down"
               fill="none"
               focusable="false"
               stroke="currentColor"
               stroke-width="4"
-              style="transform:rotate(-45deg)"
               viewBox="0 0 48 48"
             >
               <path
-                d="M7 26v14c0 .552.444 1 .996 1H22m19-19V8c0-.552-.444-1-.996-1H26"
+                d="M39.6 17.443 24.043 33 8.487 17.443"
               />
             </svg>
           </div>
@@ -1185,20 +1178,19 @@ exports[`renders Select/demo/multiple.md correctly 1`] = `
             </svg>
           </span>
           <div
-            class="arco-select-expand-icon"
+            class="arco-select-arrow-icon"
           >
             <svg
               aria-hidden="true"
-              class="arco-icon arco-icon-expand"
+              class="arco-icon arco-icon-down"
               fill="none"
               focusable="false"
               stroke="currentColor"
               stroke-width="4"
-              style="transform:rotate(-45deg)"
               viewBox="0 0 48 48"
             >
               <path
-                d="M7 26v14c0 .552.444 1 .996 1H22m19-19V8c0-.552-.444-1-.996-1H26"
+                d="M39.6 17.443 24.043 33 8.487 17.443"
               />
             </svg>
           </div>
@@ -1337,20 +1329,19 @@ exports[`renders Select/demo/multiple.md correctly 1`] = `
             </svg>
           </span>
           <div
-            class="arco-select-expand-icon"
+            class="arco-select-arrow-icon"
           >
             <svg
               aria-hidden="true"
-              class="arco-icon arco-icon-expand"
+              class="arco-icon arco-icon-down"
               fill="none"
               focusable="false"
               stroke="currentColor"
               stroke-width="4"
-              style="transform:rotate(-45deg)"
               viewBox="0 0 48 48"
             >
               <path
-                d="M7 26v14c0 .552.444 1 .996 1H22m19-19V8c0-.552-.444-1-.996-1H26"
+                d="M39.6 17.443 24.043 33 8.487 17.443"
               />
             </svg>
           </div>
@@ -1423,20 +1414,19 @@ exports[`renders Select/demo/multiple.md correctly 1`] = `
             </svg>
           </span>
           <div
-            class="arco-select-expand-icon"
+            class="arco-select-arrow-icon"
           >
             <svg
               aria-hidden="true"
-              class="arco-icon arco-icon-expand"
+              class="arco-icon arco-icon-down"
               fill="none"
               focusable="false"
               stroke="currentColor"
               stroke-width="4"
-              style="transform:rotate(-45deg)"
               viewBox="0 0 48 48"
             >
               <path
-                d="M7 26v14c0 .552.444 1 .996 1H22m19-19V8c0-.552-.444-1-.996-1H26"
+                d="M39.6 17.443 24.043 33 8.487 17.443"
               />
             </svg>
           </div>
@@ -1610,20 +1600,19 @@ exports[`renders Select/demo/on-popup-scroll.md correctly 1`] = `
       class="arco-select-suffix"
     >
       <div
-        class="arco-select-expand-icon"
+        class="arco-select-arrow-icon"
       >
         <svg
           aria-hidden="true"
-          class="arco-icon arco-icon-expand"
+          class="arco-icon arco-icon-down"
           fill="none"
           focusable="false"
           stroke="currentColor"
           stroke-width="4"
-          style="transform:rotate(-45deg)"
           viewBox="0 0 48 48"
         >
           <path
-            d="M7 26v14c0 .552.444 1 .996 1H22m19-19V8c0-.552-.444-1-.996-1H26"
+            d="M39.6 17.443 24.043 33 8.487 17.443"
           />
         </svg>
       </div>
@@ -1796,20 +1785,19 @@ exports[`renders Select/demo/options.md correctly 1`] = `
           class="arco-select-suffix"
         >
           <div
-            class="arco-select-expand-icon"
+            class="arco-select-arrow-icon"
           >
             <svg
               aria-hidden="true"
-              class="arco-icon arco-icon-expand"
+              class="arco-icon arco-icon-down"
               fill="none"
               focusable="false"
               stroke="currentColor"
               stroke-width="4"
-              style="transform:rotate(-45deg)"
               viewBox="0 0 48 48"
             >
               <path
-                d="M7 26v14c0 .552.444 1 .996 1H22m19-19V8c0-.552-.444-1-.996-1H26"
+                d="M39.6 17.443 24.043 33 8.487 17.443"
               />
             </svg>
           </div>
@@ -2130,20 +2118,19 @@ exports[`renders Select/demo/render-format.md correctly 1`] = `
           class="arco-select-suffix"
         >
           <div
-            class="arco-select-expand-icon"
+            class="arco-select-arrow-icon"
           >
             <svg
               aria-hidden="true"
-              class="arco-icon arco-icon-expand"
+              class="arco-icon arco-icon-down"
               fill="none"
               focusable="false"
               stroke="currentColor"
               stroke-width="4"
-              style="transform:rotate(-45deg)"
               viewBox="0 0 48 48"
             >
               <path
-                d="M7 26v14c0 .552.444 1 .996 1H22m19-19V8c0-.552-.444-1-.996-1H26"
+                d="M39.6 17.443 24.043 33 8.487 17.443"
               />
             </svg>
           </div>
@@ -2276,20 +2263,19 @@ exports[`renders Select/demo/render-tag.md correctly 1`] = `
             </svg>
           </span>
           <div
-            class="arco-select-expand-icon"
+            class="arco-select-arrow-icon"
           >
             <svg
               aria-hidden="true"
-              class="arco-icon arco-icon-expand"
+              class="arco-icon arco-icon-down"
               fill="none"
               focusable="false"
               stroke="currentColor"
               stroke-width="4"
-              style="transform:rotate(-45deg)"
               viewBox="0 0 48 48"
             >
               <path
-                d="M7 26v14c0 .552.444 1 .996 1H22m19-19V8c0-.552-.444-1-.996-1H26"
+                d="M39.6 17.443 24.043 33 8.487 17.443"
               />
             </svg>
           </div>
@@ -2338,20 +2324,19 @@ exports[`renders Select/demo/show-search.md correctly 1`] = `
           class="arco-select-suffix"
         >
           <div
-            class="arco-select-expand-icon"
+            class="arco-select-arrow-icon"
           >
             <svg
               aria-hidden="true"
-              class="arco-icon arco-icon-expand"
+              class="arco-icon arco-icon-down"
               fill="none"
               focusable="false"
               stroke="currentColor"
               stroke-width="4"
-              style="transform:rotate(-45deg)"
               viewBox="0 0 48 48"
             >
               <path
-                d="M7 26v14c0 .552.444 1 .996 1H22m19-19V8c0-.552-.444-1-.996-1H26"
+                d="M39.6 17.443 24.043 33 8.487 17.443"
               />
             </svg>
           </div>
@@ -2393,20 +2378,19 @@ exports[`renders Select/demo/show-search.md correctly 1`] = `
           class="arco-select-suffix"
         >
           <div
-            class="arco-select-expand-icon"
+            class="arco-select-arrow-icon"
           >
             <svg
               aria-hidden="true"
-              class="arco-icon arco-icon-expand"
+              class="arco-icon arco-icon-down"
               fill="none"
               focusable="false"
               stroke="currentColor"
               stroke-width="4"
-              style="transform:rotate(-45deg)"
               viewBox="0 0 48 48"
             >
               <path
-                d="M7 26v14c0 .552.444 1 .996 1H22m19-19V8c0-.552-.444-1-.996-1H26"
+                d="M39.6 17.443 24.043 33 8.487 17.443"
               />
             </svg>
           </div>
@@ -2447,20 +2431,19 @@ exports[`renders Select/demo/show-search.md correctly 1`] = `
           class="arco-select-suffix"
         >
           <div
-            class="arco-select-expand-icon"
+            class="arco-select-arrow-icon"
           >
             <svg
               aria-hidden="true"
-              class="arco-icon arco-icon-expand"
+              class="arco-icon arco-icon-down"
               fill="none"
               focusable="false"
               stroke="currentColor"
               stroke-width="4"
-              style="transform:rotate(-45deg)"
               viewBox="0 0 48 48"
             >
               <path
-                d="M7 26v14c0 .552.444 1 .996 1H22m19-19V8c0-.552-.444-1-.996-1H26"
+                d="M39.6 17.443 24.043 33 8.487 17.443"
               />
             </svg>
           </div>
@@ -2566,20 +2549,19 @@ exports[`renders Select/demo/size.md correctly 1`] = `
           class="arco-select-suffix"
         >
           <div
-            class="arco-select-expand-icon"
+            class="arco-select-arrow-icon"
           >
             <svg
               aria-hidden="true"
-              class="arco-icon arco-icon-expand"
+              class="arco-icon arco-icon-down"
               fill="none"
               focusable="false"
               stroke="currentColor"
               stroke-width="4"
-              style="transform:rotate(-45deg)"
               viewBox="0 0 48 48"
             >
               <path
-                d="M7 26v14c0 .552.444 1 .996 1H22m19-19V8c0-.552-.444-1-.996-1H26"
+                d="M39.6 17.443 24.043 33 8.487 17.443"
               />
             </svg>
           </div>
@@ -2629,20 +2611,19 @@ exports[`renders Select/demo/size.md correctly 1`] = `
           class="arco-select-suffix"
         >
           <div
-            class="arco-select-expand-icon"
+            class="arco-select-arrow-icon"
           >
             <svg
               aria-hidden="true"
-              class="arco-icon arco-icon-expand"
+              class="arco-icon arco-icon-down"
               fill="none"
               focusable="false"
               stroke="currentColor"
               stroke-width="4"
-              style="transform:rotate(-45deg)"
               viewBox="0 0 48 48"
             >
               <path
-                d="M7 26v14c0 .552.444 1 .996 1H22m19-19V8c0-.552-.444-1-.996-1H26"
+                d="M39.6 17.443 24.043 33 8.487 17.443"
               />
             </svg>
           </div>
@@ -2696,20 +2677,19 @@ exports[`renders Select/demo/token-separators.md correctly 1`] = `
       class="arco-select-suffix"
     >
       <div
-        class="arco-select-expand-icon"
+        class="arco-select-arrow-icon"
       >
         <svg
           aria-hidden="true"
-          class="arco-icon arco-icon-expand"
+          class="arco-icon arco-icon-down"
           fill="none"
           focusable="false"
           stroke="currentColor"
           stroke-width="4"
-          style="transform:rotate(-45deg)"
           viewBox="0 0 48 48"
         >
           <path
-            d="M7 26v14c0 .552.444 1 .996 1H22m19-19V8c0-.552-.444-1-.996-1H26"
+            d="M39.6 17.443 24.043 33 8.487 17.443"
           />
         </svg>
       </div>
@@ -2767,20 +2747,19 @@ Array [
         class="arco-select-suffix"
       >
         <div
-          class="arco-select-expand-icon"
+          class="arco-select-arrow-icon"
         >
           <svg
             aria-hidden="true"
-            class="arco-icon arco-icon-expand"
+            class="arco-icon arco-icon-down"
             fill="none"
             focusable="false"
             stroke="currentColor"
             stroke-width="4"
-            style="transform:rotate(-45deg)"
             viewBox="0 0 48 48"
           >
             <path
-              d="M7 26v14c0 .552.444 1 .996 1H22m19-19V8c0-.552-.444-1-.996-1H26"
+              d="M39.6 17.443 24.043 33 8.487 17.443"
             />
           </svg>
         </div>

--- a/components/TreeSelect/__test__/__snapshots__/demo.test.ts.snap
+++ b/components/TreeSelect/__test__/__snapshots__/demo.test.ts.snap
@@ -198,20 +198,19 @@ exports[`renders TreeSelect/demo/checkable.md correctly 1`] = `
           </svg>
         </span>
         <div
-          class="arco-tree-select-expand-icon"
+          class="arco-tree-select-arrow-icon"
         >
           <svg
             aria-hidden="true"
-            class="arco-icon arco-icon-expand"
+            class="arco-icon arco-icon-down"
             fill="none"
             focusable="false"
             stroke="currentColor"
             stroke-width="4"
-            style="transform:rotate(-45deg)"
             viewBox="0 0 48 48"
           >
             <path
-              d="M7 26v14c0 .552.444 1 .996 1H22m19-19V8c0-.552-.444-1-.996-1H26"
+              d="M39.6 17.443 24.043 33 8.487 17.443"
             />
           </svg>
         </div>
@@ -388,20 +387,19 @@ exports[`renders TreeSelect/demo/checkedStrategy.md correctly 1`] = `
           </svg>
         </span>
         <div
-          class="arco-tree-select-expand-icon"
+          class="arco-tree-select-arrow-icon"
         >
           <svg
             aria-hidden="true"
-            class="arco-icon arco-icon-expand"
+            class="arco-icon arco-icon-down"
             fill="none"
             focusable="false"
             stroke="currentColor"
             stroke-width="4"
-            style="transform:rotate(-45deg)"
             viewBox="0 0 48 48"
           >
             <path
-              d="M7 26v14c0 .552.444 1 .996 1H22m19-19V8c0-.552-.444-1-.996-1H26"
+              d="M39.6 17.443 24.043 33 8.487 17.443"
             />
           </svg>
         </div>
@@ -518,20 +516,19 @@ exports[`renders TreeSelect/demo/draggable.md correctly 1`] = `
       class="arco-tree-select-suffix"
     >
       <div
-        class="arco-tree-select-expand-icon"
+        class="arco-tree-select-arrow-icon"
       >
         <svg
           aria-hidden="true"
-          class="arco-icon arco-icon-expand"
+          class="arco-icon arco-icon-down"
           fill="none"
           focusable="false"
           stroke="currentColor"
           stroke-width="4"
-          style="transform:rotate(-45deg)"
           viewBox="0 0 48 48"
         >
           <path
-            d="M7 26v14c0 .552.444 1 .996 1H22m19-19V8c0-.552-.444-1-.996-1H26"
+            d="M39.6 17.443 24.043 33 8.487 17.443"
           />
         </svg>
       </div>
@@ -734,20 +731,19 @@ exports[`renders TreeSelect/demo/loadmore.md correctly 1`] = `
       class="arco-tree-select-suffix"
     >
       <div
-        class="arco-tree-select-expand-icon"
+        class="arco-tree-select-arrow-icon"
       >
         <svg
           aria-hidden="true"
-          class="arco-icon arco-icon-expand"
+          class="arco-icon arco-icon-down"
           fill="none"
           focusable="false"
           stroke="currentColor"
           stroke-width="4"
-          style="transform:rotate(-45deg)"
           viewBox="0 0 48 48"
         >
           <path
-            d="M7 26v14c0 .552.444 1 .996 1H22m19-19V8c0-.552-.444-1-.996-1H26"
+            d="M39.6 17.443 24.043 33 8.487 17.443"
           />
         </svg>
       </div>
@@ -806,20 +802,19 @@ exports[`renders TreeSelect/demo/multiple.md correctly 1`] = `
           class="arco-tree-select-suffix"
         >
           <div
-            class="arco-tree-select-expand-icon"
+            class="arco-tree-select-arrow-icon"
           >
             <svg
               aria-hidden="true"
-              class="arco-icon arco-icon-expand"
+              class="arco-icon arco-icon-down"
               fill="none"
               focusable="false"
               stroke="currentColor"
               stroke-width="4"
-              style="transform:rotate(-45deg)"
               viewBox="0 0 48 48"
             >
               <path
-                d="M7 26v14c0 .552.444 1 .996 1H22m19-19V8c0-.552-.444-1-.996-1H26"
+                d="M39.6 17.443 24.043 33 8.487 17.443"
               />
             </svg>
           </div>
@@ -872,20 +867,19 @@ exports[`renders TreeSelect/demo/multiple.md correctly 1`] = `
           class="arco-tree-select-suffix"
         >
           <div
-            class="arco-tree-select-expand-icon"
+            class="arco-tree-select-arrow-icon"
           >
             <svg
               aria-hidden="true"
-              class="arco-icon arco-icon-expand"
+              class="arco-icon arco-icon-down"
               fill="none"
               focusable="false"
               stroke="currentColor"
               stroke-width="4"
-              style="transform:rotate(-45deg)"
               viewBox="0 0 48 48"
             >
               <path
-                d="M7 26v14c0 .552.444 1 .996 1H22m19-19V8c0-.552-.444-1-.996-1H26"
+                d="M39.6 17.443 24.043 33 8.487 17.443"
               />
             </svg>
           </div>
@@ -939,20 +933,19 @@ exports[`renders TreeSelect/demo/onSearch.md correctly 1`] = `
       class="arco-tree-select-suffix"
     >
       <div
-        class="arco-tree-select-expand-icon"
+        class="arco-tree-select-arrow-icon"
       >
         <svg
           aria-hidden="true"
-          class="arco-icon arco-icon-expand"
+          class="arco-icon arco-icon-down"
           fill="none"
           focusable="false"
           stroke="currentColor"
           stroke-width="4"
-          style="transform:rotate(-45deg)"
           viewBox="0 0 48 48"
         >
           <path
-            d="M7 26v14c0 .552.444 1 .996 1H22m19-19V8c0-.552-.444-1-.996-1H26"
+            d="M39.6 17.443 24.043 33 8.487 17.443"
           />
         </svg>
       </div>
@@ -1052,20 +1045,19 @@ exports[`renders TreeSelect/demo/search.md correctly 1`] = `
           class="arco-tree-select-suffix"
         >
           <div
-            class="arco-tree-select-expand-icon"
+            class="arco-tree-select-arrow-icon"
           >
             <svg
               aria-hidden="true"
-              class="arco-icon arco-icon-expand"
+              class="arco-icon arco-icon-down"
               fill="none"
               focusable="false"
               stroke="currentColor"
               stroke-width="4"
-              style="transform:rotate(-45deg)"
               viewBox="0 0 48 48"
             >
               <path
-                d="M7 26v14c0 .552.444 1 .996 1H22m19-19V8c0-.552-.444-1-.996-1H26"
+                d="M39.6 17.443 24.043 33 8.487 17.443"
               />
             </svg>
           </div>
@@ -1106,20 +1098,19 @@ exports[`renders TreeSelect/demo/search.md correctly 1`] = `
           class="arco-tree-select-suffix"
         >
           <div
-            class="arco-tree-select-expand-icon"
+            class="arco-tree-select-arrow-icon"
           >
             <svg
               aria-hidden="true"
-              class="arco-icon arco-icon-expand"
+              class="arco-icon arco-icon-down"
               fill="none"
               focusable="false"
               stroke="currentColor"
               stroke-width="4"
-              style="transform:rotate(-45deg)"
               viewBox="0 0 48 48"
             >
               <path
-                d="M7 26v14c0 .552.444 1 .996 1H22m19-19V8c0-.552-.444-1-.996-1H26"
+                d="M39.6 17.443 24.043 33 8.487 17.443"
               />
             </svg>
           </div>

--- a/components/Trigger/__test__/__snapshots__/demo.test.ts.snap
+++ b/components/Trigger/__test__/__snapshots__/demo.test.ts.snap
@@ -81,20 +81,19 @@ exports[`renders Trigger/demo/alignPoint.md correctly 1`] = `
           class="arco-select-suffix"
         >
           <div
-            class="arco-select-expand-icon"
+            class="arco-select-arrow-icon"
           >
             <svg
               aria-hidden="true"
-              class="arco-icon arco-icon-expand"
+              class="arco-icon arco-icon-down"
               fill="none"
               focusable="false"
               stroke="currentColor"
               stroke-width="4"
-              style="transform:rotate(-45deg)"
               viewBox="0 0 48 48"
             >
               <path
-                d="M7 26v14c0 .552.444 1 .996 1H22m19-19V8c0-.552-.444-1-.996-1H26"
+                d="M39.6 17.443 24.043 33 8.487 17.443"
               />
             </svg>
           </div>

--- a/components/_class/select-view.tsx
+++ b/components/_class/select-view.tsx
@@ -14,7 +14,6 @@ import { ConfigContext } from '../ConfigProvider';
 import IconDown from '../../icon/react-icon/IconDown';
 import IconLoading from '../../icon/react-icon/IconLoading';
 import IconClose from '../../icon/react-icon/IconClose';
-import IconExpand from '../../icon/react-icon/IconExpand';
 import IconSearch from '../../icon/react-icon/IconSearch';
 import InputTag, { InputTagProps } from '../InputTag';
 import InputComponent from '../Input/input-element';
@@ -282,10 +281,6 @@ export const SelectView = (props: SelectViewProps, ref) => {
       arrowIcon === null ? null : (
         <div className={`${prefixCls}-arrow-icon`}>{arrowIcon}</div>
       )
-    ) : canFocusInput ? (
-      <div className={`${prefixCls}-expand-icon`}>
-        <IconExpand style={{ transform: 'rotate(-45deg)' }} />
-      </div>
     ) : (
       <div className={`${prefixCls}-arrow-icon`}>
         <IconDown />


### PR DESCRIPTION

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [ ] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [x] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context

* 统一 Select 组件单选/多选模式下的右侧箭头样式，避免歧义。
* 在 `style: { width: 'atuo' }` 且为多选模式时 ，避免聚焦后由于 `<input/>` 的 4px 宽度导致的 Select 宽度抖动。仅优化了显式指定 `showSearch = false` 的情况，允许输入的情况下，聚焦之后必须保留输入框的宽度以保证光标可见。

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|  Select  |  统一 `Select` 多选和单选模式下的右侧箭头样式。  |  Unify the style of the right arrow in `Select` multi-select and single-select modes.  |   Close #1283  |


- [ ] Test suite passes (`npm run test`)
- [x] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [x] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)
