### PR TITLE
enhance: typography add ellipsis.wrapper to replace React.Fragment

### DIFF
--- a/components/Typography/__demo__/ellipsis-controlled.md
+++ b/components/Typography/__demo__/ellipsis-controlled.md
@@ -36,7 +36,7 @@ const App = () => {
   const [text, setText] = useState(defaultText);
   const { ellipsis, ellipsisStr, expandable, suffix } = config;
   return (
-    <>
+    <div>
       <Space align="start" size={120}>
         <Form
           onValuesChange={(_, values) => setConfig(values)}
@@ -96,6 +96,7 @@ const App = () => {
                   expandable,
                   suffix,
                   ellipsisStr,
+                  wrapper: "div"
                 }
               : undefined
           }
@@ -103,7 +104,7 @@ const App = () => {
           {text}
         </Typography.Paragraph>
       </div>
-    </>
+    </div>
   );
 };
 

--- a/components/Typography/__demo__/ellipsis.md
+++ b/components/Typography/__demo__/ellipsis.md
@@ -18,75 +18,26 @@ Omit multiple lines of text when there is insufficient space.
 **Note**: In the parent element `flex` mode, the omitted `Typography`'s `ellipsis` scene will be affected. You can add `width: 100%` to make the `Typography` fill the entire parent element.
 
 ```js
-import { useState } from 'react';
-import { Typography, Switch, Tag } from '@arco-design/web-react';
+import { Typography } from '@arco-design/web-react';
+
 const mockText =
   'A design is a plan or specification for the construction of an object or system or for the implementation of an activity or process, or the result of that plan or specification in the form of a prototype, product or process. The verb to design expresses the process of developing a design. The verb to design expresses the process of developing a design. A design is a plan or specification for the construction of an object or system or for the implementation of an activity or process, or the result of that plan or specification in the form of a prototype, product or process. The verb to design expresses the process of developing a design. The verb to design expresses the process of developing a design.';
 const mockTitle =
   ' A design is a plan or specification for the construction of an object or system or for the implementation of an activity or process.';
 
 const App = () => {
-  const [ellipsis, setEllipsis] = useState(true);
   return (
-    <>
-      <Switch
-        checked={ellipsis}
-        onChange={() => {
-          setEllipsis(!ellipsis);
-        }}
-      />
-      <div>
-        <Typography.Title heading={4} ellipsis={ellipsis}>
-          {mockTitle}
-        </Typography.Title>
-        <Typography.Paragraph
-          ellipsis={
-            ellipsis
-              ? {
-                  rows: 2,
-                  showTooltip: true,
-                  expandable: true,
-                }
-              : undefined
-          }
-        >
-          {mockText}
-        </Typography.Paragraph>
-      </div>
-
-      <div>
-        <Typography.Title style={{ width: '240px' }} heading={4}>
-          Ellipsis in flex scene
-        </Typography.Title>
-        <div style={{ display: 'flex' }}>
-          <Typography.Paragraph
-            ellipsis={
-              ellipsis
-                ? {
-                    suffix: '----width: 100%',
-                  }
-                : undefined
-            }
-            style={{ width: '100%' }}
-          >
-            {mockTitle}
-          </Typography.Paragraph>
-        </div>
-        <div style={{ display: 'flex' }}>
-          <Typography.Paragraph
-            ellipsis={
-              ellipsis
-                ? {
-                    suffix: '----width: normal',
-                  }
-                : undefined
-            }
-          >
-            {mockTitle}
-          </Typography.Paragraph>
-        </div>
-      </div>
-    </>
+    <div>
+      <Typography.Title heading={4} ellipsis={{ wrapper: 'span' }}>
+        {mockTitle}
+      </Typography.Title>
+      <Typography.Paragraph ellipsis={{ rows: 2, showTooltip: true, expandable: true, wrapper: 'span' }}>
+        {mockText}
+      </Typography.Paragraph>
+      <Typography.Paragraph ellipsis={{ suffix: '---width: 100%', wrapper: 'span' }}>
+        {mockTitle}
+      </Typography.Paragraph>
+    </div>
   );
 };
 

--- a/components/Typography/__test__/__snapshots__/demo.test.ts.snap
+++ b/components/Typography/__test__/__snapshots__/demo.test.ts.snap
@@ -132,61 +132,33 @@ exports[`renders Typography/demo/basic.md correctly 1`] = `
 `;
 
 exports[`renders Typography/demo/ellipsis.md correctly 1`] = `
-Array [
-  <button
-    aria-checked="true"
-    class="arco-switch arco-switch-type-circle arco-switch-checked"
-    role="switch"
-    type="button"
+<div>
+  <h4
+    class="arco-typography"
   >
-    <div
-      class="arco-switch-dot"
-    />
-  </button>,
-  <div>
-    <h4
-      class="arco-typography"
-    >
+    <span>
        A design is a plan or specification for the construction of an object or system or for the implementation of an activity or process.
-    </h4>
-    <div
-      class="arco-typography"
-    >
+    </span>
+  </h4>
+  <div
+    class="arco-typography"
+  >
+    <span>
       A design is a plan or specification for the construction of an object or system or for the implementation of an activity or process, or the result of that plan or specification in the form of a prototype, product or process. The verb to design expresses the process of developing a design. The verb to design expresses the process of developing a design. A design is a plan or specification for the construction of an object or system or for the implementation of an activity or process, or the result of that plan or specification in the form of a prototype, product or process. The verb to design expresses the process of developing a design. The verb to design expresses the process of developing a design.
-    </div>
-  </div>,
-  <div>
-    <h4
-      class="arco-typography"
-      style="width:240px"
-    >
-      Ellipsis in flex scene
-    </h4>
-    <div
-      style="display:flex"
-    >
-      <div
-        class="arco-typography"
-        style="width:100%"
-      >
-         A design is a plan or specification for the construction of an object or system or for the implementation of an activity or process.----width: 100%
-      </div>
-    </div>
-    <div
-      style="display:flex"
-    >
-      <div
-        class="arco-typography"
-      >
-         A design is a plan or specification for the construction of an object or system or for the implementation of an activity or process.----width: normal
-      </div>
-    </div>
-  </div>,
-]
+    </span>
+  </div>
+  <div
+    class="arco-typography"
+  >
+    <span>
+       A design is a plan or specification for the construction of an object or system or for the implementation of an activity or process.---width: 100%
+    </span>
+  </div>
+</div>
 `;
 
 exports[`renders Typography/demo/ellipsis-controlled.md correctly 1`] = `
-Array [
+<div>
   <div
     class="arco-space arco-space-horizontal arco-space-align-start"
   >
@@ -499,7 +471,7 @@ Array [
         </div>
       </div>
     </div>
-  </div>,
+  </div>
   <div>
     <div
       class="arco-typography"
@@ -508,8 +480,8 @@ Array [
 implementation of an activity or process. A design is a plan or specification for the
 construction of an object or system or for the implementation of an activity or process. 
     </div>
-  </div>,
-]
+  </div>
+</div>
 `;
 
 exports[`renders Typography/demo/operations.md correctly 1`] = `

--- a/components/Typography/base.tsx
+++ b/components/Typography/base.tsx
@@ -91,6 +91,7 @@ function Base(props: BaseProps) {
     ? { rows: 1, ellipsisStr: '...', cssEllipsis: false, ...(isObject(ellipsis) ? ellipsis : {}) }
     : {};
 
+  const EllipsisWrapperTag = ellipsisConfig.wrapper || React.Fragment;
   const [expanding, setExpanding] = useMergeValue<boolean>(false, {
     defaultValue: ellipsisConfig.defaultExpanded,
     value: ellipsisConfig.expanded,
@@ -103,12 +104,12 @@ function Base(props: BaseProps) {
       : '...';
     const suffix = !isUndefined(ellipsisConfig.suffix) && ellipsisConfig.suffix;
     return (
-      <>
+      <EllipsisWrapperTag>
         {node}
         {isEllipsis && !expanding && !simpleEllipsis ? ellipsisStr : ''}
         {suffix}
         {renderOperations(isEllipsis)}
-      </>
+      </EllipsisWrapperTag>
     );
   };
 

--- a/components/Typography/interface.tsx
+++ b/components/Typography/interface.tsx
@@ -206,4 +206,8 @@ export type EllipsisConfig = {
    * @defaultValue false
    */
   defaultExpanded?: boolean;
+  // https://github.com/arco-design/arco-design/issues/1185
+  // https://github.com/facebook/react/issues/17256
+  // React.Fragment will cause the page to crash in special scenarios
+  wrapper?: string | React.FC<any> | React.ComponentClass<any>;
 };

--- a/components/Typography/useEllipsis.tsx
+++ b/components/Typography/useEllipsis.tsx
@@ -197,7 +197,7 @@ function useEllipsis(props: React.PropsWithChildren<IEllipsis>) {
   let ellipsisNode;
   if (status === MEASURE_STATUS.INIT || status === MEASURE_STATUS.BEFORE_MEASURE) {
     ellipsisNode = (
-      <>
+      <div>
         <div ref={singleRowNode} style={singleRowNodeStyle}>
           {status === MEASURE_STATUS.INIT
             ? MEASURE_LINE_HEIGHT_TEXT
@@ -206,17 +206,19 @@ function useEllipsis(props: React.PropsWithChildren<IEllipsis>) {
         <div ref={mirrorNode} style={{ width, ...mirrorNodeStyle }}>
           {renderMeasureContent(children, isEllipsis)}
         </div>
-      </>
+      </div>
     );
+    ellipsisNode = ellipsisNode.props.children;
   } else if (status === MEASURE_STATUS.MEASURING) {
     ellipsisNode = (
-      <>
+      <div>
         <div ref={mirrorNode} style={{ width, ...mirrorNodeStyle }}>
           {renderMeasureContent(getSlicedNode(midLoc), isEllipsis)}
         </div>
         {getSlicedNode(closedLoc.current)}
-      </>
+      </div>
     );
+    ellipsisNode = ellipsisNode.props.children;
   } else if (status === MEASURE_STATUS.MEASURE_END) {
     ellipsisNode = renderMeasureContent(getSlicedNode(midLoc), isEllipsis);
   } else if (status === MEASURE_STATUS.NO_NEED_ELLIPSIS) {


### PR DESCRIPTION
- 修复 Typography 省略在特殊场景下（网页自动翻译）时，React 内部报错导致白屏问题。
- 相关 issue: 
    - https://github.com/arco-design/arco-design/issues/1185
    - https://github.com/facebook/react/issues/17256
- 解决方式:
    - 新增 `ellipsis.wrapper` 参数，用户可以传入一个标签，替换 `React.Fragment`。
    - 解决方式略牵强，所以 `ellipsis.wrapper` 参数作为内部参数，不在 Api 文档开放。
    - 局限：经测验，在 `flex` 布局中，网页翻译仍会报错... 最优解可能还是要等 React 官方修复