### PR TITLE
enhancement: horizontal Menu auto ellipsis might get wrapped in some specific menu-width

### DIFF
--- a/components/Menu/__test__/index.test.tsx
+++ b/components/Menu/__test__/index.test.tsx
@@ -233,44 +233,6 @@ describe('Menu', () => {
     );
   });
 
-  it('overflowItems should be pack up', () => {
-    const props: MenuProps = {
-      defaultSelectedKeys: ['7'],
-      mode: 'horizontal',
-      style: { width: '600px' },
-    };
-    const wrapper = render(
-      <Menu {...props}>
-        <MenuItem key="1">设计指南</MenuItem>
-        <MenuItem key="2">区块</MenuItem>
-        <MenuItem key="3">模块</MenuItem>
-        <SubMenu key="wrapper" title={<span>组件</span>}>
-          <MenuItem key="4">通用组件</MenuItem>
-          <MenuItem key="5">布局组件</MenuItem>
-          <SubMenu key="nav" title={<span>导航组件</span>}>
-            <MenuItem key="6" disabled>
-              面包屑
-            </MenuItem>
-            <MenuItem key="7">垂直菜单</MenuItem>
-          </SubMenu>
-          <SubMenu key="dataInput" title={<span>数据输入</span>}>
-            <MenuItem key="8">单选框</MenuItem>
-            <MenuItem key="9">复选框</MenuItem>
-            <MenuItem key="10">输入框</MenuItem>
-          </SubMenu>
-        </SubMenu>
-        <SubMenu key="layout" title={<span>布局组件</span>}>
-          <MenuItem key="11">栅格</MenuItem>
-          <MenuItem key="12">分隔符</MenuItem>
-          <MenuItem key="13">布局</MenuItem>
-        </SubMenu>
-        <MenuItem key="15">工具</MenuItem>
-        <MenuItem key="14">主题实验室</MenuItem>
-      </Menu>
-    );
-    expect(wrapper.querySelectorAll('.arco-menu-overflow-hidden-menu-item')).toHaveLength(7);
-  });
-
   it('SubMenu properties are passed in correctly', () => {
     const wrapper = render(
       <Menu


### PR DESCRIPTION
## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [ ] Bug fix
- [x] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|  Menu  |  优化水平 `Menu` 宽度改变时自动折叠的表现，避免偶发的折行。  | Optimized the behavior of auto-folding when horizontal `Menu` width changes to avoid occasional line breaks.  |  Close #1322 |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->
## Checklist:

- [ ] Test suite passes (`npm run test`)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
