### PR TITLE
fix: disabled InputTag should also show placeholder

### DIFF
--- a/components/InputTag/style/index.less
+++ b/components/InputTag/style/index.less
@@ -83,7 +83,7 @@
     color: inherit;
     .text-ellipsis();
 
-    &[disabled] {
+    .@{prefix}-tag + &[disabled] {
       width: 0 !important;
     }
 
@@ -101,6 +101,7 @@
   }
 
   &-tag {
+    max-width: 100%;
     margin-right: @input-tag-tag-margin-right;
     font-size: @input-tag-tag-font-size;
   }


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|  InputTag |  修复 `InputTag` 设置 `disabled` 时 `placeholder` 未按预期展示的 bug。 |  Fixed the bug that `placeholder` was not displayed as expected when `InputTag` was set to `disabled`.  |                |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->
## Checklist:

- [ ] Test suite passes (`npm run test`)
- [x] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [x] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
