### PR TITLE
update: 修复type=capsule下Tabs disabled option仍有hover效果

### DIFF
--- a/components/Tabs/style/index.less
+++ b/components/Tabs/style/index.less
@@ -712,7 +712,7 @@
           background-color: var(~'@{arco-cssvars-prefix}-color-fill-3');
         }
 
-        &:hover {
+        &:not(&-disabled):hover {
           background-color: var(~'@{arco-cssvars-prefix}-color-fill-3');
         }
       }


### PR DESCRIPTION
修复暗黑模式下Tabs组件为type=capsule & disabled时仍有hover效果的问题

![image](https://user-images.githubusercontent.com/78004597/188213888-13dfc8e0-989b-44fe-837a-9d50fa3380ba.png)

修改后的视频：


https://user-images.githubusercontent.com/78004597/188213939-87d3522d-0e67-4f6b-8fd2-03d871040ee9.mp4



## Types of changes


- [ ] New feature
- [ ] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [x] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 


## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|     Tabs      |    修复深色模式下 `capsule` 类型的 `Tabs` 组件中禁用的 `TabPane` 标题区域的 hover 样式。        |   Fix disabled `TabPane` header area hover style in `Tabs` with `capsule` type in dark mode.    |      |

## Checklist:

- [x] Test suite passes (`npm run test`)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)


