### PR TITLE
enhancement: Statistic skip rendering dom of prefix when suffix is null/undefined

### DIFF
--- a/components/Statistic/__test__/__snapshots__/demo.test.ts.snap
+++ b/components/Statistic/__test__/__snapshots__/demo.test.ts.snap
@@ -20,9 +20,6 @@ exports[`renders Statistic/demo/basic.md correctly 1`] = `
         <span
           class="arco-statistic-value-int"
         >
-          <span
-            class="arco-statistic-value-prefix"
-          />
           125,670
         </span>
       </div>
@@ -40,9 +37,6 @@ exports[`renders Statistic/demo/basic.md correctly 1`] = `
         <span
           class="arco-statistic-value-int"
         >
-          <span
-            class="arco-statistic-value-prefix"
-          />
           40,509
         </span>
         <span
@@ -465,9 +459,6 @@ exports[`renders Statistic/demo/prefix_suffix.md correctly 1`] = `
         <span
           class="arco-statistic-value-int"
         >
-          <span
-            class="arco-statistic-value-prefix"
-          />
           192393
         </span>
         <span
@@ -528,9 +519,6 @@ exports[`renders Statistic/demo/prefix_suffix.md correctly 1`] = `
         <span
           class="arco-statistic-value-int"
         >
-          <span
-            class="arco-statistic-value-prefix"
-          />
           934230
         </span>
         <span
@@ -659,9 +647,6 @@ exports[`renders Statistic/demo/time.md correctly 1`] = `
       <span
         class="arco-statistic-value-int"
       >
-        <span
-          class="arco-statistic-value-prefix"
-        />
         2019/04/10 12:16:53
       </span>
     </div>

--- a/components/Statistic/index.tsx
+++ b/components/Statistic/index.tsx
@@ -136,7 +136,9 @@ function Statistic(baseProps: StatisticProps, ref) {
               valueFormatted(value, value)
             ) : (
               <span className={`${prefixCls}-value-int`}>
-                <span className={`${prefixCls}-value-prefix`}>{prefix}</span>
+                {prefix !== null && prefix !== undefined ? (
+                  <span className={`${prefixCls}-value-prefix`}>{prefix}</span>
+                ) : null}
                 {valueFormatted(value, int)}
               </span>
             )}
@@ -144,7 +146,9 @@ function Statistic(baseProps: StatisticProps, ref) {
             {decimal !== undefined || suffix ? (
               <span className={`${prefixCls}-value-decimal`}>
                 {isNumber(Number(value)) && decimal !== undefined && `.${decimal}`}
-                {suffix && <span className={`${prefixCls}-value-suffix`}>{suffix}</span>}
+                {suffix !== null && suffix !== undefined ? (
+                  <span className={`${prefixCls}-value-suffix`}>{suffix}</span>
+                ) : null}
               </span>
             ) : null}
           </div>


### PR DESCRIPTION
## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [ ] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [x] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
| Statistic | 修复 `Statistic` 不传 `prefix` / `suffix` 时，对应 dom 节点仍然渲染的 bug。 |  Fix the bug that the corresponding dom node still renders when `Statistic` does not pass `prefix` / `suffix`|                |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->
## Checklist:

- [ ] Test suite passes (`npm run test`)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
