### PR TITLE
enhance: avoid Space item mount again caused by react-key overwrite

### DIFF
--- a/components/Space/index.tsx
+++ b/components/Space/index.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, Fragment, forwardRef } from 'react';
+import React, { useContext, Fragment, forwardRef, ReactElement } from 'react';
 import cs from '../_util/classNames';
 import { ConfigContext } from '../ConfigProvider';
 import { isArray, isNumber } from '../_util/is';
@@ -93,9 +93,12 @@ function Space(baseProps: SpaceProps, ref) {
   return (
     <div ref={ref} className={classNames} style={style} {...rest}>
       {childrenList.map((child, index) => {
+        // Keep the key passed on the child to avoid additional DOM remounting
+        // Related issue: https://github.com/arco-design/arco-design/issues/1320
+        const key = (child as ReactElement)?.key || index;
         const shouldRenderSplit = split !== undefined && split !== null && index > 0;
         return (
-          <Fragment key={index}>
+          <Fragment key={key}>
             {shouldRenderSplit && <div className={`${prefixCls}-item-split`}>{split}</div>}
             <div className={`${prefixCls}-item`} style={getMarginStyle(index)}>
               {child}


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [ ] Bug fix
- [x] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 


## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
| Space |  优化 `Space` 的子元素在被指定的 `key` 值未发生变化时 DOM 节点却重新挂载的问题。  | Optimize the problem that the DOM node of `Space` is remounted when the specified `key` value has not changed.  |  Close #1320   |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->
## Checklist:

- [ ] Test suite passes (`npm run test`)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
