### PR TITLE
fix: InputTag render children twice due to ReactTransitionGroup

### DIFF
--- a/components/InputTag/input-tag.tsx
+++ b/components/InputTag/input-tag.tsx
@@ -362,8 +362,12 @@ function InputTag(baseProps: InputTagProps<string | ObjectValueType>, ref) {
       }}
     >
       <div className={`${prefixCls}-view`}>
-        <UsedTransitionGroup prefixCls={prefixCls} animation={animation}>
-          {draggable ? (
+        {draggable ? (
+          <UsedTransitionGroup
+            key="transitionGroupWithDrag"
+            prefixCls={prefixCls}
+            animation={animation}
+          >
             <Draggable
               itemWrapperStyle={{ display: 'inline-block' }}
               direction="horizontal"
@@ -380,10 +384,12 @@ function InputTag(baseProps: InputTagProps<string | ObjectValueType>, ref) {
             >
               {childrenWithAnimation}
             </Draggable>
-          ) : (
-            childrenWithAnimation
-          )}
-        </UsedTransitionGroup>
+          </UsedTransitionGroup>
+        ) : (
+          <UsedTransitionGroup prefixCls={prefixCls} animation={animation}>
+            {childrenWithAnimation}
+          </UsedTransitionGroup>
+        )}
 
         {hasSuffix && (
           <div className={`${prefixCls}-suffix`} onMouseDown={keepFocus}>


### PR DESCRIPTION
## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context

似乎是 react-transition-group 存在 bug，具体参考 https://github.com/reactjs/react-transition-group/issues/863。

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|   InputTag    |  修复 `InputTag` 组件开启 `dragToSort` 时，切换禁用状态时会将 Tag 重复渲染两遍的 bug。    |   Fixed the bug that when the `InputTag` component has enabled `dragToSort`, the tag will be rendered twice when the disabled state is toggled.  |     Close #1456     |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->
## Checklist:

- [ ] Test suite passes (`npm run test`)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
