### PR TITLE
enhancement: Select with width:auto not wroks as expect

### DIFF
--- a/components/BackTop/__test__/__snapshots__/demo.test.ts.snap
+++ b/components/BackTop/__test__/__snapshots__/demo.test.ts.snap
@@ -280,18 +280,22 @@ exports[`renders BackTop/demo/easing.md correctly 1`] = `
           class="arco-select-view"
           title="linear"
         >
-          <input
-            aria-hidden="true"
-            autocomplete="off"
-            class="arco-select-view-input arco-select-hidden"
-            style="width:100%;pointer-events:none"
-            tabindex="-1"
-            value="linear"
-          />
           <span
-            class="arco-select-view-value"
+            class="arco-select-view-selector"
           >
-            linear
+            <input
+              aria-hidden="true"
+              autocomplete="off"
+              class="arco-select-view-input arco-select-hidden"
+              style="width:100%;pointer-events:none"
+              tabindex="-1"
+              value="linear"
+            />
+            <span
+              class="arco-select-view-value"
+            >
+              linear
+            </span>
           </span>
           <div
             aria-hidden="true"

--- a/components/Calendar/__test__/__snapshots__/demo.test.ts.snap
+++ b/components/Calendar/__test__/__snapshots__/demo.test.ts.snap
@@ -3176,18 +3176,22 @@ exports[`renders Calendar/demo/select-header.md correctly 1`] = `
           <div
             class="arco-select-view"
           >
-            <input
-              aria-hidden="true"
-              autocomplete="off"
-              class="arco-select-view-input arco-select-hidden"
-              style="width:100%;pointer-events:none"
-              tabindex="-1"
-              value="2020"
-            />
             <span
-              class="arco-select-view-value"
+              class="arco-select-view-selector"
             >
-              2020
+              <input
+                aria-hidden="true"
+                autocomplete="off"
+                class="arco-select-view-input arco-select-hidden"
+                style="width:100%;pointer-events:none"
+                tabindex="-1"
+                value="2020"
+              />
+              <span
+                class="arco-select-view-value"
+              >
+                2020
+              </span>
             </span>
             <div
               aria-hidden="true"
@@ -3224,18 +3228,22 @@ exports[`renders Calendar/demo/select-header.md correctly 1`] = `
           <div
             class="arco-select-view"
           >
-            <input
-              aria-hidden="true"
-              autocomplete="off"
-              class="arco-select-view-input arco-select-hidden"
-              style="width:100%;pointer-events:none"
-              tabindex="-1"
-              value="4"
-            />
             <span
-              class="arco-select-view-value"
+              class="arco-select-view-selector"
             >
-              4
+              <input
+                aria-hidden="true"
+                autocomplete="off"
+                class="arco-select-view-input arco-select-hidden"
+                style="width:100%;pointer-events:none"
+                tabindex="-1"
+                value="4"
+              />
+              <span
+                class="arco-select-view-value"
+              >
+                4
+              </span>
             </span>
             <div
               aria-hidden="true"

--- a/components/Cascader/__test__/__snapshots__/demo.test.ts.snap
+++ b/components/Cascader/__test__/__snapshots__/demo.test.ts.snap
@@ -29,18 +29,23 @@ exports[`renders Cascader/demo/addon.md correctly 1`] = `
           class="arco-cascader-view"
           title=""
         >
-          <input
-            autocomplete="off"
-            class="arco-cascader-view-input"
-            placeholder="Please select ..."
-            style="width:100%;pointer-events:none"
-            tabindex="-1"
-            value=""
-          />
           <span
-            aria-hidden="true"
-            class="arco-cascader-view-value arco-cascader-hidden"
-          />
+            class="arco-cascader-view-selector"
+          >
+            <input
+              autocomplete="off"
+              class="arco-cascader-view-input"
+              placeholder="Please select ..."
+              style="width:100%;pointer-events:none"
+              tabindex="-1"
+              value=""
+            />
+            <span
+              class="arco-cascader-view-value arco-cascader-view-value-mirror"
+            >
+              Please select ...
+            </span>
+          </span>
           <div
             aria-hidden="true"
             class="arco-cascader-suffix"
@@ -164,18 +169,23 @@ exports[`renders Cascader/demo/basic.md correctly 1`] = `
         class="arco-cascader-view"
         title=""
       >
-        <input
-          autocomplete="off"
-          class="arco-cascader-view-input"
-          placeholder="Please select ..."
-          style="width:100%;pointer-events:none"
-          tabindex="-1"
-          value=""
-        />
         <span
-          aria-hidden="true"
-          class="arco-cascader-view-value arco-cascader-hidden"
-        />
+          class="arco-cascader-view-selector"
+        >
+          <input
+            autocomplete="off"
+            class="arco-cascader-view-input"
+            placeholder="Please select ..."
+            style="width:100%;pointer-events:none"
+            tabindex="-1"
+            value=""
+          />
+          <span
+            class="arco-cascader-view-value arco-cascader-view-value-mirror"
+          >
+            Please select ...
+          </span>
+        </span>
         <div
           aria-hidden="true"
           class="arco-cascader-suffix"
@@ -217,18 +227,23 @@ exports[`renders Cascader/demo/basic.md correctly 1`] = `
         class="arco-cascader-view"
         title=""
       >
-        <input
-          autocomplete="off"
-          class="arco-cascader-view-input"
-          placeholder="Hover to expand"
-          style="width:100%;pointer-events:none"
-          tabindex="-1"
-          value=""
-        />
         <span
-          aria-hidden="true"
-          class="arco-cascader-view-value arco-cascader-hidden"
-        />
+          class="arco-cascader-view-selector"
+        >
+          <input
+            autocomplete="off"
+            class="arco-cascader-view-input"
+            placeholder="Hover to expand"
+            style="width:100%;pointer-events:none"
+            tabindex="-1"
+            value=""
+          />
+          <span
+            class="arco-cascader-view-value arco-cascader-view-value-mirror"
+          >
+            Hover to expand
+          </span>
+        </span>
         <div
           aria-hidden="true"
           class="arco-cascader-suffix"
@@ -278,17 +293,22 @@ exports[`renders Cascader/demo/change_on_select.md correctly 1`] = `
         class="arco-cascader-view"
         title=""
       >
-        <input
-          autocomplete="off"
-          class="arco-cascader-view-input"
-          placeholder="Please select ..."
-          style="width:100%"
-          value=""
-        />
         <span
-          aria-hidden="true"
-          class="arco-cascader-view-value arco-cascader-hidden"
-        />
+          class="arco-cascader-view-selector"
+        >
+          <input
+            autocomplete="off"
+            class="arco-cascader-view-input"
+            placeholder="Please select ..."
+            style="width:100%"
+            value=""
+          />
+          <span
+            class="arco-cascader-view-value arco-cascader-view-value-mirror"
+          >
+            Please select ...
+          </span>
+        </span>
         <div
           aria-hidden="true"
           class="arco-cascader-suffix"
@@ -395,19 +415,23 @@ exports[`renders Cascader/demo/clear.md correctly 1`] = `
     class="arco-cascader-view"
     title="Shanghai / Shanghai / Huangpu"
   >
-    <input
-      aria-hidden="true"
-      autocomplete="off"
-      class="arco-cascader-view-input arco-cascader-hidden"
-      placeholder="Please select ..."
-      style="width:100%;pointer-events:none"
-      tabindex="-1"
-      value="Shanghai / Shanghai / Huangpu"
-    />
     <span
-      class="arco-cascader-view-value"
+      class="arco-cascader-view-selector"
     >
-      Shanghai / Shanghai / Huangpu
+      <input
+        aria-hidden="true"
+        autocomplete="off"
+        class="arco-cascader-view-input arco-cascader-hidden"
+        placeholder="Please select ..."
+        style="width:100%;pointer-events:none"
+        tabindex="-1"
+        value="Shanghai / Shanghai / Huangpu"
+      />
+      <span
+        class="arco-cascader-view-value"
+      >
+        Shanghai / Shanghai / Huangpu
+      </span>
     </span>
     <div
       aria-hidden="true"
@@ -473,17 +497,22 @@ exports[`renders Cascader/demo/control.md correctly 1`] = `
         class="arco-cascader-view"
         title=""
       >
-        <input
-          autocomplete="off"
-          class="arco-cascader-view-input"
-          placeholder="Please select ..."
-          style="width:100%"
-          value=""
-        />
         <span
-          aria-hidden="true"
-          class="arco-cascader-view-value arco-cascader-hidden"
-        />
+          class="arco-cascader-view-selector"
+        >
+          <input
+            autocomplete="off"
+            class="arco-cascader-view-input"
+            placeholder="Please select ..."
+            style="width:100%"
+            value=""
+          />
+          <span
+            class="arco-cascader-view-value arco-cascader-view-value-mirror"
+          >
+            Please select ...
+          </span>
+        </span>
         <div
           aria-hidden="true"
           class="arco-cascader-suffix"
@@ -614,18 +643,22 @@ exports[`renders Cascader/demo/disabled.md correctly 1`] = `
         class="arco-cascader-view"
         title="Beijing / Beijing / Dongcheng / Chaoyangmen"
       >
-        <input
-          aria-hidden="true"
-          autocomplete="off"
-          class="arco-cascader-view-input arco-cascader-hidden"
-          placeholder="Beijing / Beijing / Dongcheng / Chaoyangmen"
-          style="width:100%"
-          value="Beijing / Beijing / Dongcheng / Chaoyangmen"
-        />
         <span
-          class="arco-cascader-view-value"
+          class="arco-cascader-view-selector"
         >
-          Beijing / Beijing / Dongcheng / Chaoyangmen
+          <input
+            aria-hidden="true"
+            autocomplete="off"
+            class="arco-cascader-view-input arco-cascader-hidden"
+            placeholder="Beijing / Beijing / Dongcheng / Chaoyangmen"
+            style="width:100%"
+            value="Beijing / Beijing / Dongcheng / Chaoyangmen"
+          />
+          <span
+            class="arco-cascader-view-value"
+          >
+            Beijing / Beijing / Dongcheng / Chaoyangmen
+          </span>
         </span>
         <div
           aria-hidden="true"
@@ -916,18 +949,23 @@ exports[`renders Cascader/demo/dropdown.md correctly 1`] = `
         class="arco-cascader-view"
         title=""
       >
-        <input
-          autocomplete="off"
-          class="arco-cascader-view-input"
-          placeholder="Please select ..."
-          style="width:100%;pointer-events:none"
-          tabindex="-1"
-          value=""
-        />
         <span
-          aria-hidden="true"
-          class="arco-cascader-view-value arco-cascader-hidden"
-        />
+          class="arco-cascader-view-selector"
+        >
+          <input
+            autocomplete="off"
+            class="arco-cascader-view-input"
+            placeholder="Please select ..."
+            style="width:100%;pointer-events:none"
+            tabindex="-1"
+            value=""
+          />
+          <span
+            class="arco-cascader-view-value arco-cascader-view-value-mirror"
+          >
+            Please select ...
+          </span>
+        </span>
         <div
           aria-hidden="true"
           class="arco-cascader-suffix"
@@ -969,17 +1007,20 @@ exports[`renders Cascader/demo/dropdown.md correctly 1`] = `
         class="arco-cascader-view"
         title=""
       >
-        <input
-          autocomplete="off"
-          class="arco-cascader-view-input"
-          style="width:100%;pointer-events:none"
-          tabindex="-1"
-          value=""
-        />
         <span
-          aria-hidden="true"
-          class="arco-cascader-view-value arco-cascader-hidden"
-        />
+          class="arco-cascader-view-selector"
+        >
+          <input
+            autocomplete="off"
+            class="arco-cascader-view-input"
+            style="width:100%;pointer-events:none"
+            tabindex="-1"
+            value=""
+          />
+          <span
+            class="arco-cascader-view-value arco-cascader-view-value-mirror"
+          />
+        </span>
         <div
           aria-hidden="true"
           class="arco-cascader-suffix"
@@ -1139,18 +1180,22 @@ exports[`renders Cascader/demo/filter_option.md correctly 1`] = `
         class="arco-cascader-view"
         title="Shanghai / Shanghai / Huangpu"
       >
-        <input
-          aria-hidden="true"
-          autocomplete="off"
-          class="arco-cascader-view-input arco-cascader-hidden"
-          placeholder="Shanghai / Shanghai / Huangpu"
-          style="width:100%"
-          value="Shanghai / Shanghai / Huangpu"
-        />
         <span
-          class="arco-cascader-view-value"
+          class="arco-cascader-view-selector"
         >
-          Shanghai / Shanghai / Huangpu
+          <input
+            aria-hidden="true"
+            autocomplete="off"
+            class="arco-cascader-view-input arco-cascader-hidden"
+            placeholder="Shanghai / Shanghai / Huangpu"
+            style="width:100%"
+            value="Shanghai / Shanghai / Huangpu"
+          />
+          <span
+            class="arco-cascader-view-value"
+          >
+            Shanghai / Shanghai / Huangpu
+          </span>
         </span>
         <div
           aria-hidden="true"
@@ -1327,18 +1372,22 @@ exports[`renders Cascader/demo/footer.md correctly 1`] = `
         class="arco-cascader-view"
         title="Shanghai / Shanghai / Huangpu"
       >
-        <input
-          aria-hidden="true"
-          autocomplete="off"
-          class="arco-cascader-view-input arco-cascader-hidden"
-          placeholder="Shanghai / Shanghai / Huangpu"
-          style="width:100%"
-          value="Shanghai / Shanghai / Huangpu"
-        />
         <span
-          class="arco-cascader-view-value"
+          class="arco-cascader-view-selector"
         >
-          Shanghai / Shanghai / Huangpu
+          <input
+            aria-hidden="true"
+            autocomplete="off"
+            class="arco-cascader-view-input arco-cascader-hidden"
+            placeholder="Shanghai / Shanghai / Huangpu"
+            style="width:100%"
+            value="Shanghai / Shanghai / Huangpu"
+          />
+          <span
+            class="arco-cascader-view-value"
+          >
+            Shanghai / Shanghai / Huangpu
+          </span>
         </span>
         <div
           aria-hidden="true"
@@ -1508,19 +1557,23 @@ exports[`renders Cascader/demo/format.md correctly 1`] = `
     class="arco-cascader-view"
     title="Shanghai > Shanghai > Huangpu"
   >
-    <input
-      aria-hidden="true"
-      autocomplete="off"
-      class="arco-cascader-view-input arco-cascader-hidden"
-      placeholder="Please select ..."
-      style="width:100%;pointer-events:none"
-      tabindex="-1"
-      value="Shanghai > Shanghai > Huangpu"
-    />
     <span
-      class="arco-cascader-view-value"
+      class="arco-cascader-view-selector"
     >
-      Shanghai &gt; Shanghai &gt; Huangpu
+      <input
+        aria-hidden="true"
+        autocomplete="off"
+        class="arco-cascader-view-input arco-cascader-hidden"
+        placeholder="Please select ..."
+        style="width:100%;pointer-events:none"
+        tabindex="-1"
+        value="Shanghai > Shanghai > Huangpu"
+      />
+      <span
+        class="arco-cascader-view-value"
+      >
+        Shanghai &gt; Shanghai &gt; Huangpu
+      </span>
     </span>
     <div
       aria-hidden="true"
@@ -1586,17 +1639,22 @@ exports[`renders Cascader/demo/loadmore.md correctly 1`] = `
         class="arco-cascader-view"
         title=""
       >
-        <input
-          autocomplete="off"
-          class="arco-cascader-view-input"
-          placeholder="Please select ..."
-          style="width:100%"
-          value=""
-        />
         <span
-          aria-hidden="true"
-          class="arco-cascader-view-value arco-cascader-hidden"
-        />
+          class="arco-cascader-view-selector"
+        >
+          <input
+            autocomplete="off"
+            class="arco-cascader-view-input"
+            placeholder="Please select ..."
+            style="width:100%"
+            value=""
+          />
+          <span
+            class="arco-cascader-view-value arco-cascader-view-value-mirror"
+          >
+            Please select ...
+          </span>
+        </span>
         <div
           aria-hidden="true"
           class="arco-cascader-suffix"
@@ -1913,17 +1971,22 @@ exports[`renders Cascader/demo/onSearch.md correctly 1`] = `
           class="arco-cascader-view"
           title=""
         >
-          <input
-            autocomplete="off"
-            class="arco-cascader-view-input"
-            placeholder="Please enter ..."
-            style="width:100%"
-            value=""
-          />
           <span
-            aria-hidden="true"
-            class="arco-cascader-view-value arco-cascader-hidden"
-          />
+            class="arco-cascader-view-selector"
+          >
+            <input
+              autocomplete="off"
+              class="arco-cascader-view-input"
+              placeholder="Please enter ..."
+              style="width:100%"
+              value=""
+            />
+            <span
+              class="arco-cascader-view-value arco-cascader-view-value-mirror"
+            >
+              Please enter ...
+            </span>
+          </span>
           <div
             aria-hidden="true"
             class="arco-cascader-suffix"
@@ -2038,18 +2101,22 @@ exports[`renders Cascader/demo/render_option.md correctly 1`] = `
         class="arco-cascader-view"
         title="Shanghai / Shanghai / Huangpu"
       >
-        <input
-          aria-hidden="true"
-          autocomplete="off"
-          class="arco-cascader-view-input arco-cascader-hidden"
-          placeholder="Shanghai / Shanghai / Huangpu"
-          style="width:100%"
-          value="Shanghai / Shanghai / Huangpu"
-        />
         <span
-          class="arco-cascader-view-value"
+          class="arco-cascader-view-selector"
         >
-          Shanghai / Shanghai / Huangpu
+          <input
+            aria-hidden="true"
+            autocomplete="off"
+            class="arco-cascader-view-input arco-cascader-hidden"
+            placeholder="Shanghai / Shanghai / Huangpu"
+            style="width:100%"
+            value="Shanghai / Shanghai / Huangpu"
+          />
+          <span
+            class="arco-cascader-view-value"
+          >
+            Shanghai / Shanghai / Huangpu
+          </span>
         </span>
         <div
           aria-hidden="true"
@@ -2192,18 +2259,22 @@ exports[`renders Cascader/demo/search.md correctly 1`] = `
         class="arco-cascader-view"
         title="Shanghai / Shanghai / Huangpu"
       >
-        <input
-          aria-hidden="true"
-          autocomplete="off"
-          class="arco-cascader-view-input arco-cascader-hidden"
-          placeholder="Shanghai / Shanghai / Huangpu"
-          style="width:100%"
-          value="Shanghai / Shanghai / Huangpu"
-        />
         <span
-          class="arco-cascader-view-value"
+          class="arco-cascader-view-selector"
         >
-          Shanghai / Shanghai / Huangpu
+          <input
+            aria-hidden="true"
+            autocomplete="off"
+            class="arco-cascader-view-input arco-cascader-hidden"
+            placeholder="Shanghai / Shanghai / Huangpu"
+            style="width:100%"
+            value="Shanghai / Shanghai / Huangpu"
+          />
+          <span
+            class="arco-cascader-view-value"
+          >
+            Shanghai / Shanghai / Huangpu
+          </span>
         </span>
         <div
           aria-hidden="true"
@@ -2412,17 +2483,22 @@ exports[`renders Cascader/demo/showEmptyChildren.md correctly 1`] = `
       class="arco-cascader-view"
       title=""
     >
-      <input
-        autocomplete="off"
-        class="arco-cascader-view-input"
-        placeholder="Please select ..."
-        style="width:100%"
-        value=""
-      />
       <span
-        aria-hidden="true"
-        class="arco-cascader-view-value arco-cascader-hidden"
-      />
+        class="arco-cascader-view-selector"
+      >
+        <input
+          autocomplete="off"
+          class="arco-cascader-view-input"
+          placeholder="Please select ..."
+          style="width:100%"
+          value=""
+        />
+        <span
+          class="arco-cascader-view-value arco-cascader-view-value-mirror"
+        >
+          Please select ...
+        </span>
+      </span>
       <div
         aria-hidden="true"
         class="arco-cascader-suffix"
@@ -2529,18 +2605,23 @@ exports[`renders Cascader/demo/size.md correctly 1`] = `
         class="arco-cascader-view"
         title=""
       >
-        <input
-          autocomplete="off"
-          class="arco-cascader-view-input"
-          placeholder="Please select ..."
-          style="width:100%;pointer-events:none"
-          tabindex="-1"
-          value=""
-        />
         <span
-          aria-hidden="true"
-          class="arco-cascader-view-value arco-cascader-hidden"
-        />
+          class="arco-cascader-view-selector"
+        >
+          <input
+            autocomplete="off"
+            class="arco-cascader-view-input"
+            placeholder="Please select ..."
+            style="width:100%;pointer-events:none"
+            tabindex="-1"
+            value=""
+          />
+          <span
+            class="arco-cascader-view-value arco-cascader-view-value-mirror"
+          >
+            Please select ...
+          </span>
+        </span>
         <div
           aria-hidden="true"
           class="arco-cascader-suffix"
@@ -2656,18 +2737,23 @@ exports[`renders Cascader/demo/visible.md correctly 1`] = `
       class="arco-cascader-view"
       title=""
     >
-      <input
-        autocomplete="off"
-        class="arco-cascader-view-input"
-        placeholder="Please select ..."
-        style="width:100%;pointer-events:none"
-        tabindex="-1"
-        value=""
-      />
       <span
-        aria-hidden="true"
-        class="arco-cascader-view-value arco-cascader-hidden"
-      />
+        class="arco-cascader-view-selector"
+      >
+        <input
+          autocomplete="off"
+          class="arco-cascader-view-input"
+          placeholder="Please select ..."
+          style="width:100%;pointer-events:none"
+          tabindex="-1"
+          value=""
+        />
+        <span
+          class="arco-cascader-view-value arco-cascader-view-value-mirror"
+        >
+          Please select ...
+        </span>
+      </span>
       <div
         aria-hidden="true"
         class="arco-cascader-suffix"

--- a/components/Cascader/__test__/__snapshots__/index.test.tsx.snap
+++ b/components/Cascader/__test__/__snapshots__/index.test.tsx.snap
@@ -13,17 +13,20 @@ exports[`ConfigProvider componentConfig.Cascader default 1`] = `
     class="arco-cascader-view"
     title=""
   >
-    <input
-      autocomplete="off"
-      class="arco-cascader-view-input"
-      style="width:100%;pointer-events:none"
-      tabindex="-1"
-      value=""
-    />
     <span
-      aria-hidden="true"
-      class="arco-cascader-view-value arco-cascader-hidden"
-    />
+      class="arco-cascader-view-selector"
+    >
+      <input
+        autocomplete="off"
+        class="arco-cascader-view-input"
+        style="width:100%;pointer-events:none"
+        tabindex="-1"
+        value=""
+      />
+      <span
+        class="arco-cascader-view-value arco-cascader-view-value-mirror"
+      />
+    </span>
     <div
       aria-hidden="true"
       class="arco-cascader-suffix"
@@ -63,17 +66,20 @@ exports[`ConfigProvider componentConfig.Cascader set className globally 1`] = `
     class="arco-cascader-view"
     title=""
   >
-    <input
-      autocomplete="off"
-      class="arco-cascader-view-input"
-      style="width:100%;pointer-events:none"
-      tabindex="-1"
-      value=""
-    />
     <span
-      aria-hidden="true"
-      class="arco-cascader-view-value arco-cascader-hidden"
-    />
+      class="arco-cascader-view-selector"
+    >
+      <input
+        autocomplete="off"
+        class="arco-cascader-view-input"
+        style="width:100%;pointer-events:none"
+        tabindex="-1"
+        value=""
+      />
+      <span
+        class="arco-cascader-view-value arco-cascader-view-value-mirror"
+      />
+    </span>
     <div
       aria-hidden="true"
       class="arco-cascader-suffix"
@@ -113,17 +119,20 @@ exports[`ConfigProvider componentConfig.Cascader set className globally and comp
     class="arco-cascader-view"
     title=""
   >
-    <input
-      autocomplete="off"
-      class="arco-cascader-view-input"
-      style="width:100%;pointer-events:none"
-      tabindex="-1"
-      value=""
-    />
     <span
-      aria-hidden="true"
-      class="arco-cascader-view-value arco-cascader-hidden"
-    />
+      class="arco-cascader-view-selector"
+    >
+      <input
+        autocomplete="off"
+        class="arco-cascader-view-input"
+        style="width:100%;pointer-events:none"
+        tabindex="-1"
+        value=""
+      />
+      <span
+        class="arco-cascader-view-value arco-cascader-view-value-mirror"
+      />
+    </span>
     <div
       aria-hidden="true"
       class="arco-cascader-suffix"
@@ -164,17 +173,20 @@ exports[`ConfigProvider componentConfig.Cascader set data-* property 1`] = `
     class="arco-cascader-view"
     title=""
   >
-    <input
-      autocomplete="off"
-      class="arco-cascader-view-input"
-      style="width:100%;pointer-events:none"
-      tabindex="-1"
-      value=""
-    />
     <span
-      aria-hidden="true"
-      class="arco-cascader-view-value arco-cascader-hidden"
-    />
+      class="arco-cascader-view-selector"
+    >
+      <input
+        autocomplete="off"
+        class="arco-cascader-view-input"
+        style="width:100%;pointer-events:none"
+        tabindex="-1"
+        value=""
+      />
+      <span
+        class="arco-cascader-view-value arco-cascader-view-value-mirror"
+      />
+    </span>
     <div
       aria-hidden="true"
       class="arco-cascader-suffix"

--- a/components/ConfigProvider/__test__/__snapshots__/demo.test.ts.snap
+++ b/components/ConfigProvider/__test__/__snapshots__/demo.test.ts.snap
@@ -311,18 +311,22 @@ Array [
           class="arco-select-view"
           title="10 条/页"
         >
-          <input
-            aria-hidden="true"
-            autocomplete="off"
-            class="arco-select-view-input arco-select-hidden"
-            style="width:100%;pointer-events:none"
-            tabindex="-1"
-            value="10 条/页"
-          />
           <span
-            class="arco-select-view-value"
+            class="arco-select-view-selector"
           >
-            10 条/页
+            <input
+              aria-hidden="true"
+              autocomplete="off"
+              class="arco-select-view-input arco-select-hidden"
+              style="width:100%;pointer-events:none"
+              tabindex="-1"
+              value="10 条/页"
+            />
+            <span
+              class="arco-select-view-value"
+            >
+              10 条/页
+            </span>
           </span>
           <div
             aria-hidden="true"
@@ -1164,18 +1168,23 @@ Array [
           class="arco-cascader-view"
           title=""
         >
-          <input
-            autocomplete="off"
-            class="arco-cascader-view-input"
-            placeholder="Cascader"
-            style="width:100%;pointer-events:none"
-            tabindex="-1"
-            value=""
-          />
           <span
-            aria-hidden="true"
-            class="arco-cascader-view-value arco-cascader-hidden"
-          />
+            class="arco-cascader-view-selector"
+          >
+            <input
+              autocomplete="off"
+              class="arco-cascader-view-input"
+              placeholder="Cascader"
+              style="width:100%;pointer-events:none"
+              tabindex="-1"
+              value=""
+            />
+            <span
+              class="arco-cascader-view-value arco-cascader-view-value-mirror"
+            >
+              Cascader
+            </span>
+          </span>
           <div
             aria-hidden="true"
             class="arco-cascader-suffix"
@@ -1218,18 +1227,23 @@ Array [
           class="arco-select-view"
           title=""
         >
-          <input
-            autocomplete="off"
-            class="arco-select-view-input"
-            placeholder="Select"
-            style="width:100%;pointer-events:none"
-            tabindex="-1"
-            value=""
-          />
           <span
-            aria-hidden="true"
-            class="arco-select-view-value arco-select-hidden"
-          />
+            class="arco-select-view-selector"
+          >
+            <input
+              autocomplete="off"
+              class="arco-select-view-input"
+              placeholder="Select"
+              style="width:100%;pointer-events:none"
+              tabindex="-1"
+              value=""
+            />
+            <span
+              class="arco-select-view-value arco-select-view-value-mirror"
+            >
+              Select
+            </span>
+          </span>
           <div
             aria-hidden="true"
             class="arco-select-suffix"
@@ -1271,18 +1285,23 @@ Array [
           class="arco-tree-select-view"
           title=""
         >
-          <input
-            autocomplete="off"
-            class="arco-tree-select-view-input"
-            placeholder="TreeSelect"
-            style="width:100%;pointer-events:none"
-            tabindex="-1"
-            value=""
-          />
           <span
-            aria-hidden="true"
-            class="arco-tree-select-view-value arco-tree-select-hidden"
-          />
+            class="arco-tree-select-view-selector"
+          >
+            <input
+              autocomplete="off"
+              class="arco-tree-select-view-input"
+              placeholder="TreeSelect"
+              style="width:100%;pointer-events:none"
+              tabindex="-1"
+              value=""
+            />
+            <span
+              class="arco-tree-select-view-value arco-tree-select-view-value-mirror"
+            >
+              TreeSelect
+            </span>
+          </span>
           <div
             aria-hidden="true"
             class="arco-tree-select-suffix"
@@ -1960,18 +1979,22 @@ exports[`renders ConfigProvider/demo/rtl.md correctly 1`] = `
               class="arco-select-view"
               title="10 条/页"
             >
-              <input
-                aria-hidden="true"
-                autocomplete="off"
-                class="arco-select-view-input arco-select-hidden"
-                style="width:100%;pointer-events:none"
-                tabindex="-1"
-                value="10 条/页"
-              />
               <span
-                class="arco-select-view-value"
+                class="arco-select-view-selector"
               >
-                10 条/页
+                <input
+                  aria-hidden="true"
+                  autocomplete="off"
+                  class="arco-select-view-input arco-select-hidden"
+                  style="width:100%;pointer-events:none"
+                  tabindex="-1"
+                  value="10 条/页"
+                />
+                <span
+                  class="arco-select-view-value"
+                >
+                  10 条/页
+                </span>
               </span>
               <div
                 aria-hidden="true"

--- a/components/DatePicker/__test__/__snapshots__/demo.test.ts.snap
+++ b/components/DatePicker/__test__/__snapshots__/demo.test.ts.snap
@@ -4088,18 +4088,22 @@ exports[`renders DatePicker/demo/timezone.md correctly 1`] = `
             class="arco-select-view"
             title="Asia/Shanghai"
           >
-            <input
-              aria-hidden="true"
-              autocomplete="off"
-              class="arco-select-view-input arco-select-hidden"
-              style="width:100%;pointer-events:none"
-              tabindex="-1"
-              value="Asia/Shanghai"
-            />
             <span
-              class="arco-select-view-value"
+              class="arco-select-view-selector"
             >
-              Asia/Shanghai
+              <input
+                aria-hidden="true"
+                autocomplete="off"
+                class="arco-select-view-input arco-select-hidden"
+                style="width:100%;pointer-events:none"
+                tabindex="-1"
+                value="Asia/Shanghai"
+              />
+              <span
+                class="arco-select-view-value"
+              >
+                Asia/Shanghai
+              </span>
             </span>
             <div
               aria-hidden="true"
@@ -4486,18 +4490,22 @@ exports[`renders DatePicker/demo/utcOffset.md correctly 1`] = `
             class="arco-select-view"
             title="UTC "
           >
-            <input
-              aria-hidden="true"
-              autocomplete="off"
-              class="arco-select-view-input arco-select-hidden"
-              style="width:100%;pointer-events:none"
-              tabindex="-1"
-              value="UTC "
-            />
             <span
-              class="arco-select-view-value"
+              class="arco-select-view-selector"
             >
-              UTC 
+              <input
+                aria-hidden="true"
+                autocomplete="off"
+                class="arco-select-view-input arco-select-hidden"
+                style="width:100%;pointer-events:none"
+                tabindex="-1"
+                value="UTC "
+              />
+              <span
+                class="arco-select-view-value"
+              >
+                UTC 
+              </span>
             </span>
             <div
               aria-hidden="true"

--- a/components/Form/__test__/__snapshots__/demo.test.ts.snap
+++ b/components/Form/__test__/__snapshots__/demo.test.ts.snap
@@ -553,17 +553,22 @@ exports[`renders Form/demo/control.md correctly 1`] = `
                   class="arco-cascader-view"
                   title=""
                 >
-                  <input
-                    autocomplete="off"
-                    class="arco-cascader-view-input"
-                    placeholder="please select"
-                    style="width:100%"
-                    value=""
-                  />
                   <span
-                    aria-hidden="true"
-                    class="arco-cascader-view-value arco-cascader-hidden"
-                  />
+                    class="arco-cascader-view-selector"
+                  >
+                    <input
+                      autocomplete="off"
+                      class="arco-cascader-view-input"
+                      placeholder="please select"
+                      style="width:100%"
+                      value=""
+                    />
+                    <span
+                      class="arco-cascader-view-value arco-cascader-view-value-mirror"
+                    >
+                      please select
+                    </span>
+                  </span>
                   <div
                     aria-hidden="true"
                     class="arco-cascader-suffix"
@@ -711,18 +716,23 @@ exports[`renders Form/demo/control.md correctly 1`] = `
                   class="arco-select-view"
                   title=""
                 >
-                  <input
-                    autocomplete="off"
-                    class="arco-select-view-input"
-                    placeholder="please select"
-                    style="width:100%;pointer-events:none"
-                    tabindex="-1"
-                    value=""
-                  />
                   <span
-                    aria-hidden="true"
-                    class="arco-select-view-value arco-select-hidden"
-                  />
+                    class="arco-select-view-selector"
+                  >
+                    <input
+                      autocomplete="off"
+                      class="arco-select-view-input"
+                      placeholder="please select"
+                      style="width:100%;pointer-events:none"
+                      tabindex="-1"
+                      value=""
+                    />
+                    <span
+                      class="arco-select-view-value arco-select-view-value-mirror"
+                    >
+                      please select
+                    </span>
+                  </span>
                   <div
                     aria-hidden="true"
                     class="arco-select-suffix"
@@ -934,18 +944,23 @@ exports[`renders Form/demo/control.md correctly 1`] = `
                   class="arco-tree-select-view"
                   title=""
                 >
-                  <input
-                    autocomplete="off"
-                    class="arco-tree-select-view-input"
-                    placeholder="please select"
-                    style="width:100%;pointer-events:none"
-                    tabindex="-1"
-                    value=""
-                  />
                   <span
-                    aria-hidden="true"
-                    class="arco-tree-select-view-value arco-tree-select-hidden"
-                  />
+                    class="arco-tree-select-view-selector"
+                  >
+                    <input
+                      autocomplete="off"
+                      class="arco-tree-select-view-input"
+                      placeholder="please select"
+                      style="width:100%;pointer-events:none"
+                      tabindex="-1"
+                      value=""
+                    />
+                    <span
+                      class="arco-tree-select-view-value arco-tree-select-view-value-mirror"
+                    >
+                      please select
+                    </span>
+                  </span>
                   <div
                     aria-hidden="true"
                     class="arco-tree-select-suffix"
@@ -2038,18 +2053,23 @@ exports[`renders Form/demo/custom.md correctly 1`] = `
                         class="arco-select-view"
                         title=""
                       >
-                        <input
-                          autocomplete="off"
-                          class="arco-select-view-input"
-                          placeholder="Please select ..."
-                          style="width:100%;pointer-events:none"
-                          tabindex="-1"
-                          value=""
-                        />
                         <span
-                          aria-hidden="true"
-                          class="arco-select-view-value arco-select-hidden"
-                        />
+                          class="arco-select-view-selector"
+                        >
+                          <input
+                            autocomplete="off"
+                            class="arco-select-view-input"
+                            placeholder="Please select ..."
+                            style="width:100%;pointer-events:none"
+                            tabindex="-1"
+                            value=""
+                          />
+                          <span
+                            class="arco-select-view-value arco-select-view-value-mirror"
+                          >
+                            Please select ...
+                          </span>
+                        </span>
                         <div
                           aria-hidden="true"
                           class="arco-select-suffix"
@@ -2412,18 +2432,23 @@ exports[`renders Form/demo/disabled.md correctly 1`] = `
                   class="arco-cascader-view"
                   title=""
                 >
-                  <input
-                    autocomplete="off"
-                    class="arco-cascader-view-input"
-                    disabled=""
-                    placeholder="please select"
-                    style="width:100%"
-                    value=""
-                  />
                   <span
-                    aria-hidden="true"
-                    class="arco-cascader-view-value arco-cascader-hidden"
-                  />
+                    class="arco-cascader-view-selector"
+                  >
+                    <input
+                      autocomplete="off"
+                      class="arco-cascader-view-input"
+                      disabled=""
+                      placeholder="please select"
+                      style="width:100%"
+                      value=""
+                    />
+                    <span
+                      class="arco-cascader-view-value arco-cascader-view-value-mirror"
+                    >
+                      please select
+                    </span>
+                  </span>
                   <div
                     aria-hidden="true"
                     class="arco-cascader-suffix"
@@ -2573,19 +2598,24 @@ exports[`renders Form/demo/disabled.md correctly 1`] = `
                   class="arco-select-view"
                   title=""
                 >
-                  <input
-                    autocomplete="off"
-                    class="arco-select-view-input"
-                    disabled=""
-                    placeholder="please select"
-                    style="width:100%;pointer-events:none"
-                    tabindex="-1"
-                    value=""
-                  />
                   <span
-                    aria-hidden="true"
-                    class="arco-select-view-value arco-select-hidden"
-                  />
+                    class="arco-select-view-selector"
+                  >
+                    <input
+                      autocomplete="off"
+                      class="arco-select-view-input"
+                      disabled=""
+                      placeholder="please select"
+                      style="width:100%;pointer-events:none"
+                      tabindex="-1"
+                      value=""
+                    />
+                    <span
+                      class="arco-select-view-value arco-select-view-value-mirror"
+                    >
+                      please select
+                    </span>
+                  </span>
                   <div
                     aria-hidden="true"
                     class="arco-select-suffix"
@@ -3887,18 +3917,23 @@ exports[`renders Form/demo/form-provider.md correctly 1`] = `
                       class="arco-select-view"
                       title=""
                     >
-                      <input
-                        autocomplete="off"
-                        class="arco-select-view-input"
-                        placeholder="select gender"
-                        style="width:100%;pointer-events:none"
-                        tabindex="-1"
-                        value=""
-                      />
                       <span
-                        aria-hidden="true"
-                        class="arco-select-view-value arco-select-hidden"
-                      />
+                        class="arco-select-view-selector"
+                      >
+                        <input
+                          autocomplete="off"
+                          class="arco-select-view-input"
+                          placeholder="select gender"
+                          style="width:100%;pointer-events:none"
+                          tabindex="-1"
+                          value=""
+                        />
+                        <span
+                          class="arco-select-view-value arco-select-view-value-mirror"
+                        >
+                          select gender
+                        </span>
+                      </span>
                       <div
                         aria-hidden="true"
                         class="arco-select-suffix"
@@ -5909,18 +5944,23 @@ exports[`renders Form/demo/nest-form-item.md correctly 1`] = `
                     class="arco-select-view"
                     title=""
                   >
-                    <input
-                      autocomplete="off"
-                      class="arco-select-view-input"
-                      placeholder="please enter you gender"
-                      style="width:100%;pointer-events:none"
-                      tabindex="-1"
-                      value=""
-                    />
                     <span
-                      aria-hidden="true"
-                      class="arco-select-view-value arco-select-hidden"
-                    />
+                      class="arco-select-view-selector"
+                    >
+                      <input
+                        autocomplete="off"
+                        class="arco-select-view-input"
+                        placeholder="please enter you gender"
+                        style="width:100%;pointer-events:none"
+                        tabindex="-1"
+                        value=""
+                      />
+                      <span
+                        class="arco-select-view-value arco-select-view-value-mirror"
+                      >
+                        please enter you gender
+                      </span>
+                    </span>
                     <div
                       aria-hidden="true"
                       class="arco-select-suffix"
@@ -6016,18 +6056,23 @@ exports[`renders Form/demo/nest-form-item.md correctly 1`] = `
                   class="arco-select-view"
                   title=""
                 >
-                  <input
-                    autocomplete="off"
-                    class="arco-select-view-input"
-                    placeholder="please select"
-                    style="width:100%;pointer-events:none"
-                    tabindex="-1"
-                    value=""
-                  />
                   <span
-                    aria-hidden="true"
-                    class="arco-select-view-value arco-select-hidden"
-                  />
+                    class="arco-select-view-selector"
+                  >
+                    <input
+                      autocomplete="off"
+                      class="arco-select-view-input"
+                      placeholder="please select"
+                      style="width:100%;pointer-events:none"
+                      tabindex="-1"
+                      value=""
+                    />
+                    <span
+                      class="arco-select-view-value arco-select-view-value-mirror"
+                    >
+                      please select
+                    </span>
+                  </span>
                   <div
                     aria-hidden="true"
                     class="arco-select-suffix"
@@ -7285,17 +7330,22 @@ exports[`renders Form/demo/size.md correctly 1`] = `
                   class="arco-cascader-view"
                   title=""
                 >
-                  <input
-                    autocomplete="off"
-                    class="arco-cascader-view-input"
-                    placeholder="please select"
-                    style="width:100%"
-                    value=""
-                  />
                   <span
-                    aria-hidden="true"
-                    class="arco-cascader-view-value arco-cascader-hidden"
-                  />
+                    class="arco-cascader-view-selector"
+                  >
+                    <input
+                      autocomplete="off"
+                      class="arco-cascader-view-input"
+                      placeholder="please select"
+                      style="width:100%"
+                      value=""
+                    />
+                    <span
+                      class="arco-cascader-view-value arco-cascader-view-value-mirror"
+                    >
+                      please select
+                    </span>
+                  </span>
                   <div
                     aria-hidden="true"
                     class="arco-cascader-suffix"
@@ -7409,18 +7459,23 @@ exports[`renders Form/demo/size.md correctly 1`] = `
                   class="arco-select-view"
                   title=""
                 >
-                  <input
-                    autocomplete="off"
-                    class="arco-select-view-input"
-                    placeholder="please select"
-                    style="width:100%;pointer-events:none"
-                    tabindex="-1"
-                    value=""
-                  />
                   <span
-                    aria-hidden="true"
-                    class="arco-select-view-value arco-select-hidden"
-                  />
+                    class="arco-select-view-selector"
+                  >
+                    <input
+                      autocomplete="off"
+                      class="arco-select-view-input"
+                      placeholder="please select"
+                      style="width:100%;pointer-events:none"
+                      tabindex="-1"
+                      value=""
+                    />
+                    <span
+                      class="arco-select-view-value arco-select-view-value-mirror"
+                    >
+                      please select
+                    </span>
+                  </span>
                   <div
                     aria-hidden="true"
                     class="arco-select-suffix"
@@ -7570,18 +7625,23 @@ exports[`renders Form/demo/size.md correctly 1`] = `
                   class="arco-tree-select-view"
                   title=""
                 >
-                  <input
-                    autocomplete="off"
-                    class="arco-tree-select-view-input"
-                    placeholder="please select"
-                    style="width:100%;pointer-events:none"
-                    tabindex="-1"
-                    value=""
-                  />
                   <span
-                    aria-hidden="true"
-                    class="arco-tree-select-view-value arco-tree-select-hidden"
-                  />
+                    class="arco-tree-select-view-selector"
+                  >
+                    <input
+                      autocomplete="off"
+                      class="arco-tree-select-view-input"
+                      placeholder="please select"
+                      style="width:100%;pointer-events:none"
+                      tabindex="-1"
+                      value=""
+                    />
+                    <span
+                      class="arco-tree-select-view-value arco-tree-select-view-value-mirror"
+                    >
+                      please select
+                    </span>
+                  </span>
                   <div
                     aria-hidden="true"
                     class="arco-tree-select-suffix"
@@ -8929,18 +8989,23 @@ exports[`renders Form/demo/validate-status.md correctly 1`] = `
                   class="arco-cascader-view"
                   title=""
                 >
-                  <input
-                    autocomplete="off"
-                    class="arco-cascader-view-input"
-                    placeholder="Cascader..."
-                    style="width:100%;pointer-events:none"
-                    tabindex="-1"
-                    value=""
-                  />
                   <span
-                    aria-hidden="true"
-                    class="arco-cascader-view-value arco-cascader-hidden"
-                  />
+                    class="arco-cascader-view-selector"
+                  >
+                    <input
+                      autocomplete="off"
+                      class="arco-cascader-view-input"
+                      placeholder="Cascader..."
+                      style="width:100%;pointer-events:none"
+                      tabindex="-1"
+                      value=""
+                    />
+                    <span
+                      class="arco-cascader-view-value arco-cascader-view-value-mirror"
+                    >
+                      Cascader...
+                    </span>
+                  </span>
                   <div
                     aria-hidden="true"
                     class="arco-cascader-suffix"
@@ -9231,18 +9296,23 @@ exports[`renders Form/demo/validate-status.md correctly 1`] = `
                   class="arco-tree-select-view"
                   title=""
                 >
-                  <input
-                    autocomplete="off"
-                    class="arco-tree-select-view-input"
-                    placeholder="TreeSelect..."
-                    style="width:100%;pointer-events:none"
-                    tabindex="-1"
-                    value=""
-                  />
                   <span
-                    aria-hidden="true"
-                    class="arco-tree-select-view-value arco-tree-select-hidden"
-                  />
+                    class="arco-tree-select-view-selector"
+                  >
+                    <input
+                      autocomplete="off"
+                      class="arco-tree-select-view-input"
+                      placeholder="TreeSelect..."
+                      style="width:100%;pointer-events:none"
+                      tabindex="-1"
+                      value=""
+                    />
+                    <span
+                      class="arco-tree-select-view-value arco-tree-select-view-value-mirror"
+                    >
+                      TreeSelect...
+                    </span>
+                  </span>
                   <div
                     aria-hidden="true"
                     class="arco-tree-select-suffix"

--- a/components/Input/__test__/__snapshots__/demo.test.ts.snap
+++ b/components/Input/__test__/__snapshots__/demo.test.ts.snap
@@ -116,18 +116,22 @@ exports[`renders Input/demo/addon.md correctly 1`] = `
                   class="arco-select-view"
                   title=".com"
                 >
-                  <input
-                    aria-hidden="true"
-                    autocomplete="off"
-                    class="arco-select-view-input arco-select-hidden"
-                    placeholder=".com"
-                    style="width:100%"
-                    value=".com"
-                  />
                   <span
-                    class="arco-select-view-value"
+                    class="arco-select-view-selector"
                   >
-                    .com
+                    <input
+                      aria-hidden="true"
+                      autocomplete="off"
+                      class="arco-select-view-input arco-select-hidden"
+                      placeholder=".com"
+                      style="width:100%"
+                      value=".com"
+                    />
+                    <span
+                      class="arco-select-view-value"
+                    >
+                      .com
+                    </span>
                   </span>
                   <div
                     aria-hidden="true"
@@ -232,18 +236,22 @@ exports[`renders Input/demo/group.md correctly 1`] = `
             class="arco-select-view"
             title="Beijing"
           >
-            <input
-              aria-hidden="true"
-              autocomplete="off"
-              class="arco-select-view-input arco-select-hidden"
-              placeholder="Beijing"
-              style="width:100%"
-              value="Beijing"
-            />
             <span
-              class="arco-select-view-value"
+              class="arco-select-view-selector"
             >
-              Beijing
+              <input
+                aria-hidden="true"
+                autocomplete="off"
+                class="arco-select-view-input arco-select-hidden"
+                placeholder="Beijing"
+                style="width:100%"
+                value="Beijing"
+              />
+              <span
+                class="arco-select-view-value"
+              >
+                Beijing
+              </span>
             </span>
             <div
               aria-hidden="true"
@@ -296,18 +304,22 @@ exports[`renders Input/demo/group.md correctly 1`] = `
             class="arco-select-view"
             title="Beijing"
           >
-            <input
-              aria-hidden="true"
-              autocomplete="off"
-              class="arco-select-view-input arco-select-hidden"
-              placeholder="Beijing"
-              style="width:100%"
-              value="Beijing"
-            />
             <span
-              class="arco-select-view-value"
+              class="arco-select-view-selector"
             >
-              Beijing
+              <input
+                aria-hidden="true"
+                autocomplete="off"
+                class="arco-select-view-input arco-select-hidden"
+                placeholder="Beijing"
+                style="width:100%"
+                value="Beijing"
+              />
+              <span
+                class="arco-select-view-value"
+              >
+                Beijing
+              </span>
             </span>
             <div
               aria-hidden="true"
@@ -389,18 +401,22 @@ exports[`renders Input/demo/group.md correctly 1`] = `
             class="arco-select-view"
             title="Beijing"
           >
-            <input
-              aria-hidden="true"
-              autocomplete="off"
-              class="arco-select-view-input arco-select-hidden"
-              placeholder="Beijing"
-              style="width:100%"
-              value="Beijing"
-            />
             <span
-              class="arco-select-view-value"
+              class="arco-select-view-selector"
             >
-              Beijing
+              <input
+                aria-hidden="true"
+                autocomplete="off"
+                class="arco-select-view-input arco-select-hidden"
+                placeholder="Beijing"
+                style="width:100%"
+                value="Beijing"
+              />
+              <span
+                class="arco-select-view-value"
+              >
+                Beijing
+              </span>
             </span>
             <div
               aria-hidden="true"
@@ -1624,18 +1640,23 @@ exports[`renders Input/demo/size.md correctly 1`] = `
               class="arco-select-view"
               title=""
             >
-              <input
-                autocomplete="off"
-                class="arco-select-view-input"
-                placeholder="Please select"
-                style="width:100%;pointer-events:none"
-                tabindex="-1"
-                value=""
-              />
               <span
-                aria-hidden="true"
-                class="arco-select-view-value arco-select-hidden"
-              />
+                class="arco-select-view-selector"
+              >
+                <input
+                  autocomplete="off"
+                  class="arco-select-view-input"
+                  placeholder="Please select"
+                  style="width:100%;pointer-events:none"
+                  tabindex="-1"
+                  value=""
+                />
+                <span
+                  class="arco-select-view-value arco-select-view-value-mirror"
+                >
+                  Please select
+                </span>
+              </span>
               <div
                 aria-hidden="true"
                 class="arco-select-suffix"

--- a/components/Pagination/__test__/__snapshots__/demo.test.ts.snap
+++ b/components/Pagination/__test__/__snapshots__/demo.test.ts.snap
@@ -135,18 +135,22 @@ exports[`renders Pagination/demo/all-options.md correctly 1`] = `
           class="arco-select-view"
           title="10 条/页"
         >
-          <input
-            aria-hidden="true"
-            autocomplete="off"
-            class="arco-select-view-input arco-select-hidden"
-            style="width:100%;pointer-events:none"
-            tabindex="-1"
-            value="10 条/页"
-          />
           <span
-            class="arco-select-view-value"
+            class="arco-select-view-selector"
           >
-            10 条/页
+            <input
+              aria-hidden="true"
+              autocomplete="off"
+              class="arco-select-view-input arco-select-hidden"
+              style="width:100%;pointer-events:none"
+              tabindex="-1"
+              value="10 条/页"
+            />
+            <span
+              class="arco-select-view-value"
+            >
+              10 条/页
+            </span>
           </span>
           <div
             aria-hidden="true"
@@ -321,19 +325,23 @@ exports[`renders Pagination/demo/all-options.md correctly 1`] = `
           class="arco-select-view"
           title="10 条/页"
         >
-          <input
-            aria-hidden="true"
-            autocomplete="off"
-            class="arco-select-view-input arco-select-hidden"
-            disabled=""
-            style="width:100%;pointer-events:none"
-            tabindex="-1"
-            value="10 条/页"
-          />
           <span
-            class="arco-select-view-value"
+            class="arco-select-view-selector"
           >
-            10 条/页
+            <input
+              aria-hidden="true"
+              autocomplete="off"
+              class="arco-select-view-input arco-select-hidden"
+              disabled=""
+              style="width:100%;pointer-events:none"
+              tabindex="-1"
+              value="10 条/页"
+            />
+            <span
+              class="arco-select-view-value"
+            >
+              10 条/页
+            </span>
           </span>
           <div
             aria-hidden="true"
@@ -621,18 +629,22 @@ exports[`renders Pagination/demo/change-size.md correctly 1`] = `
         class="arco-select-view"
         title="10 条/页"
       >
-        <input
-          aria-hidden="true"
-          autocomplete="off"
-          class="arco-select-view-input arco-select-hidden"
-          style="width:100%;pointer-events:none"
-          tabindex="-1"
-          value="10 条/页"
-        />
         <span
-          class="arco-select-view-value"
+          class="arco-select-view-selector"
         >
-          10 条/页
+          <input
+            aria-hidden="true"
+            autocomplete="off"
+            class="arco-select-view-input arco-select-hidden"
+            style="width:100%;pointer-events:none"
+            tabindex="-1"
+            value="10 条/页"
+          />
+          <span
+            class="arco-select-view-value"
+          >
+            10 条/页
+          </span>
         </span>
         <div
           aria-hidden="true"
@@ -804,18 +816,22 @@ exports[`renders Pagination/demo/count-more.md correctly 1`] = `
         class="arco-select-view"
         title="10 条/页"
       >
-        <input
-          aria-hidden="true"
-          autocomplete="off"
-          class="arco-select-view-input arco-select-hidden"
-          style="width:100%;pointer-events:none"
-          tabindex="-1"
-          value="10 条/页"
-        />
         <span
-          class="arco-select-view-value"
+          class="arco-select-view-selector"
         >
-          10 条/页
+          <input
+            aria-hidden="true"
+            autocomplete="off"
+            class="arco-select-view-input arco-select-hidden"
+            style="width:100%;pointer-events:none"
+            tabindex="-1"
+            value="10 条/页"
+          />
+          <span
+            class="arco-select-view-value"
+          >
+            10 条/页
+          </span>
         </span>
         <div
           aria-hidden="true"
@@ -1210,18 +1226,22 @@ exports[`renders Pagination/demo/more-buffer.md correctly 1`] = `
               class="arco-select-view"
               title="10 条/页"
             >
-              <input
-                aria-hidden="true"
-                autocomplete="off"
-                class="arco-select-view-input arco-select-hidden"
-                style="width:100%;pointer-events:none"
-                tabindex="-1"
-                value="10 条/页"
-              />
               <span
-                class="arco-select-view-value"
+                class="arco-select-view-selector"
               >
-                10 条/页
+                <input
+                  aria-hidden="true"
+                  autocomplete="off"
+                  class="arco-select-view-input arco-select-hidden"
+                  style="width:100%;pointer-events:none"
+                  tabindex="-1"
+                  value="10 条/页"
+                />
+                <span
+                  class="arco-select-view-value"
+                >
+                  10 条/页
+                </span>
               </span>
               <div
                 aria-hidden="true"
@@ -1397,18 +1417,22 @@ exports[`renders Pagination/demo/more-buffer.md correctly 1`] = `
               class="arco-select-view"
               title="10 条/页"
             >
-              <input
-                aria-hidden="true"
-                autocomplete="off"
-                class="arco-select-view-input arco-select-hidden"
-                style="width:100%;pointer-events:none"
-                tabindex="-1"
-                value="10 条/页"
-              />
               <span
-                class="arco-select-view-value"
+                class="arco-select-view-selector"
               >
-                10 条/页
+                <input
+                  aria-hidden="true"
+                  autocomplete="off"
+                  class="arco-select-view-input arco-select-hidden"
+                  style="width:100%;pointer-events:none"
+                  tabindex="-1"
+                  value="10 条/页"
+                />
+                <span
+                  class="arco-select-view-value"
+                >
+                  10 条/页
+                </span>
               </span>
               <div
                 aria-hidden="true"
@@ -1597,18 +1621,22 @@ exports[`renders Pagination/demo/more-buffer.md correctly 1`] = `
               class="arco-select-view"
               title="10 条/页"
             >
-              <input
-                aria-hidden="true"
-                autocomplete="off"
-                class="arco-select-view-input arco-select-hidden"
-                style="width:100%;pointer-events:none"
-                tabindex="-1"
-                value="10 条/页"
-              />
               <span
-                class="arco-select-view-value"
+                class="arco-select-view-selector"
               >
-                10 条/页
+                <input
+                  aria-hidden="true"
+                  autocomplete="off"
+                  class="arco-select-view-input arco-select-hidden"
+                  style="width:100%;pointer-events:none"
+                  tabindex="-1"
+                  value="10 条/页"
+                />
+                <span
+                  class="arco-select-view-value"
+                >
+                  10 条/页
+                </span>
               </span>
               <div
                 aria-hidden="true"
@@ -2172,18 +2200,22 @@ exports[`renders Pagination/demo/size.md correctly 1`] = `
           class="arco-select-view"
           title="10 条/页"
         >
-          <input
-            aria-hidden="true"
-            autocomplete="off"
-            class="arco-select-view-input arco-select-hidden"
-            style="width:100%;pointer-events:none"
-            tabindex="-1"
-            value="10 条/页"
-          />
           <span
-            class="arco-select-view-value"
+            class="arco-select-view-selector"
           >
-            10 条/页
+            <input
+              aria-hidden="true"
+              autocomplete="off"
+              class="arco-select-view-input arco-select-hidden"
+              style="width:100%;pointer-events:none"
+              tabindex="-1"
+              value="10 条/页"
+            />
+            <span
+              class="arco-select-view-value"
+            >
+              10 条/页
+            </span>
           </span>
           <div
             aria-hidden="true"

--- a/components/Select/__test__/__snapshots__/demo.test.ts.snap
+++ b/components/Select/__test__/__snapshots__/demo.test.ts.snap
@@ -29,18 +29,23 @@ exports[`renders Select/demo/addbefore.md correctly 1`] = `
           class="arco-select-view"
           title=""
         >
-          <input
-            autocomplete="off"
-            class="arco-select-view-input"
-            placeholder="Please select"
-            style="width:100%;pointer-events:none"
-            tabindex="-1"
-            value=""
-          />
           <span
-            aria-hidden="true"
-            class="arco-select-view-value arco-select-hidden"
-          />
+            class="arco-select-view-selector"
+          >
+            <input
+              autocomplete="off"
+              class="arco-select-view-input"
+              placeholder="Please select"
+              style="width:100%;pointer-events:none"
+              tabindex="-1"
+              value=""
+            />
+            <span
+              class="arco-select-view-value arco-select-view-value-mirror"
+            >
+              Please select
+            </span>
+          </span>
           <div
             aria-hidden="true"
             class="arco-select-suffix"
@@ -161,17 +166,22 @@ exports[`renders Select/demo/allow-create.md correctly 1`] = `
         class="arco-select-view"
         title=""
       >
-        <input
-          autocomplete="off"
-          class="arco-select-view-input"
-          placeholder="Create an item"
-          style="width:100%"
-          value=""
-        />
         <span
-          aria-hidden="true"
-          class="arco-select-view-value arco-select-hidden"
-        />
+          class="arco-select-view-selector"
+        >
+          <input
+            autocomplete="off"
+            class="arco-select-view-input"
+            placeholder="Create an item"
+            style="width:100%"
+            value=""
+          />
+          <span
+            class="arco-select-view-value arco-select-view-value-mirror"
+          >
+            Create an item
+          </span>
+        </span>
         <div
           aria-hidden="true"
           class="arco-select-suffix"
@@ -403,18 +413,23 @@ exports[`renders Select/demo/basic.md correctly 1`] = `
         class="arco-select-view"
         title=""
       >
-        <input
-          autocomplete="off"
-          class="arco-select-view-input"
-          placeholder="Please select"
-          style="width:100%;pointer-events:none"
-          tabindex="-1"
-          value=""
-        />
         <span
-          aria-hidden="true"
-          class="arco-select-view-value arco-select-hidden"
-        />
+          class="arco-select-view-selector"
+        >
+          <input
+            autocomplete="off"
+            class="arco-select-view-input"
+            placeholder="Please select"
+            style="width:100%;pointer-events:none"
+            tabindex="-1"
+            value=""
+          />
+          <span
+            class="arco-select-view-value arco-select-view-value-mirror"
+          >
+            Please select
+          </span>
+        </span>
         <div
           aria-hidden="true"
           class="arco-select-suffix"
@@ -457,20 +472,24 @@ exports[`renders Select/demo/basic.md correctly 1`] = `
         class="arco-select-view"
         title="Beijing"
       >
-        <input
-          aria-hidden="true"
-          autocomplete="off"
-          class="arco-select-view-input arco-select-hidden"
-          disabled=""
-          placeholder="Select city"
-          style="width:100%;pointer-events:none"
-          tabindex="-1"
-          value="Beijing"
-        />
         <span
-          class="arco-select-view-value"
+          class="arco-select-view-selector"
         >
-          Beijing
+          <input
+            aria-hidden="true"
+            autocomplete="off"
+            class="arco-select-view-input arco-select-hidden"
+            disabled=""
+            placeholder="Select city"
+            style="width:100%;pointer-events:none"
+            tabindex="-1"
+            value="Beijing"
+          />
+          <span
+            class="arco-select-view-value"
+          >
+            Beijing
+          </span>
         </span>
         <div
           aria-hidden="true"
@@ -514,18 +533,23 @@ exports[`renders Select/demo/clear.md correctly 1`] = `
     class="arco-select-view"
     title=""
   >
-    <input
-      autocomplete="off"
-      class="arco-select-view-input"
-      placeholder="Please select"
-      style="width:100%;pointer-events:none"
-      tabindex="-1"
-      value=""
-    />
     <span
-      aria-hidden="true"
-      class="arco-select-view-value arco-select-hidden"
-    />
+      class="arco-select-view-selector"
+    >
+      <input
+        autocomplete="off"
+        class="arco-select-view-input"
+        placeholder="Please select"
+        style="width:100%;pointer-events:none"
+        tabindex="-1"
+        value=""
+      />
+      <span
+        class="arco-select-view-value arco-select-view-value-mirror"
+      >
+        Please select
+      </span>
+    </span>
     <div
       aria-hidden="true"
       class="arco-select-suffix"
@@ -573,18 +597,23 @@ exports[`renders Select/demo/custom-popup-width.md correctly 1`] = `
         class="arco-select-view"
         title=""
       >
-        <input
-          autocomplete="off"
-          class="arco-select-view-input"
-          placeholder="Please select"
-          style="width:100%;pointer-events:none"
-          tabindex="-1"
-          value=""
-        />
         <span
-          aria-hidden="true"
-          class="arco-select-view-value arco-select-hidden"
-        />
+          class="arco-select-view-selector"
+        >
+          <input
+            autocomplete="off"
+            class="arco-select-view-input"
+            placeholder="Please select"
+            style="width:100%;pointer-events:none"
+            tabindex="-1"
+            value=""
+          />
+          <span
+            class="arco-select-view-value arco-select-view-value-mirror"
+          >
+            Please select
+          </span>
+        </span>
         <div
           aria-hidden="true"
           class="arco-select-suffix"
@@ -626,18 +655,23 @@ exports[`renders Select/demo/custom-popup-width.md correctly 1`] = `
         class="arco-select-view"
         title=""
       >
-        <input
-          autocomplete="off"
-          class="arco-select-view-input"
-          placeholder="Please select"
-          style="width:100%;pointer-events:none"
-          tabindex="-1"
-          value=""
-        />
         <span
-          aria-hidden="true"
-          class="arco-select-view-value arco-select-hidden"
-        />
+          class="arco-select-view-selector"
+        >
+          <input
+            autocomplete="off"
+            class="arco-select-view-input"
+            placeholder="Please select"
+            style="width:100%;pointer-events:none"
+            tabindex="-1"
+            value=""
+          />
+          <span
+            class="arco-select-view-value arco-select-view-value-mirror"
+          >
+            Please select
+          </span>
+        </span>
         <div
           aria-hidden="true"
           class="arco-select-suffix"
@@ -876,18 +910,23 @@ exports[`renders Select/demo/dropdown-render.md correctly 1`] = `
     class="arco-select-view"
     title=""
   >
-    <input
-      autocomplete="off"
-      class="arco-select-view-input"
-      placeholder="Select city"
-      style="width:100%;pointer-events:none"
-      tabindex="-1"
-      value=""
-    />
     <span
-      aria-hidden="true"
-      class="arco-select-view-value arco-select-hidden"
-    />
+      class="arco-select-view-selector"
+    >
+      <input
+        autocomplete="off"
+        class="arco-select-view-input"
+        placeholder="Select city"
+        style="width:100%;pointer-events:none"
+        tabindex="-1"
+        value=""
+      />
+      <span
+        class="arco-select-view-value arco-select-view-value-mirror"
+      >
+        Select city
+      </span>
+    </span>
     <div
       aria-hidden="true"
       class="arco-select-suffix"
@@ -929,17 +968,22 @@ exports[`renders Select/demo/group.md correctly 1`] = `
       class="arco-select-view"
       title=""
     >
-      <input
-        autocomplete="off"
-        class="arco-select-view-input"
-        placeholder="Select drink"
-        style="width:100%"
-        value=""
-      />
       <span
-        aria-hidden="true"
-        class="arco-select-view-value arco-select-hidden"
-      />
+        class="arco-select-view-selector"
+      >
+        <input
+          autocomplete="off"
+          class="arco-select-view-input"
+          placeholder="Select drink"
+          style="width:100%"
+          value=""
+        />
+        <span
+          class="arco-select-view-value arco-select-view-value-mirror"
+        >
+          Select drink
+        </span>
+      </span>
       <div
         aria-hidden="true"
         class="arco-select-suffix"
@@ -1582,18 +1626,23 @@ exports[`renders Select/demo/no-border.md correctly 1`] = `
         class="arco-select-view"
         title=""
       >
-        <input
-          autocomplete="off"
-          class="arco-select-view-input"
-          placeholder="Please select"
-          style="width:100%;pointer-events:none"
-          tabindex="-1"
-          value=""
-        />
         <span
-          aria-hidden="true"
-          class="arco-select-view-value arco-select-hidden"
-        />
+          class="arco-select-view-selector"
+        >
+          <input
+            autocomplete="off"
+            class="arco-select-view-input"
+            placeholder="Please select"
+            style="width:100%;pointer-events:none"
+            tabindex="-1"
+            value=""
+          />
+          <span
+            class="arco-select-view-value arco-select-view-value-mirror"
+          >
+            Please select
+          </span>
+        </span>
         <div
           aria-hidden="true"
           class="arco-select-suffix"
@@ -1636,20 +1685,24 @@ exports[`renders Select/demo/no-border.md correctly 1`] = `
         class="arco-select-view"
         title="Beijing"
       >
-        <input
-          aria-hidden="true"
-          autocomplete="off"
-          class="arco-select-view-input arco-select-hidden"
-          disabled=""
-          placeholder="Please select"
-          style="width:100%;pointer-events:none"
-          tabindex="-1"
-          value="Beijing"
-        />
         <span
-          class="arco-select-view-value"
+          class="arco-select-view-selector"
         >
-          Beijing
+          <input
+            aria-hidden="true"
+            autocomplete="off"
+            class="arco-select-view-input arco-select-hidden"
+            disabled=""
+            placeholder="Please select"
+            style="width:100%;pointer-events:none"
+            tabindex="-1"
+            value="Beijing"
+          />
+          <span
+            class="arco-select-view-value"
+          >
+            Beijing
+          </span>
         </span>
         <div
           aria-hidden="true"
@@ -1763,19 +1816,23 @@ exports[`renders Select/demo/options.md correctly 1`] = `
         class="arco-select-view"
         title="Beijing"
       >
-        <input
-          aria-hidden="true"
-          autocomplete="off"
-          class="arco-select-view-input arco-select-hidden"
-          placeholder="Select city"
-          style="width:100%;pointer-events:none"
-          tabindex="-1"
-          value="Beijing"
-        />
         <span
-          class="arco-select-view-value"
+          class="arco-select-view-selector"
         >
-          Beijing
+          <input
+            aria-hidden="true"
+            autocomplete="off"
+            class="arco-select-view-input arco-select-hidden"
+            placeholder="Select city"
+            style="width:100%;pointer-events:none"
+            tabindex="-1"
+            value="Beijing"
+          />
+          <span
+            class="arco-select-view-value"
+          >
+            Beijing
+          </span>
         </span>
         <div
           aria-hidden="true"
@@ -1948,19 +2005,23 @@ exports[`renders Select/demo/relative.md correctly 1`] = `
         class="arco-select-view"
         title="Beijing"
       >
-        <input
-          aria-hidden="true"
-          autocomplete="off"
-          class="arco-select-view-input arco-select-hidden"
-          placeholder="Select Province"
-          style="width:100%;pointer-events:none"
-          tabindex="-1"
-          value="Beijing"
-        />
         <span
-          class="arco-select-view-value"
+          class="arco-select-view-selector"
         >
-          Beijing
+          <input
+            aria-hidden="true"
+            autocomplete="off"
+            class="arco-select-view-input arco-select-hidden"
+            placeholder="Select Province"
+            style="width:100%;pointer-events:none"
+            tabindex="-1"
+            value="Beijing"
+          />
+          <span
+            class="arco-select-view-value"
+          >
+            Beijing
+          </span>
         </span>
         <div
           aria-hidden="true"
@@ -2003,18 +2064,24 @@ exports[`renders Select/demo/relative.md correctly 1`] = `
         class="arco-select-view"
         title=""
       >
-        <input
-          aria-hidden="true"
-          autocomplete="off"
-          class="arco-select-view-input arco-select-hidden"
-          placeholder="Select city"
-          style="width:100%;pointer-events:none"
-          tabindex="-1"
-          value=""
-        />
         <span
-          class="arco-select-view-value"
-        />
+          class="arco-select-view-selector"
+        >
+          <input
+            aria-hidden="true"
+            autocomplete="off"
+            class="arco-select-view-input arco-select-hidden"
+            placeholder="Select city"
+            style="width:100%;pointer-events:none"
+            tabindex="-1"
+            value=""
+          />
+          <span
+            class="arco-select-view-value"
+          >
+            Select city
+          </span>
+        </span>
         <div
           aria-hidden="true"
           class="arco-select-suffix"
@@ -2064,18 +2131,23 @@ exports[`renders Select/demo/render-format.md correctly 1`] = `
         class="arco-select-view"
         title=""
       >
-        <input
-          autocomplete="off"
-          class="arco-select-view-input"
-          placeholder="Select city"
-          style="width:100%;pointer-events:none"
-          tabindex="-1"
-          value=""
-        />
         <span
-          aria-hidden="true"
-          class="arco-select-view-value arco-select-hidden"
-        />
+          class="arco-select-view-selector"
+        >
+          <input
+            autocomplete="off"
+            class="arco-select-view-input"
+            placeholder="Select city"
+            style="width:100%;pointer-events:none"
+            tabindex="-1"
+            value=""
+          />
+          <span
+            class="arco-select-view-value arco-select-view-value-mirror"
+          >
+            Select city
+          </span>
+        </span>
         <div
           aria-hidden="true"
           class="arco-select-suffix"
@@ -2421,17 +2493,22 @@ exports[`renders Select/demo/show-search.md correctly 1`] = `
         class="arco-select-view"
         title=""
       >
-        <input
-          autocomplete="off"
-          class="arco-select-view-input"
-          placeholder="Select city"
-          style="width:100%"
-          value=""
-        />
         <span
-          aria-hidden="true"
-          class="arco-select-view-value arco-select-hidden"
-        />
+          class="arco-select-view-selector"
+        >
+          <input
+            autocomplete="off"
+            class="arco-select-view-input"
+            placeholder="Select city"
+            style="width:100%"
+            value=""
+          />
+          <span
+            class="arco-select-view-value arco-select-view-value-mirror"
+          >
+            Select city
+          </span>
+        </span>
         <div
           aria-hidden="true"
           class="arco-select-suffix"
@@ -2474,17 +2551,22 @@ exports[`renders Select/demo/show-search.md correctly 1`] = `
         class="arco-select-view"
         title=""
       >
-        <input
-          autocomplete="off"
-          class="arco-select-view-input"
-          placeholder="Filter option"
-          style="width:100%"
-          value=""
-        />
         <span
-          aria-hidden="true"
-          class="arco-select-view-value arco-select-hidden"
-        />
+          class="arco-select-view-selector"
+        >
+          <input
+            autocomplete="off"
+            class="arco-select-view-input"
+            placeholder="Filter option"
+            style="width:100%"
+            value=""
+          />
+          <span
+            class="arco-select-view-value arco-select-view-value-mirror"
+          >
+            Filter option
+          </span>
+        </span>
         <div
           aria-hidden="true"
           class="arco-select-suffix"
@@ -2526,17 +2608,22 @@ exports[`renders Select/demo/show-search.md correctly 1`] = `
         class="arco-select-view"
         title=""
       >
-        <input
-          autocomplete="off"
-          class="arco-select-view-input"
-          placeholder="Retain input value"
-          style="width:100%"
-          value=""
-        />
         <span
-          aria-hidden="true"
-          class="arco-select-view-value arco-select-hidden"
-        />
+          class="arco-select-view-selector"
+        >
+          <input
+            autocomplete="off"
+            class="arco-select-view-input"
+            placeholder="Retain input value"
+            style="width:100%"
+            value=""
+          />
+          <span
+            class="arco-select-view-value arco-select-view-value-mirror"
+          >
+            Retain input value
+          </span>
+        </span>
         <div
           aria-hidden="true"
           class="arco-select-suffix"
@@ -2644,17 +2731,22 @@ exports[`renders Select/demo/size.md correctly 1`] = `
         class="arco-select-view"
         title=""
       >
-        <input
-          autocomplete="off"
-          class="arco-select-view-input"
-          placeholder="Please select"
-          style="width:100%"
-          value=""
-        />
         <span
-          aria-hidden="true"
-          class="arco-select-view-value arco-select-hidden"
-        />
+          class="arco-select-view-selector"
+        >
+          <input
+            autocomplete="off"
+            class="arco-select-view-input"
+            placeholder="Please select"
+            style="width:100%"
+            value=""
+          />
+          <span
+            class="arco-select-view-value arco-select-view-value-mirror"
+          >
+            Please select
+          </span>
+        </span>
         <div
           aria-hidden="true"
           class="arco-select-suffix"

--- a/components/Select/__test__/__snapshots__/index.test.tsx.snap
+++ b/components/Select/__test__/__snapshots__/index.test.tsx.snap
@@ -13,17 +13,20 @@ exports[`ConfigProvider componentConfig.Select default 1`] = `
     class="arco-select-view"
     title=""
   >
-    <input
-      autocomplete="off"
-      class="arco-select-view-input"
-      style="width:100%;pointer-events:none"
-      tabindex="-1"
-      value=""
-    />
     <span
-      aria-hidden="true"
-      class="arco-select-view-value arco-select-hidden"
-    />
+      class="arco-select-view-selector"
+    >
+      <input
+        autocomplete="off"
+        class="arco-select-view-input"
+        style="width:100%;pointer-events:none"
+        tabindex="-1"
+        value=""
+      />
+      <span
+        class="arco-select-view-value arco-select-view-value-mirror"
+      />
+    </span>
     <div
       aria-hidden="true"
       class="arco-select-suffix"
@@ -63,17 +66,20 @@ exports[`ConfigProvider componentConfig.Select set className globally 1`] = `
     class="arco-select-view"
     title=""
   >
-    <input
-      autocomplete="off"
-      class="arco-select-view-input"
-      style="width:100%;pointer-events:none"
-      tabindex="-1"
-      value=""
-    />
     <span
-      aria-hidden="true"
-      class="arco-select-view-value arco-select-hidden"
-    />
+      class="arco-select-view-selector"
+    >
+      <input
+        autocomplete="off"
+        class="arco-select-view-input"
+        style="width:100%;pointer-events:none"
+        tabindex="-1"
+        value=""
+      />
+      <span
+        class="arco-select-view-value arco-select-view-value-mirror"
+      />
+    </span>
     <div
       aria-hidden="true"
       class="arco-select-suffix"
@@ -113,17 +119,20 @@ exports[`ConfigProvider componentConfig.Select set className globally and compon
     class="arco-select-view"
     title=""
   >
-    <input
-      autocomplete="off"
-      class="arco-select-view-input"
-      style="width:100%;pointer-events:none"
-      tabindex="-1"
-      value=""
-    />
     <span
-      aria-hidden="true"
-      class="arco-select-view-value arco-select-hidden"
-    />
+      class="arco-select-view-selector"
+    >
+      <input
+        autocomplete="off"
+        class="arco-select-view-input"
+        style="width:100%;pointer-events:none"
+        tabindex="-1"
+        value=""
+      />
+      <span
+        class="arco-select-view-value arco-select-view-value-mirror"
+      />
+    </span>
     <div
       aria-hidden="true"
       class="arco-select-suffix"
@@ -164,17 +173,20 @@ exports[`ConfigProvider componentConfig.Select set data-* property 1`] = `
     class="arco-select-view"
     title=""
   >
-    <input
-      autocomplete="off"
-      class="arco-select-view-input"
-      style="width:100%;pointer-events:none"
-      tabindex="-1"
-      value=""
-    />
     <span
-      aria-hidden="true"
-      class="arco-select-view-value arco-select-hidden"
-    />
+      class="arco-select-view-selector"
+    >
+      <input
+        autocomplete="off"
+        class="arco-select-view-input"
+        style="width:100%;pointer-events:none"
+        tabindex="-1"
+        value=""
+      />
+      <span
+        class="arco-select-view-value arco-select-view-value-mirror"
+      />
+    </span>
     <div
       aria-hidden="true"
       class="arco-select-suffix"

--- a/components/Select/style/mixin.less
+++ b/components/Select/style/mixin.less
@@ -166,27 +166,36 @@
 
     &-single &-view {
       &-input {
+        position: absolute;
+        left: 0;
+        right: 0;
+        top: 50%;
+        transform: translateY(-50%);
         box-sizing: border-box;
         width: 100%;
         padding: 0;
         border: none;
         outline: none;
         background: transparent;
+        z-index: 1;
         .text-ellipsis();
+      }
+
+      &-selector {
+        position: relative;
+        display: inline-block;
+        box-sizing: border-box;
+        width: 100%;
+        overflow: hidden;
       }
 
       &-value {
         display: inline-block;
-        box-sizing: border-box;
         width: 100%;
         .text-ellipsis();
 
-        // 修复当value为空字符串时，造成select外层div的高度多余了4px的样式问题。
-        &::after {
-          content: '.';
-          font-size: 0;
-          line-height: 0;
-          visibility: hidden;
+        &-mirror {
+          opacity: 0;
         }
       }
 

--- a/components/Table/__test__/__snapshots__/demo.test.ts.snap
+++ b/components/Table/__test__/__snapshots__/demo.test.ts.snap
@@ -9813,18 +9813,22 @@ exports[`renders Table/demo/pagination.md correctly 1`] = `
                 class="arco-select-view"
                 title="10 条/页"
               >
-                <input
-                  aria-hidden="true"
-                  autocomplete="off"
-                  class="arco-select-view-input arco-select-hidden"
-                  style="width:100%;pointer-events:none"
-                  tabindex="-1"
-                  value="10 条/页"
-                />
                 <span
-                  class="arco-select-view-value"
+                  class="arco-select-view-selector"
                 >
-                  10 条/页
+                  <input
+                    aria-hidden="true"
+                    autocomplete="off"
+                    class="arco-select-view-input arco-select-hidden"
+                    style="width:100%;pointer-events:none"
+                    tabindex="-1"
+                    value="10 条/页"
+                  />
+                  <span
+                    class="arco-select-view-value"
+                  >
+                    10 条/页
+                  </span>
                 </span>
                 <div
                   aria-hidden="true"

--- a/components/TimePicker/__test__/__snapshots__/demo.test.ts.snap
+++ b/components/TimePicker/__test__/__snapshots__/demo.test.ts.snap
@@ -786,18 +786,22 @@ exports[`renders TimePicker/demo/timezone.md correctly 1`] = `
             class="arco-select-view"
             title="Asia/Shanghai"
           >
-            <input
-              aria-hidden="true"
-              autocomplete="off"
-              class="arco-select-view-input arco-select-hidden"
-              style="width:100%;pointer-events:none"
-              tabindex="-1"
-              value="Asia/Shanghai"
-            />
             <span
-              class="arco-select-view-value"
+              class="arco-select-view-selector"
             >
-              Asia/Shanghai
+              <input
+                aria-hidden="true"
+                autocomplete="off"
+                class="arco-select-view-input arco-select-hidden"
+                style="width:100%;pointer-events:none"
+                tabindex="-1"
+                value="Asia/Shanghai"
+              />
+              <span
+                class="arco-select-view-value"
+              >
+                Asia/Shanghai
+              </span>
             </span>
             <div
               aria-hidden="true"
@@ -1201,18 +1205,22 @@ exports[`renders TimePicker/demo/utcOffset.md correctly 1`] = `
             class="arco-select-view"
             title="UTC "
           >
-            <input
-              aria-hidden="true"
-              autocomplete="off"
-              class="arco-select-view-input arco-select-hidden"
-              style="width:100%;pointer-events:none"
-              tabindex="-1"
-              value="UTC "
-            />
             <span
-              class="arco-select-view-value"
+              class="arco-select-view-selector"
             >
-              UTC 
+              <input
+                aria-hidden="true"
+                autocomplete="off"
+                class="arco-select-view-input arco-select-hidden"
+                style="width:100%;pointer-events:none"
+                tabindex="-1"
+                value="UTC "
+              />
+              <span
+                class="arco-select-view-value"
+              >
+                UTC 
+              </span>
             </span>
             <div
               aria-hidden="true"

--- a/components/TreeSelect/__test__/__snapshots__/demo.test.ts.snap
+++ b/components/TreeSelect/__test__/__snapshots__/demo.test.ts.snap
@@ -29,17 +29,20 @@ exports[`renders TreeSelect/demo/addon.md correctly 1`] = `
           class="arco-tree-select-view"
           title=""
         >
-          <input
-            autocomplete="off"
-            class="arco-tree-select-view-input"
-            style="width:100%;pointer-events:none"
-            tabindex="-1"
-            value=""
-          />
           <span
-            aria-hidden="true"
-            class="arco-tree-select-view-value arco-tree-select-hidden"
-          />
+            class="arco-tree-select-view-selector"
+          >
+            <input
+              autocomplete="off"
+              class="arco-tree-select-view-input"
+              style="width:100%;pointer-events:none"
+              tabindex="-1"
+              value=""
+            />
+            <span
+              class="arco-tree-select-view-value arco-tree-select-view-value-mirror"
+            />
+          </span>
           <div
             aria-hidden="true"
             class="arco-tree-select-suffix"
@@ -153,18 +156,22 @@ exports[`renders TreeSelect/demo/basic.md correctly 1`] = `
     class="arco-tree-select-view"
     title="Trunk"
   >
-    <input
-      aria-hidden="true"
-      autocomplete="off"
-      class="arco-tree-select-view-input arco-tree-select-hidden"
-      style="width:100%;pointer-events:none"
-      tabindex="-1"
-      value="Trunk"
-    />
     <span
-      class="arco-tree-select-view-value"
+      class="arco-tree-select-view-selector"
     >
-      Trunk
+      <input
+        aria-hidden="true"
+        autocomplete="off"
+        class="arco-tree-select-view-input arco-tree-select-hidden"
+        style="width:100%;pointer-events:none"
+        tabindex="-1"
+        value="Trunk"
+      />
+      <span
+        class="arco-tree-select-view-value"
+      >
+        Trunk
+      </span>
     </span>
     <div
       aria-hidden="true"
@@ -560,18 +567,22 @@ exports[`renders TreeSelect/demo/controled.md correctly 1`] = `
     class="arco-tree-select-view"
     title="Leaf"
   >
-    <input
-      aria-hidden="true"
-      autocomplete="off"
-      class="arco-tree-select-view-input arco-tree-select-hidden"
-      style="width:100%;pointer-events:none"
-      tabindex="-1"
-      value="Leaf"
-    />
     <span
-      class="arco-tree-select-view-value"
+      class="arco-tree-select-view-selector"
     >
-      Leaf
+      <input
+        aria-hidden="true"
+        autocomplete="off"
+        class="arco-tree-select-view-input arco-tree-select-hidden"
+        style="width:100%;pointer-events:none"
+        tabindex="-1"
+        value="Leaf"
+      />
+      <span
+        class="arco-tree-select-view-value"
+      >
+        Leaf
+      </span>
     </span>
     <div
       aria-hidden="true"
@@ -686,18 +697,23 @@ exports[`renders TreeSelect/demo/dropdownRender.md correctly 1`] = `
     class="arco-tree-select-view"
     title=""
   >
-    <input
-      autocomplete="off"
-      class="arco-tree-select-view-input"
-      placeholder="Please select ..."
-      style="width:100%;pointer-events:none"
-      tabindex="-1"
-      value=""
-    />
     <span
-      aria-hidden="true"
-      class="arco-tree-select-view-value arco-tree-select-hidden"
-    />
+      class="arco-tree-select-view-selector"
+    >
+      <input
+        autocomplete="off"
+        class="arco-tree-select-view-input"
+        placeholder="Please select ..."
+        style="width:100%;pointer-events:none"
+        tabindex="-1"
+        value=""
+      />
+      <span
+        class="arco-tree-select-view-value arco-tree-select-view-value-mirror"
+      >
+        Please select ...
+      </span>
+    </span>
     <div
       aria-hidden="true"
       class="arco-tree-select-suffix"
@@ -739,17 +755,20 @@ exports[`renders TreeSelect/demo/fieldnames.md correctly 1`] = `
       class="arco-tree-select-view"
       title=""
     >
-      <input
-        autocomplete="off"
-        class="arco-tree-select-view-input"
-        style="width:100%;pointer-events:none"
-        tabindex="-1"
-        value=""
-      />
       <span
-        aria-hidden="true"
-        class="arco-tree-select-view-value arco-tree-select-hidden"
-      />
+        class="arco-tree-select-view-selector"
+      >
+        <input
+          autocomplete="off"
+          class="arco-tree-select-view-input"
+          style="width:100%;pointer-events:none"
+          tabindex="-1"
+          value=""
+        />
+        <span
+          class="arco-tree-select-view-value arco-tree-select-view-value-mirror"
+        />
+      </span>
       <div
         aria-hidden="true"
         class="arco-tree-select-suffix"
@@ -791,18 +810,22 @@ exports[`renders TreeSelect/demo/labelInvalue.md correctly 1`] = `
     class="arco-tree-select-view"
     title="Leaf"
   >
-    <input
-      aria-hidden="true"
-      autocomplete="off"
-      class="arco-tree-select-view-input arco-tree-select-hidden"
-      style="width:100%;pointer-events:none"
-      tabindex="-1"
-      value="Leaf"
-    />
     <span
-      class="arco-tree-select-view-value"
+      class="arco-tree-select-view-selector"
     >
-      Leaf
+      <input
+        aria-hidden="true"
+        autocomplete="off"
+        class="arco-tree-select-view-input arco-tree-select-hidden"
+        style="width:100%;pointer-events:none"
+        tabindex="-1"
+        value="Leaf"
+      />
+      <span
+        class="arco-tree-select-view-value"
+      >
+        Leaf
+      </span>
     </span>
     <div
       aria-hidden="true"
@@ -844,18 +867,22 @@ exports[`renders TreeSelect/demo/loadmore.md correctly 1`] = `
     class="arco-tree-select-view"
     title="node2"
   >
-    <input
-      aria-hidden="true"
-      autocomplete="off"
-      class="arco-tree-select-view-input arco-tree-select-hidden"
-      placeholder="node2"
-      style="width:100%"
-      value="node2"
-    />
     <span
-      class="arco-tree-select-view-value"
+      class="arco-tree-select-view-selector"
     >
-      node2
+      <input
+        aria-hidden="true"
+        autocomplete="off"
+        class="arco-tree-select-view-input arco-tree-select-hidden"
+        placeholder="node2"
+        style="width:100%"
+        value="node2"
+      />
+      <span
+        class="arco-tree-select-view-value"
+      >
+        node2
+      </span>
     </span>
     <div
       aria-hidden="true"
@@ -1096,18 +1123,23 @@ exports[`renders TreeSelect/demo/popupVisible.md correctly 1`] = `
     class="arco-tree-select-view"
     title=""
   >
-    <input
-      autocomplete="off"
-      class="arco-tree-select-view-input"
-      placeholder="hover to show options"
-      style="width:100%;pointer-events:none"
-      tabindex="-1"
-      value=""
-    />
     <span
-      aria-hidden="true"
-      class="arco-tree-select-view-value arco-tree-select-hidden"
-    />
+      class="arco-tree-select-view-selector"
+    >
+      <input
+        autocomplete="off"
+        class="arco-tree-select-view-input"
+        placeholder="hover to show options"
+        style="width:100%;pointer-events:none"
+        tabindex="-1"
+        value=""
+      />
+      <span
+        class="arco-tree-select-view-value arco-tree-select-view-value-mirror"
+      >
+        hover to show options
+      </span>
+    </span>
     <div
       aria-hidden="true"
       class="arco-tree-select-suffix"
@@ -1155,17 +1187,22 @@ exports[`renders TreeSelect/demo/search.md correctly 1`] = `
         class="arco-tree-select-view"
         title=""
       >
-        <input
-          autocomplete="off"
-          class="arco-tree-select-view-input"
-          placeholder="Please select ..."
-          style="width:100%"
-          value=""
-        />
         <span
-          aria-hidden="true"
-          class="arco-tree-select-view-value arco-tree-select-hidden"
-        />
+          class="arco-tree-select-view-selector"
+        >
+          <input
+            autocomplete="off"
+            class="arco-tree-select-view-input"
+            placeholder="Please select ..."
+            style="width:100%"
+            value=""
+          />
+          <span
+            class="arco-tree-select-view-value arco-tree-select-view-value-mirror"
+          >
+            Please select ...
+          </span>
+        </span>
         <div
           aria-hidden="true"
           class="arco-tree-select-suffix"
@@ -1207,17 +1244,22 @@ exports[`renders TreeSelect/demo/search.md correctly 1`] = `
         class="arco-tree-select-view"
         title=""
       >
-        <input
-          autocomplete="off"
-          class="arco-tree-select-view-input"
-          placeholder="Please select ..."
-          style="width:100%"
-          value=""
-        />
         <span
-          aria-hidden="true"
-          class="arco-tree-select-view-value arco-tree-select-hidden"
-        />
+          class="arco-tree-select-view-selector"
+        >
+          <input
+            autocomplete="off"
+            class="arco-tree-select-view-input"
+            placeholder="Please select ..."
+            style="width:100%"
+            value=""
+          />
+          <span
+            class="arco-tree-select-view-value arco-tree-select-view-value-mirror"
+          >
+            Please select ...
+          </span>
+        </span>
         <div
           aria-hidden="true"
           class="arco-tree-select-suffix"
@@ -1339,18 +1381,22 @@ exports[`renders TreeSelect/demo/size.md correctly 1`] = `
         class="arco-tree-select-view"
         title="Trunk"
       >
-        <input
-          aria-hidden="true"
-          autocomplete="off"
-          class="arco-tree-select-view-input arco-tree-select-hidden"
-          style="width:100%;pointer-events:none"
-          tabindex="-1"
-          value="Trunk"
-        />
         <span
-          class="arco-tree-select-view-value"
+          class="arco-tree-select-view-selector"
         >
-          Trunk
+          <input
+            aria-hidden="true"
+            autocomplete="off"
+            class="arco-tree-select-view-input arco-tree-select-hidden"
+            style="width:100%;pointer-events:none"
+            tabindex="-1"
+            value="Trunk"
+          />
+          <span
+            class="arco-tree-select-view-value"
+          >
+            Trunk
+          </span>
         </span>
         <div
           aria-hidden="true"
@@ -1394,18 +1440,23 @@ exports[`renders TreeSelect/demo/treeData.md correctly 1`] = `
     class="arco-tree-select-view"
     title=""
   >
-    <input
-      autocomplete="off"
-      class="arco-tree-select-view-input"
-      placeholder="请选择..."
-      style="width:100%;pointer-events:none"
-      tabindex="-1"
-      value=""
-    />
     <span
-      aria-hidden="true"
-      class="arco-tree-select-view-value arco-tree-select-hidden"
-    />
+      class="arco-tree-select-view-selector"
+    >
+      <input
+        autocomplete="off"
+        class="arco-tree-select-view-input"
+        placeholder="请选择..."
+        style="width:100%;pointer-events:none"
+        tabindex="-1"
+        value=""
+      />
+      <span
+        class="arco-tree-select-view-value arco-tree-select-view-value-mirror"
+      >
+        请选择...
+      </span>
+    </span>
     <div
       aria-hidden="true"
       class="arco-tree-select-suffix"
@@ -1446,17 +1497,20 @@ exports[`renders TreeSelect/demo/virtual.md correctly 1`] = `
       class="arco-tree-select-view"
       title=""
     >
-      <input
-        autocomplete="off"
-        class="arco-tree-select-view-input"
-        style="width:100%;pointer-events:none"
-        tabindex="-1"
-        value=""
-      />
       <span
-        aria-hidden="true"
-        class="arco-tree-select-view-value arco-tree-select-hidden"
-      />
+        class="arco-tree-select-view-selector"
+      >
+        <input
+          autocomplete="off"
+          class="arco-tree-select-view-input"
+          style="width:100%;pointer-events:none"
+          tabindex="-1"
+          value=""
+        />
+        <span
+          class="arco-tree-select-view-value arco-tree-select-view-value-mirror"
+        />
+      </span>
       <div
         aria-hidden="true"
         class="arco-tree-select-suffix"

--- a/components/_class/select-view.tsx
+++ b/components/_class/select-view.tsx
@@ -385,7 +385,7 @@ export const SelectView = (props: SelectViewProps, ref) => {
     const needShowInput = !!((mergedFocused && canFocusInput) || isEmptyValue);
 
     return (
-      <>
+      <span className={`${prefixCls}-view-selector`}>
         <InputComponent
           aria-hidden={!needShowInput || undefined}
           ref={refInput}
@@ -396,13 +396,15 @@ export const SelectView = (props: SelectViewProps, ref) => {
           autoComplete="off"
           {...inputProps}
         />
+
         <span
-          aria-hidden={needShowInput || undefined}
-          className={cs(`${prefixCls}-view-value`, { [`${prefixCls}-hidden`]: needShowInput })}
+          className={cs(`${prefixCls}-view-value`, {
+            [`${prefixCls}-view-value-mirror`]: needShowInput,
+          })}
         >
-          {_inputValue}
+          {_inputValue || inputProps.placeholder}
         </span>
-      </>
+      </span>
     );
   };
 


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [ ] Bug fix
- [x] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|   Select     | 修复 `Select` 在 `width: auto` 时宽度未跟随内容自动变化的问题。 |   Fix the bug that the width of `Select` does not automatically change with the content when `width: auto` is set.  |     Close #1481   |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->
## Checklist:

- [ ] Test suite passes (`npm run test`)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
