### PR TITLE
fix: forbid draging of disabled Transfer items

### DIFF
--- a/components/Transfer/item.tsx
+++ b/components/Transfer/item.tsx
@@ -39,6 +39,7 @@ function TransferItem(props: TransferItemProps) {
   const [dragPosition, setDragPosition] = useState(0);
 
   const _disabled = disabled || item.disabled;
+  const _draggable = draggable && !_disabled;
   const checked = selectedKeys.indexOf(item.key) > -1;
   const itemContent = render ? render(item) : item.value;
 
@@ -62,14 +63,14 @@ function TransferItem(props: TransferItemProps) {
         baseClassName,
         {
           [`${baseClassName}-disabled`]: _disabled,
-          [`${baseClassName}-draggable`]: draggable,
+          [`${baseClassName}-draggable`]: _draggable,
           [`${baseClassName}-gap-top`]: dragOver && dragPosition < 0,
           [`${baseClassName}-gap-bottom`]: dragOver && dragPosition > 0,
           [`${baseClassName}-${dragStatus}`]: dragStatus !== 'none',
         },
         className
       )}
-      draggable={draggable}
+      draggable={_draggable}
       onDragStart={(e) => {
         e.stopPropagation();
         setDragStatus('dragging');


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|  Transfer  |  修复 `Transfer` 开启 `draggable` 时被禁用的选项仍然可以被拖拽的问题。    |  Fix `Transfer` disabled items can still be draggable when `draggable` is enabled.  |   |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->
## Checklist:

- [ ] Test suite passes (`npm run test`)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
