### PR TITLE
feat: InputNumber formatter add sencond paramter to notify user-typing status

### DIFF
--- a/components/InputNumber/README.en-US.md
+++ b/components/InputNumber/README.en-US.md
@@ -32,7 +32,7 @@ An input box which only allows to enter number.
 |icons|Customize icons|{up?: ReactNode;down?: ReactNode;plus?: ReactNode;minus?: ReactNode;} |`-`|-|
 |style|Additional style|CSSProperties |`-`|-|
 |value|To set value|undefined \| number \| string |`-`|-|
-|formatter|Specifies the format of the value presented|(value: number \| string) => string |`-`|-|
+|formatter|Specifies the format of the value presented|(value: number \| string, info: { userTyping: boolean; input: string }) => string |`-`|Param `info` in `2.41.0`|
 |onBlur|Callback when the input is blurred|(e) => void |`-`|-|
 |onChange|Callback when the value changes|(value: number) => void |`-`|-|
 |onFocus|Callback when the input is focused|(e) => void |`-`|-|

--- a/components/InputNumber/README.zh-CN.md
+++ b/components/InputNumber/README.zh-CN.md
@@ -32,7 +32,7 @@
 |icons|配置图标|{up?: ReactNode;down?: ReactNode;plus?: ReactNode;minus?: ReactNode;} |`-`|-|
 |style|节点样式|CSSProperties |`-`|-|
 |value|当前值|undefined \| number \| string |`-`|-|
-|formatter|定义输入框展示值|(value: number \| string) => string |`-`|-|
+|formatter|定义输入框展示值|(value: number \| string, info: { userTyping: boolean; input: string }) => string |`-`|Param `info` in `2.41.0`|
 |onBlur|输入框失去聚焦事件的回调|(e) => void |`-`|-|
 |onChange|变化回调|(value: number) => void |`-`|-|
 |onFocus|输入框聚焦事件的回调|(e) => void |`-`|-|

--- a/components/InputNumber/__test__/index.test.tsx
+++ b/components/InputNumber/__test__/index.test.tsx
@@ -198,14 +198,17 @@ describe('InputNumber ', () => {
           defaultValue={6}
           min={0}
           max={15}
-          formatter={(num) => `${num}%`}
+          formatter={(value, { userTyping, input }) =>
+            userTyping ? input : `${`${value}`.replace(/%/g, '')}%`
+          }
+          parser={(value) => value.replace('%', '')}
           onChange={(val) => (changeValue = val)}
         />
       );
       const input = wrapper.find('.arco-input')[0];
       fireEvent.focus(input);
       fireEvent.change(input, { target: { value: '12' } });
-      expect(getInputValue(wrapper)).toBe('12%');
+      expect(getInputValue(wrapper)).toBe('12');
       expect(changeValue).toBe(12);
       fireEvent.blur(input);
       expect(getInputValue(wrapper)).toBe('12%');

--- a/components/InputNumber/interface.ts
+++ b/components/InputNumber/interface.ts
@@ -88,8 +88,9 @@ export interface InputNumberProps
   /**
    * @zh 定义输入框展示值
    * @en Specifies the format of the value presented
+   * @version Param `info` in `2.41.0`
    */
-  formatter?: (value: number | string) => string;
+  formatter?: (value: number | string, info: { userTyping: boolean; input: string }) => string;
   /**
    * @zh 从 formatter 转换为数字，和 formatter 搭配使用。
    * @en Specifies the value extracted from formatter


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [x] New feature
- [ ] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context

#1510

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|    InputNumber   |  `InputNumber` 组件 `formatter` 新增参数以标记用户输入状态。     |  The `InputNumber` component `formatter` adds a parameter to mark the user-typing state.  |  Close #1510          |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->
## Checklist:

- [x] Test suite passes (`npm run test`)
- [x] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [x] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
