### PR TITLE
enhance: Remove unnecessary searches in  retainInputValueWhileSelect mode

### DIFF
--- a/components/TreeSelect/__test__/index.test.tsx
+++ b/components/TreeSelect/__test__/index.test.tsx
@@ -164,20 +164,36 @@ describe('TreeSelect', () => {
   });
 
   it('showSearch = retainInputValueWhileSelect ', () => {
+    const mockSearch = jest.fn();
     const wrapper = render(
       <TreeSelect
         multiple
         treeData={treeData}
         showSearch={{ retainInputValueWhileSelect: false }}
+        onSearch={mockSearch}
       />
     );
     clickInput();
     expect(wrapper.find(`${prefixCls}-select-view input`)).toHaveLength(1);
-
     fireEvent.change(wrapper.find('input').item(0), { target: { value: '小' } });
     jest.runAllTimers();
     jest.advanceTimersByTime(200);
-    expect(wrapper.querySelector(`${prefixCls}-select-view input`)?.textContent).toBe('');
+    expect(wrapper.find(`${prefixCls}-select-view input`).item(0).getAttribute('value')).toEqual(
+      '小'
+    );
+    expect(mockSearch).toHaveBeenCalledTimes(1);
+    fireEvent.click(wrapper.find(`${prefixCls}-node-title`).item(0));
+    expect(wrapper.find(`${prefixCls}-select-view input`).item(0).getAttribute('value')).toEqual(
+      ''
+    );
+    jest.runAllTimers();
+    jest.advanceTimersByTime(200);
+    expect(mockSearch).toHaveBeenCalledTimes(2);
+
+    fireEvent.click(wrapper.find(`${prefixCls}-node-title`).item(2));
+    jest.runAllTimers();
+    jest.advanceTimersByTime(200);
+    expect(mockSearch).toHaveBeenCalledTimes(2);
   });
 
   it('define onSearch props', () => {

--- a/components/TreeSelect/tree-select.tsx
+++ b/components/TreeSelect/tree-select.tsx
@@ -144,18 +144,18 @@ const TreeSelect: ForwardRefRenderFunction<
     [props.onSearch, treeData, key2nodeProps, props.filterTreeNode]
   );
 
-  const resetInputValue = () => {
+  const resetInputValue = useCallback(() => {
     // 多选选中值时候不清除搜索文本
     let retainInputValueWhileSelect = true;
     if (isObject(props.showSearch)) {
       retainInputValueWhileSelect = props.showSearch.retainInputValueWhileSelect !== false;
     }
-
-    if (props.multiple && !retainInputValueWhileSelect) {
+    // default scene: inputValue = refOnInputChangeCallbackValue =  undefined
+    // if updateTo ''，will trigger an unnecessary onsearch
+    if (props.multiple && !retainInputValueWhileSelect && inputValue !== undefined) {
       tryUpdateInputValue('', 'optionChecked');
-      handleSearch('');
     }
-  };
+  }, [inputValue, props.multiple, JSON.stringify(props.showSearch)]);
 
   const triggerChange = useCallback<typeof setValue>(
     (newValue: LabelValue[], extra) => {
@@ -165,7 +165,7 @@ const TreeSelect: ForwardRefRenderFunction<
         setPopupVisible(false);
       }
     },
-    [setValue]
+    [setValue, resetInputValue]
   );
 
   const handleRemoveCheckedItem = (item, index, e) => {


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [ ] Bug fix
- [x] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context

<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

## Solution

<!-- Describe how the problem is fixed in detail -->

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
| TreeSelect   |   减少 `TreeSelect` 组件在开启 `retainInputValueWhileSelect` 时重新渲染的次数  |  Reduce the number of times the `TreeSelect` component re-renders when `retainInputValueWhileSelect` is enabled |  Closed:  #1271    |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->
## Checklist:

- [ ] Test suite passes (`npm run test`)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
