### PR TITLE
fix: Select shows placeholder as value when value is empty string

### DIFF
--- a/components/Select/__test__/__snapshots__/demo.test.ts.snap
+++ b/components/Select/__test__/__snapshots__/demo.test.ts.snap
@@ -2078,9 +2078,7 @@ exports[`renders Select/demo/relative.md correctly 1`] = `
           />
           <span
             class="arco-select-view-value"
-          >
-            Select city
-          </span>
+          />
         </span>
         <div
           aria-hidden="true"

--- a/components/Select/__test__/index.test.tsx
+++ b/components/Select/__test__/index.test.tsx
@@ -397,4 +397,19 @@ describe('Select', () => {
     fireEvent.keyDown(wrapper.querySelector('input'));
     expect(onKeyDown).toHaveBeenCalled();
   });
+
+  it('show placeholder correctly', async () => {
+    const placeholder = 'Please select';
+    const wrapper = render(
+      <div>
+        <Select value="" placeholder={placeholder} />
+        <Select value={null} placeholder={placeholder} />
+        <Select placeholder={placeholder} />
+      </div>
+    );
+    const eleSpanList = wrapper.querySelectorAll('.arco-select-view-value');
+    expect(eleSpanList[0]).toHaveTextContent('');
+    expect(eleSpanList[1]).toHaveTextContent('');
+    expect(eleSpanList[2]).toHaveTextContent(placeholder);
+  });
 });

--- a/components/_class/select-view.tsx
+++ b/components/_class/select-view.tsx
@@ -402,7 +402,7 @@ export const SelectView = (props: SelectViewProps, ref) => {
             [`${prefixCls}-view-value-mirror`]: needShowInput,
           })}
         >
-          {_inputValue || inputProps.placeholder}
+          {isEmptyValue ? inputProps.placeholder : _inputValue}
         </span>
       </span>
     );


### PR DESCRIPTION

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|  Select  | 修复 `Select` 组件在 `value = ''` 时，错误将 `placeholder` 作为 `value` 展示的 bug。  |   Fixed `Select` component showing `placeholder` as `value` bug when `value = ''`.  |                |

- [ ] Test suite passes (`npm run test`)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
