### PR TITLE
fix: update pageShowDates when mode changed

### DIFF
--- a/components/DatePicker/picker-range.tsx
+++ b/components/DatePicker/picker-range.tsx
@@ -275,7 +275,7 @@ const Picker = (baseProps: RangePickerProps) => {
       blurInput();
     }
     firstRange.current = mergedPopupVisible;
-  }, [mergedPopupVisible]);
+  }, [mergedPopupVisible, mode]);
 
   const startStr = propsValueDayjs?.[0]?.format(format);
   const endStr = propsValueDayjs?.[1]?.format(format);


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context

<!-- Explain what problem does the PR solve -->
RangePicker在trigger打开的情况下切换mode，RangePicker的年份没有及时更新
<!-- Link to related open issues if applicable -->
https://codesandbox.io/s/sweet-sid-msnhzj?file=/demo.js
## Solution
<!-- Describe how the problem is fixed in detail -->
添加mode作为更新pageShowDates的依赖
## How is the change tested?
<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->
无影响用例，直接单元测试
## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|       DatePicker    |          修复 `RangePicker` 在弹出层打开的情况下切换 `mode` 年份不更新的 bug     |         Fix RangePicker switching mode year without updating when popup is turned on      |       #1570          |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->
## Checklist:

- [x] Test suite passes (`npm run test`)
- [x] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [x] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
