### PR TITLE
fix(Tabs): addButton width causes inaccurate calculation of header sc…

### DIFF
--- a/stories/Tabs.story.tsx
+++ b/stories/Tabs.story.tsx
@@ -1,42 +1,23 @@
 import React, { useState } from 'react';
-import { Tabs, Typography, Input, Button } from '@self';
-import { IconEdit } from '@self/icon';
+import { Tabs, Typography, Button } from '@self';
 
 const TabPane = Tabs.TabPane;
+let count = 5;
 
-let count = 10;
-
+const style = {
+  textAlign: 'center',
+  marginTop: 20,
+};
 const initTabs = [...new Array(count)].map((x, i) => ({
   title: `Tab ${i + 1}`,
   key: `key${i + 1}`,
   content: `${i + 1}`,
 }));
 
-const TabTitle = (props: { title: string }) => {
-  const { title } = props;
-  const [editing, setEditing] = React.useState(true);
-  return (
-    <div style={{ display: 'inline-flex', alignItems: 'center', height: 40 }}>
-      {editing ? (
-        <Input
-          autoFocus
-          style={{ width: 30, margin: '10px' }}
-          value={title}
-          onBlur={() => setEditing(false)}
-        />
-      ) : (
-        <div style={{ width: 30 }}>
-          {title}
-          <IconEdit style={{ marginLeft: 10 }} onClick={() => setEditing(true)} />
-        </div>
-      )}
-    </div>
-  );
-};
-
 function DemoTabs() {
   const [tabs, setTabs] = useState(initTabs);
   const [activeTab, setActiveTab] = useState('key2');
+  const [bool, setBool] = useState(true);
 
   const handleAddTab = () => {
     const newTab = {
@@ -45,42 +26,29 @@ function DemoTabs() {
       content: `${count}`,
     };
     setTabs([...tabs, newTab]);
+    if (tabs.length >= 10) {
+      setBool(false);
+    }
     setActiveTab(newTab.key);
   };
 
-  const handleDeleteTab = (key: string) => {
-    const index = tabs.findIndex((x) => x.key === key);
-    const newTabs = tabs.slice(0, index).concat(tabs.slice(index + 1));
-
-    if (key === activeTab && index > -1 && newTabs.length) {
-      setActiveTab(newTabs[index] ? newTabs[index].key : newTabs[index - 1].key);
-    }
-
-    if (index > -1) {
-      setTabs(newTabs);
-    }
-  };
-
   return (
-    <div>
-      <Tabs
-        editable
-        type="card-gutter"
-        activeTab={activeTab}
-        onAddTab={handleAddTab}
-        onDeleteTab={handleDeleteTab}
-        onChange={setActiveTab}
-        extra={<Button>我是一个超级超级超级长的Button</Button>}
-      >
-        {tabs.map((x, i) => (
-          <TabPane destroyOnHide key={x.key} title={<TabTitle title={x.title} />}>
-            <Typography.Paragraph
-              style={{ textAlign: 'center', marginTop: 20 }}
-            >{`Content of Tab Panel ${x.content}`}</Typography.Paragraph>
-          </TabPane>
-        ))}
-      </Tabs>
-    </div>
+    <Tabs
+      editable={bool}
+      addButton={<Button onClick={handleAddTab}>{tabs.length} +</Button>}
+      showAddButton
+      activeTab={activeTab}
+      onChange={setActiveTab}
+      extra={<Button>a</Button>}
+    >
+      {tabs.map((x, i) => (
+        <TabPane destroyOnHide key={x.key} title={x.title}>
+          <Typography.Paragraph
+            style={style}
+          >{`Content of Tab Panel ${x.content}`}</Typography.Paragraph>
+        </TabPane>
+      ))}
+    </Tabs>
   );
 }
 


### PR DESCRIPTION
…roll timing.

<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context

<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

## Solution

<!-- Describe how the problem is fixed in detail -->

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|  Tabs |   修复 Tabs 组件的 `addButton` 宽度造成滚动时机计算不准确的 bug   |  Fix the bug that the width of `addButton` of the Tabs component causes inaccurate calculation of scrolling timing  |    Closed: #1585    |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->
## Checklist:

- [ ] Test suite passes (`npm run test`)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
