### PR TITLE
style: Select's input style when it is invisible

### DIFF
--- a/components/Select/style/mixin.less
+++ b/components/Select/style/mixin.less
@@ -145,11 +145,12 @@
 
     .hide-input-element() {
       // 需要在隐藏 input 的同时保证其能被 Tab 键聚焦
-      // 故不要用 display: none / visibility: hidden
-      // width 设置为0的隐藏方式，会导致在火狐浏览器下select-view.tsx中role=combobox的div触发onFocus之后不能立刻触发onClick
+      // 故不要用 display: none / visibility: hidden / width: 0
+      // width 设置为 0，会导致在火狐浏览器下触发 onFocus 之后不能立刻触发 onClick
+      // https://github.com/arco-design/arco-design/issues/1232
       opacity: 0;
-      // width: 0 的 div 还能引起换行导致输入框被撑开，将其脱离标准文档流
       position: absolute;
+      pointer-events: none;
     }
 
     &-multiple,


### PR DESCRIPTION
缺少 `pointer-events: none` 可能导致绝对定位的 `<input />` 遮挡下边的元素。