### PR TITLE
fix: modal hook

### DIFF
--- a/components/Modal/__test__/useModal.test.tsx
+++ b/components/Modal/__test__/useModal.test.tsx
@@ -1,6 +1,6 @@
 import React, { createContext } from 'react';
 import Modal from '..';
-import { $, cleanup, render } from '../../../tests/util';
+import { $, cleanup, fireEvent, render } from '../../../tests/util';
 
 describe('Modal api test', () => {
   beforeEach(() => {
@@ -13,11 +13,17 @@ describe('Modal api test', () => {
   });
 
   it('useModal', () => {
-    const [modal, contextHolder] = Modal.useModal();
-
     const ConfigContext = createContext({});
+    let modal;
+    const Demo = () => {
+      const [_modal, _contextHolder] = Modal.useModal();
 
-    render(<ConfigContext.Provider value="PJY">{contextHolder}</ConfigContext.Provider>);
+      modal = _modal;
+
+      return <ConfigContext.Provider value="PJY">{_contextHolder}</ConfigContext.Provider>;
+    };
+
+    render(<Demo />);
 
     const m = modal.confirm?.({
       title: <span id="modal-title">123</span>,
@@ -35,6 +41,109 @@ describe('Modal api test', () => {
 
     m?.close();
 
+    jest.runAllTimers();
+
+    expect($('.arco-modal').length).toBe(0);
+  });
+
+  it('useModal update when onOk return promise', () => {
+    const ConfigContext = createContext({});
+
+    let modal;
+    const Demo = () => {
+      const [_modal, _contextHolder] = Modal.useModal();
+
+      modal = _modal;
+
+      return <ConfigContext.Provider value="PJY">{_contextHolder}</ConfigContext.Provider>;
+    };
+
+    render(<Demo />);
+
+    const m = modal.confirm?.({
+      title: 'title',
+      content: '123',
+      icon: null,
+      okButtonProps: { id: 'ok-btn' },
+      onOk: () =>
+        new Promise((resolve) => {
+          m?.update({
+            title: 'new title',
+          });
+          setTimeout(() => {
+            resolve(null);
+          }, 1000);
+        }),
+    });
+
+    jest.runAllTimers();
+
+    expect($('.arco-modal-title')[0].innerHTML).toBe('<span>title</span>');
+
+    m?.update({ content: 'yyds' });
+    expect($('.arco-modal-title')[0].innerHTML).toBe('<span>title</span>');
+    expect($('.arco-modal-content')[0].innerHTML).toBe('yyds');
+
+    fireEvent.click($('#ok-btn')[0] as HTMLElement);
+
+    expect($('.arco-modal-title')[0].innerHTML).toBe('<span>new title</span>');
+    expect($('.arco-modal-content')[0].innerHTML).toBe('yyds');
+
+    m.close();
+    jest.runAllTimers();
+
+    expect($('.arco-modal').length).toBe(0);
+  });
+
+  it('continue update modal', () => {
+    const ConfigContext = createContext({});
+
+    let modal;
+    const Demo = () => {
+      const [_modal, _contextHolder] = Modal.useModal();
+
+      modal = _modal;
+
+      return <ConfigContext.Provider value="PJY">{_contextHolder}</ConfigContext.Provider>;
+    };
+
+    render(<Demo />);
+
+    const m = modal.confirm?.({
+      title: 'title',
+      content: '123',
+      icon: 'icon-',
+      okButtonProps: { id: 'ok-btn' },
+      onOk: () =>
+        new Promise((resolve) => {
+          m?.update({
+            title: 'new title',
+          });
+          setTimeout(() => {
+            resolve(null);
+          }, 1000);
+        }),
+    });
+
+    jest.runAllTimers();
+
+    expect($('.arco-modal-title')[0].innerHTML).toBe('<span>icon-title</span>');
+
+    m?.update({ content: 'yyds', icon: 'icontest-' });
+
+    expect($('.arco-modal-title')[0].innerHTML).toBe('<span>icontest-title</span>');
+    expect($('.arco-modal-content')[0].innerHTML).toBe('yyds');
+
+    fireEvent.click($('#ok-btn')[0] as HTMLElement);
+
+    expect($('.arco-modal-title')[0].innerHTML).toBe('<span>icontest-new title</span>');
+    expect($('.arco-modal-content')[0].innerHTML).toBe('yyds');
+
+    m?.update({ icon: 'icontest2-' });
+
+    expect($('.arco-modal-title')[0].innerHTML).toBe('<span>icontest2-new title</span>');
+
+    m.close();
     jest.runAllTimers();
 
     expect($('.arco-modal').length).toBe(0);

--- a/components/Modal/useModal/hookModal.tsx
+++ b/components/Modal/useModal/hookModal.tsx
@@ -12,11 +12,8 @@ function HookModal(props, ref) {
   const [config, setConfig] = useState<ConfirmProps>(props);
 
   useImperativeHandle(ref, () => ({
-    update: (newConfig: ConfirmProps) => {
-      setConfig({
-        ...config,
-        ...newConfig,
-      });
+    update: (config: ConfirmProps) => {
+      setConfig(config);
     },
     close: () => {
       setVisible(false);

--- a/components/Modal/useModal/hookModal.tsx
+++ b/components/Modal/useModal/hookModal.tsx
@@ -26,20 +26,20 @@ function HookModal(props, ref) {
   function onOk() {
     const ret = config.onOk && config.onOk();
     if (ret && ret.then) {
-      setConfig({
+      setConfig((config) => ({
         ...config,
         confirmLoading: true,
-      });
+      }));
       ret.then(
         () => {
           setVisible(false);
         },
         (e: Error) => {
           console.error(e);
-          setConfig({
+          setConfig((config) => ({
             ...config,
             confirmLoading: false,
-          });
+          }));
         }
       );
     }

--- a/components/Modal/useModal/index.tsx
+++ b/components/Modal/useModal/index.tsx
@@ -26,6 +26,7 @@ function useModal(): [modalFunctionsType, ReactElement] {
   function addNewModal(config) {
     uuid += 1;
     const modalRef = createRef<HookModalRef>();
+    let currentConfig = { ...config };
 
     function afterClose() {
       config.afterClose && config.afterClose();
@@ -33,7 +34,12 @@ function useModal(): [modalFunctionsType, ReactElement] {
     }
 
     const modal = (
-      <HookModal key={uuid} ref={modalRef} {...normalizeConfig(config)} afterClose={afterClose} />
+      <HookModal
+        key={uuid}
+        ref={modalRef}
+        {...normalizeConfig({ ...config })}
+        afterClose={afterClose}
+      />
     );
 
     contextHolderRef.current?.addInstance(modal);
@@ -46,8 +52,12 @@ function useModal(): [modalFunctionsType, ReactElement] {
       modalRef.current?.close();
     }
 
-    function update(config) {
-      modalRef.current?.update(config);
+    function update(newConfig) {
+      currentConfig = {
+        ...currentConfig,
+        ...newConfig,
+      };
+      modalRef.current?.update(normalizeConfig({ ...currentConfig }));
     }
 
     destroyList.push(close);

--- a/components/Modal/useModal/index.tsx
+++ b/components/Modal/useModal/index.tsx
@@ -1,4 +1,4 @@
-import React, { createRef, ReactElement } from 'react';
+import React, { createRef, useRef, ReactElement } from 'react';
 import ContextHolderElement, { HolderRef } from '../../_util/contextHolder';
 import HookModal, { HookModalRef } from './hookModal';
 import { normalizeConfig, ConfirmProps } from '../confirm';
@@ -18,7 +18,7 @@ type modalFunctionsType = {
 };
 
 function useModal(): [modalFunctionsType, ReactElement] {
-  const contextHolderRef = createRef<HolderRef>();
+  const contextHolderRef = useRef<HolderRef>();
   const holderEle = <ContextHolderElement ref={contextHolderRef} />;
 
   let uuid = 0;


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context

<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

## Solution

<!-- Describe how the problem is fixed in detail -->

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|  Modal         |   修复 `Modal.useModal` 返回的 `modal.confirm` 在 `useCallback` 中调用时，不显示弹出层的 bug。             |               Fix the bug that the popup layer is not displayed when `modal.confirm` returned by `Modal.useModal` is called in `useCallback`. | close #1621                |
|  Modal         |     修复通过 `Modal.useModal` 创建的弹出层在通过 `update` 方法更新 title 时，icon 丢失的 bug。                       |    Fix the bug that the icon is lost when the title of the popup layer created by `Modal.useModal` is updated by the `update` method            ||
|  Modal         |     修复通过 `Modal.useModal` 创建的弹出层在 onOK 设置为 Promise 时，Promise 中通过 `update` 更新弹出层内容不生效的 bug。          |   Fix the bug that updating the content of the popup layer through `update` in Promise does not take effect when onOK is set to Promise for the popup layer created by `Modal.useModal`.            |                |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->
## Checklist:

- [ ] Test suite passes (`npm run test`)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
