### PR TITLE
fix: avoid Number.toFiexd() error while value's precision is larger than 100

### DIFF
--- a/components/InputNumber/__test__/index.test.tsx
+++ b/components/InputNumber/__test__/index.test.tsx
@@ -290,4 +290,9 @@ describe('InputNumber ', () => {
     expect(getInputValue(wrapper)).toBe(valueStrAfterAddOnce);
     expect(onChange).toBeCalledWith(valueStrAfterAddOnce);
   });
+
+  it('avoid Number.toFixed() error while precision is larger than 100', () => {
+    const wrapper = render(<InputNumber defaultValue={1e-200} />);
+    expect(getInputValue(wrapper)).toBe('0');
+  });
 });

--- a/components/InputNumber/utils.ts
+++ b/components/InputNumber/utils.ts
@@ -36,7 +36,9 @@ export function toSafeString(number: number | string): string {
       return BigInt(number).toString();
     }
 
-    nativeNumberStr = Number(number).toFixed(getNumberPrecision(nativeNumberStr));
+    // This may lose precision, but foFixed must accept argument in the range 0-100
+    const precision = getNumberPrecision(nativeNumberStr);
+    nativeNumberStr = Number(number).toFixed(Math.min(100, precision));
   }
 
   return trimNumber(nativeNumberStr).fullStr;


### PR DESCRIPTION


<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context

<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

## Solution

<!-- Describe how the problem is fixed in detail -->

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|     InputNumber      |  修复 `InputNumber` 组件传入精度超过 100 (e.g. 1e-200) 的小数时页面崩溃的问题。  |  Fix the page crash issue when the `InputNumber` passes a decimal with a precision greater than 100 (e.g. 1e-200).   |                |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->
## Checklist:

- [ ] Test suite passes (`npm run test`)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
