### PR TITLE
feat(Menu): allow to customize the text displayed when menu overflows

### DIFF
--- a/components/Menu/README.en-US.md
+++ b/components/Menu/README.en-US.md
@@ -26,7 +26,7 @@ A component to organize, arrange, and display a list of options.
 |className|Additional css class|string \| string[] |`-`|-|
 |defaultOpenKeys|The initially opened menu item's key array|string[] |`-`|-|
 |defaultSelectedKeys|The initially selected menu item's key array|string[] |`-`|-|
-|ellipsis|Whether the horizontal menu automatically collapses when it overflows|\| boolean\| {text?: string;} |`true`|2.24.0|
+|ellipsis|Whether the horizontal menu automatically collapses when it overflows|\| boolean\| {text?: ReactNode;} |`true`|2.24.0|
 |icons|Customize icons|{horizontalArrowDown?: ReactNode \| null;popArrowRight?: ReactNode \| null;collapseDefault?: ReactNode \| null;collapseActive?: ReactNode \| null;} |`-`|-|
 |openKeys|Opened menu item's key array|string[] |`-`|-|
 |scrollConfig|Scroll to the configuration item in the visible area and receive all the parameters of[scroll-into-view-if-needed](https://github.com/stipsan/scroll-into-view-if-needed)|{ [key: string]: any } |`-`|-|

--- a/components/Menu/README.en-US.md
+++ b/components/Menu/README.en-US.md
@@ -18,16 +18,15 @@ A component to organize, arrange, and display a list of options.
 |autoOpen|Whether to expand all multi-level menus by default|boolean |`-`|-|
 |autoScrollIntoView|Whether to automatically scroll the selected item to the visible area|boolean |`-`|-|
 |collapse|Whether to collapse the menu horizontally|boolean |`-`|-|
-|ellipsis|Whether the horizontal menu automatically collapses when it overflows|boolean |`true`|2.24.0|
 |hasCollapseButton|Whether built-in folding button|boolean |`-`|-|
 |selectable|Whether is the menu item selectable|boolean |`true`|-|
 |levelIndent|Indentation between levels|number |`-`|-|
-|ellipsisText|The text displayed when the horizontal menu overflows|string |`···`|2.44.0|
 |mode|Mode of Menu|'vertical' \| 'horizontal' \| 'pop' \| 'popButton' |`vertical`|-|
 |theme|Theme of Menu|'light' \| 'dark' |`light`|-|
 |className|Additional css class|string \| string[] |`-`|-|
 |defaultOpenKeys|The initially opened menu item's key array|string[] |`-`|-|
 |defaultSelectedKeys|The initially selected menu item's key array|string[] |`-`|-|
+|ellipsis|Whether the horizontal menu automatically collapses when it overflows|\| boolean\| {text?: string;} |`true`|2.24.0|
 |icons|Customize icons|{horizontalArrowDown?: ReactNode \| null;popArrowRight?: ReactNode \| null;collapseDefault?: ReactNode \| null;collapseActive?: ReactNode \| null;} |`-`|-|
 |openKeys|Opened menu item's key array|string[] |`-`|-|
 |scrollConfig|Scroll to the configuration item in the visible area and receive all the parameters of[scroll-into-view-if-needed](https://github.com/stipsan/scroll-into-view-if-needed)|{ [key: string]: any } |`-`|-|

--- a/components/Menu/README.en-US.md
+++ b/components/Menu/README.en-US.md
@@ -22,6 +22,7 @@ A component to organize, arrange, and display a list of options.
 |hasCollapseButton|Whether built-in folding button|boolean |`-`|-|
 |selectable|Whether is the menu item selectable|boolean |`true`|-|
 |levelIndent|Indentation between levels|number |`-`|-|
+|ellipsisText|The text displayed when the horizontal menu overflows|string |`···`|2.44.0|
 |mode|Mode of Menu|'vertical' \| 'horizontal' \| 'pop' \| 'popButton' |`vertical`|-|
 |theme|Theme of Menu|'light' \| 'dark' |`light`|-|
 |className|Additional css class|string \| string[] |`-`|-|

--- a/components/Menu/README.zh-CN.md
+++ b/components/Menu/README.zh-CN.md
@@ -18,16 +18,15 @@
 |autoOpen|默认展开所有多级菜单|boolean |`-`|-|
 |autoScrollIntoView|是否自动滚动选中项目到可见区域|boolean |`-`|-|
 |collapse|是否水平折叠收起菜单|boolean |`-`|-|
-|ellipsis|水平菜单是否自动溢出省略|boolean |`true`|2.24.0|
 |hasCollapseButton|是否内置折叠按钮|boolean |`-`|-|
 |selectable|菜单选项是否可选|boolean |`true`|-|
 |levelIndent|层级之间的缩进量|number |`-`|-|
-|ellipsisText|水平菜单溢出省略时显示的文本|string |`···`|2.44.0|
 |mode|菜单类型，目前支持垂直（vertical）、水平菜单（horizontal）、弹出（pop）|'vertical' \| 'horizontal' \| 'pop' \| 'popButton' |`vertical`|-|
 |theme|菜单风格|'light' \| 'dark' |`light`|-|
 |className|节点类名|string \| string[] |`-`|-|
 |defaultOpenKeys|初始展开的子菜单 key 数组|string[] |`-`|-|
 |defaultSelectedKeys|初始选中的菜单项 key 数组|string[] |`-`|-|
+|ellipsis|水平菜单是否自动溢出省略|\| boolean\| {text?: string;} |`true`|2.24.0|
 |icons|用于定制图标|{horizontalArrowDown?: ReactNode \| null;popArrowRight?: ReactNode \| null;collapseDefault?: ReactNode \| null;collapseActive?: ReactNode \| null;} |`-`|-|
 |openKeys|展开的子菜单 key 数组（受控模式）|string[] |`-`|-|
 |scrollConfig|滚动到可见区域的配置项，接收所有[scroll-into-view-if-needed](https://github.com/stipsan/scroll-into-view-if-needed)的参数|{ [key: string]: any } |`-`|-|

--- a/components/Menu/README.zh-CN.md
+++ b/components/Menu/README.zh-CN.md
@@ -22,6 +22,7 @@
 |hasCollapseButton|是否内置折叠按钮|boolean |`-`|-|
 |selectable|菜单选项是否可选|boolean |`true`|-|
 |levelIndent|层级之间的缩进量|number |`-`|-|
+|ellipsisText|水平菜单溢出省略时显示的文本|string |`···`|2.44.0|
 |mode|菜单类型，目前支持垂直（vertical）、水平菜单（horizontal）、弹出（pop）|'vertical' \| 'horizontal' \| 'pop' \| 'popButton' |`vertical`|-|
 |theme|菜单风格|'light' \| 'dark' |`light`|-|
 |className|节点类名|string \| string[] |`-`|-|

--- a/components/Menu/README.zh-CN.md
+++ b/components/Menu/README.zh-CN.md
@@ -26,7 +26,7 @@
 |className|节点类名|string \| string[] |`-`|-|
 |defaultOpenKeys|初始展开的子菜单 key 数组|string[] |`-`|-|
 |defaultSelectedKeys|初始选中的菜单项 key 数组|string[] |`-`|-|
-|ellipsis|水平菜单是否自动溢出省略|\| boolean\| {text?: string;} |`true`|2.24.0|
+|ellipsis|水平菜单是否自动溢出省略|\| boolean\| {text?: ReactNode;} |`true`|2.24.0|
 |icons|用于定制图标|{horizontalArrowDown?: ReactNode \| null;popArrowRight?: ReactNode \| null;collapseDefault?: ReactNode \| null;collapseActive?: ReactNode \| null;} |`-`|-|
 |openKeys|展开的子菜单 key 数组（受控模式）|string[] |`-`|-|
 |scrollConfig|滚动到可见区域的配置项，接收所有[scroll-into-view-if-needed](https://github.com/stipsan/scroll-into-view-if-needed)的参数|{ [key: string]: any } |`-`|-|

--- a/components/Menu/index.tsx
+++ b/components/Menu/index.tsx
@@ -24,6 +24,7 @@ const defaultProps: MenuProps = {
   mode: 'vertical',
   selectable: true,
   ellipsis: true,
+  ellipsisText: '···',
 };
 
 function Menu(baseProps: MenuProps, ref) {
@@ -44,6 +45,7 @@ function Menu(baseProps: MenuProps, ref) {
     triggerProps,
     tooltipProps,
     ellipsis,
+    ellipsisText,
     accordion,
     autoOpen,
     autoScrollIntoView,
@@ -123,7 +125,7 @@ function Menu(baseProps: MenuProps, ref) {
       <>
         <div className={`${prefixCls}-inner`}>
           {mode === 'horizontal' && ellipsis !== false ? (
-            <OverflowWrap>{childrenList}</OverflowWrap>
+            <OverflowWrap ellipsisText={ellipsisText}>{childrenList}</OverflowWrap>
           ) : (
             childrenList
           )}

--- a/components/Menu/index.tsx
+++ b/components/Menu/index.tsx
@@ -17,6 +17,7 @@ import MenuContext from './context';
 import useMergeProps from '../_util/hooks/useMergeProps';
 import useKeyboardEvent from '../_util/hooks/useKeyboardEvent';
 import useId from '../_util/hooks/useId';
+import { isObject } from '../_util/is';
 
 const DEFAULT_THEME: MenuProps['theme'] = 'light';
 
@@ -24,7 +25,6 @@ const defaultProps: MenuProps = {
   mode: 'vertical',
   selectable: true,
   ellipsis: true,
-  ellipsisText: '···',
 };
 
 function Menu(baseProps: MenuProps, ref) {
@@ -45,7 +45,6 @@ function Menu(baseProps: MenuProps, ref) {
     triggerProps,
     tooltipProps,
     ellipsis,
-    ellipsisText,
     accordion,
     autoOpen,
     autoScrollIntoView,
@@ -125,7 +124,9 @@ function Menu(baseProps: MenuProps, ref) {
       <>
         <div className={`${prefixCls}-inner`}>
           {mode === 'horizontal' && ellipsis !== false ? (
-            <OverflowWrap ellipsisText={ellipsisText}>{childrenList}</OverflowWrap>
+            <OverflowWrap ellipsisText={isObject(ellipsis) ? ellipsis.text : '···'}>
+              {childrenList}
+            </OverflowWrap>
           ) : (
             childrenList
           )}

--- a/components/Menu/interface.tsx
+++ b/components/Menu/interface.tsx
@@ -69,6 +69,13 @@ export interface MenuProps extends Omit<HTMLAttributes<HTMLDivElement>, 'classNa
    */
   ellipsis?: boolean;
   /**
+   * @zh 水平菜单溢出省略时显示的文本
+   * @en The text displayed when the horizontal menu overflows
+   * @defaultValue ···
+   * @version 2.44.0
+   */
+  ellipsisText?: string;
+  /**
    * @zh 是否自动滚动选中项目到可见区域
    * @en Whether to automatically scroll the selected item to the visible area
    */

--- a/components/Menu/interface.tsx
+++ b/components/Menu/interface.tsx
@@ -70,7 +70,7 @@ export interface MenuProps extends Omit<HTMLAttributes<HTMLDivElement>, 'classNa
   ellipsis?:
     | boolean
     | {
-        text?: string;
+        text?: ReactNode;
       };
   /**
    * @zh 是否自动滚动选中项目到可见区域

--- a/components/Menu/interface.tsx
+++ b/components/Menu/interface.tsx
@@ -67,14 +67,11 @@ export interface MenuProps extends Omit<HTMLAttributes<HTMLDivElement>, 'classNa
    * @defaultValue true
    * @version 2.24.0
    */
-  ellipsis?: boolean;
-  /**
-   * @zh 水平菜单溢出省略时显示的文本
-   * @en The text displayed when the horizontal menu overflows
-   * @defaultValue ···
-   * @version 2.44.0
-   */
-  ellipsisText?: string;
+  ellipsis?:
+    | boolean
+    | {
+        text?: string;
+      };
   /**
    * @zh 是否自动滚动选中项目到可见区域
    * @en Whether to automatically scroll the selected item to the visible area

--- a/components/Menu/overflow-wrap.tsx
+++ b/components/Menu/overflow-wrap.tsx
@@ -18,7 +18,7 @@ function translatePxToNumber(str): number {
 }
 
 interface OverflowWrapProps {
-  ellipsisText?: string;
+  ellipsisText?: ReactNode;
   children: ReactNode;
 }
 

--- a/components/Menu/overflow-wrap.tsx
+++ b/components/Menu/overflow-wrap.tsx
@@ -18,11 +18,12 @@ function translatePxToNumber(str): number {
 }
 
 interface OverflowWrapProps {
+  ellipsisText?: string;
   children: ReactNode;
 }
 
 const OverflowWrap = (props: OverflowWrapProps) => {
-  const { children } = props;
+  const { children, ellipsisText = '···' } = props;
   const { prefixCls } = useContext(MenuContext);
 
   const refUl = useRef(null);
@@ -89,7 +90,7 @@ const OverflowWrap = (props: OverflowWrapProps) => {
   const renderOverflowSubMenu = (children, isMirror = false) => {
     return (
       <SubMenu
-        title={<span>···</span>}
+        title={<span>{ellipsisText}</span>}
         key={`arco-menu-overflow-sub-menu${isMirror ? '-mirror' : ''}`}
         className={isMirror ? overflowSubMenuMirrorClass : overflowSubMenuClass}
         {...props}


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [x] New feature
- [ ] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context

<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

目前水平菜单(Menu)自动溢出省略状态下写死了 `···` 文本，有很多场景需要自定义这个符号的具体字符，比如使用 `更多` 作为水平溢出省略的自定义文本。这个 PR 就是为了解决这类问题。

Currently the horizontal menu automatic overflow omission state is hard code `···` text, there are many scenarios need to customize the specific characters of this symbol, such as the use of `more` as the horizontal overflow custom text. This PR is designed to solve such problems.

## Solution

<!-- Describe how the problem is fixed in detail -->

为 Menu 组件增加 `ellipsisText` prop，在 `ellipsis` 开启的时候参考该参数渲溢出的 Submenu，为了避免 break change，该参数的默认值为 `···`。

Add `ellipsisText` prop to the Menu component, and render the overflow Submenu title with this prop when `ellipsis` is turned on. To avoid break change, the default value of this parameter is `···`.

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|  Menu         |     `Menu` 组件新增 `ellipsisText` 属性以自定义溢出文本。          | The Menu component adds an ellipsisText prop to customize the overflow submenu title.              |                |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->
## Checklist:

- [x] Test suite passes (`npm run test`)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
