### PR TITLE
fix: collapse onChange is called twice when header icon or title is clicked due to bubbling

### DIFF
--- a/components/Collapse/__test__/index.test.tsx
+++ b/components/Collapse/__test__/index.test.tsx
@@ -115,6 +115,32 @@ describe('Collapse', () => {
     expect(wrapper.find(`${prefixCls}-item-active`)).toHaveLength(data.length);
   });
 
+  it('onChange should be called only once on expanded or collapsed', () => {
+    jest.useFakeTimers();
+    const changeCollapse = jest.fn();
+    const activeKeys = ['2'];
+    const wrapper = render(
+      <Collapse defaultActiveKey={activeKeys} onChange={changeCollapse}>
+        {data.map((item, index) => (
+          <CollapseItem key={index} header={item.header} name={index.toString()}>
+            {item.content}
+          </CollapseItem>
+        ))}
+      </Collapse>
+    );
+
+    // Click icon -> one onChange call
+    fireEvent.click(
+      wrapper.find(`${prefixCls}-item`).item(0).querySelector(`${prefixCls}-item-header-icon`)!
+    );
+    expect(changeCollapse.mock.calls).toHaveLength(1);
+    // Click header -> another one onChange call
+    fireEvent.click(
+      wrapper.find(`${prefixCls}-item`).item(0).querySelector(`${prefixCls}-item-header-title`)!
+    );
+    expect(changeCollapse.mock.calls).toHaveLength(2);
+  });
+
   it('render correctly when content empty', () => {
     const wrapper = render(
       <Collapse>

--- a/components/Collapse/item.tsx
+++ b/components/Collapse/item.tsx
@@ -34,7 +34,10 @@ function Item(props: PropsWithChildren<CollapseItemProps>, ref) {
     if (disabled) return;
     const { triggerRegion } = ctx;
     const triggerRegionLevel = triggerRegion === 'icon' ? 0 : triggerRegion === 'header' ? 1 : 2;
-    regionLevel <= triggerRegionLevel && ctx.onToggle(name, e);
+    if (regionLevel <= triggerRegionLevel) {
+      ctx.onToggle(name, e);
+      e.stopPropagation();
+    }
   };
 
   return (


### PR DESCRIPTION
…licked due to bubbling

<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context

<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

Collapse onChange is called twice when header icon or title is clicked due to bubbling

## Solution

<!-- Describe how the problem is fixed in detail -->

Stop click event bubbling

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|  Collapse   |    修复 Collapse 点击 header icon 或者 header title 进行展开/折叠时会触发2次 onChange 的 bug。    |     Collapse onChange is called twice when header icon or title is clicked due to bubbling          |     https://github.com/arco-design/arco-design/issues/1722           |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->
## Checklist:

- [x] Test suite passes (`npm run test`)
- [x] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [x] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
