### PR TITLE
fix(TreeSelect): onVisibleChange is not triggered after the drop-down…

### DIFF
--- a/components/DatePicker/interface.tsx
+++ b/components/DatePicker/interface.tsx
@@ -252,7 +252,7 @@ export interface BaseDatePickerProps {
   /**
    * @zh 展示日期的格式，参考[dayjs](https://github.com/iamkun/dayjs)。使用 `string` 时，可以手动键入和编辑日期。使用 `(value: Dayjs) => string` 时，只能在 Picker 中选取日期。
    * @en Date format, refer to [dayjs](https://github.com/iamkun/dayjs). When using a `string`, manual editing is allowed. When using `(value: Dayjs) => string`, value must be picked from Picker.
-   * @defaultValue YYYY-MM-DD 
+   * @defaultValue YYYY-MM-DD
    */
   format?: string | ((value: Dayjs) => string);
   /**

--- a/components/TreeSelect/__demo__/basic.md
+++ b/components/TreeSelect/__demo__/basic.md
@@ -19,7 +19,9 @@ const TreeNode = TreeSelect.Node;
 
 const App = () => {
   return (
-    <TreeSelect defaultValue="node1" style={{ width: 300 }} allowClear>
+    <TreeSelect defaultValue="node1" style={{ width: 300 }} allowClear onVisibleChange={() => {
+      console.log('a')
+    }}>
       <TreeNode key="node1" title="Trunk">
         <TreeNode key="node2" title="Leaf" />
       </TreeNode>

--- a/components/TreeSelect/__test__/index.test.tsx
+++ b/components/TreeSelect/__test__/index.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import TreeSelect from '..';
 import { normalizeValueToArray } from '../utils';
-import { cleanup, fireEvent, render } from '../../../tests/util';
+import { $, cleanup, fireEvent, render } from '../../../tests/util';
 
 const treeData = [
   {
@@ -97,7 +97,22 @@ describe('TreeSelect', () => {
     expect(mockVisibleChange).toHaveBeenCalledTimes(2);
     expect(mockVisibleChange.mock.calls[1]).toEqual([false]);
     // todo
-    // expect(wrapper.find('Tree')).toHaveLength(0);
+    expect(wrapper.find('Tree')).toHaveLength(0);
+    clickInput();
+
+    jest.runAllTimers();
+    expect(mockVisibleChange).toHaveBeenCalledTimes(3);
+    expect(mockVisibleChange.mock.calls[2]).toEqual([true]);
+
+    const text = $('.arco-tree-node-title-text').item(0).innerHTML;
+    fireEvent.click($('.arco-tree-node-title').item(0) as HTMLDivElement);
+
+    jest.runAllTimers();
+    expect(wrapper.find('.arco-tree')).toHaveLength(0);
+    expect($('.arco-tree-select-view-value').item(0).innerHTML).toBe(text);
+
+    expect(mockVisibleChange).toHaveBeenCalledTimes(4);
+    expect(mockVisibleChange.mock.calls[3]).toEqual([false]);
   });
 
   it('select correctly', () => {
@@ -683,8 +698,8 @@ describe('TreeSelect', () => {
 
   it('onKeyDown is called', () => {
     const onKeyDown = jest.fn();
-    const wrapper = render(<TreeSelect onKeyDown={onKeyDown} />);
-    fireEvent.keyDown(wrapper.querySelector('input'));
+    render(<TreeSelect onKeyDown={onKeyDown} />);
+    fireEvent.keyDown($('input').item(0));
     expect(onKeyDown).toHaveBeenCalled();
   });
 });

--- a/components/TreeSelect/tree-select.tsx
+++ b/components/TreeSelect/tree-select.tsx
@@ -94,6 +94,13 @@ const TreeSelect: ForwardRefRenderFunction<
   // Unique ID of this select instance
   const instancePopupID = useId(`${prefixCls}-popup-`);
 
+  const tryUpdatePopupVisible = (visible) => {
+    if (visible !== popupVisible) {
+      setPopupVisible(visible);
+      props.onVisibleChange?.(visible);
+    }
+  };
+
   // 尝试更新 inputValue，并触发 onInputValueChange
   const tryUpdateInputValue = (value: string, reason: InputValueChangeReason) => {
     if (
@@ -162,10 +169,10 @@ const TreeSelect: ForwardRefRenderFunction<
       setValue(newValue, extra);
       resetInputValue();
       if (!multiple) {
-        setPopupVisible(false);
+        tryUpdatePopupVisible(false);
       }
     },
-    [setValue, resetInputValue]
+    [setValue, resetInputValue, popupVisible]
   );
 
   const handleRemoveCheckedItem = (item, index, e) => {
@@ -309,8 +316,8 @@ const TreeSelect: ForwardRefRenderFunction<
         }}
         disabled={props.disabled}
         onVisibleChange={(visible: boolean) => {
-          setPopupVisible(visible);
-          props.onVisibleChange && props.onVisibleChange(visible);
+          tryUpdatePopupVisible(visible);
+          // props.onVisibleChange && props.onVisibleChange(visible);
         }}
         popupVisible={popupVisible}
       >


### PR DESCRIPTION
… panel is selected for a certain item.

<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context

<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

## Solution

<!-- Describe how the problem is fixed in detail -->

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|   TreeSelect        |    修复 `TreeSelect` 单选模式下，选中某一项下拉面板收起后没有触发 `onVisibleChange` 的 bug。           |               Fix the bug that `onVisibleChange` is not triggered after the selected node triggers the drop-down panel to collapse in `TreeSelect` single-selection mode.|               close #1757  |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->
## Checklist:

- [ ] Test suite passes (`npm run test`)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
