### PR TITLE
fix(InputTag): property validate not work for value updating caused by tokenSeparators

### DIFF
--- a/components/InputTag/__test__/index.test.tsx
+++ b/components/InputTag/__test__/index.test.tsx
@@ -36,6 +36,7 @@ describe('InputTag', () => {
     expect(eleRoot).toHaveClass('arco-input-tag-focus');
 
     fireEvent.change(eleInput, { target: { value: 'b' } });
+    await sleep(10);
     fireEvent.keyDown(eleInput, { keyCode: Enter.code });
     await sleep(10);
     expect(JSON.stringify(mockOnChange.mock.calls[0][0])).toBe(JSON.stringify(['a', 'b']));
@@ -51,9 +52,10 @@ describe('InputTag', () => {
     const eleInput = wrapper.querySelector('input') as HTMLElement;
 
     fireEvent.change(eleInput, { target: { value: inputValue } });
-    fireEvent.blur(eleInput);
-
     await sleep(10);
+    fireEvent.blur(eleInput);
+    await sleep(10);
+
     expect(JSON.stringify(mockOnChange.mock.calls[0][0])).toBe(JSON.stringify([inputValue]));
   });
 
@@ -89,8 +91,8 @@ describe('InputTag', () => {
     fireEvent.change(wrapper.querySelector('input') as HTMLElement, {
       target: { value: inputValue },
     });
+    await sleep(10);
     fireEvent.keyDown(wrapper.querySelector('input') as HTMLElement, { keyCode: Enter.code });
-
     await sleep(10);
 
     expect(JSON.stringify(mockOnChange.mock.calls[0][0])).toBe(
@@ -100,10 +102,20 @@ describe('InputTag', () => {
 
   it('tokenSeparators', async () => {
     const onChange = jest.fn();
-    const wrapper = render(<InputTag tokenSeparators={[',', ';', '\n']} onChange={onChange} />);
+    const wrapper = render(
+      <InputTag
+        tokenSeparators={[',', ';', '\n']}
+        validate={async (text) => {
+          // only allow number less than 10
+          return isNaN(+text) ? false : +text > 10 ? '10' : text;
+        }}
+        onChange={onChange}
+      />
+    );
     const eleInput = wrapper.querySelector('input');
 
-    fireEvent.change(eleInput, { target: { value: 'a,b' } });
-    expect(onChange.mock.calls[0][0]).toEqual(['a', 'b']);
+    fireEvent.change(eleInput, { target: { value: 'a,b,1,2,12' } });
+    await sleep(10);
+    expect(onChange.mock.calls[0][0]).toEqual(['1', '2', '10']);
   });
 });


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|  InputTag     |  修复 `InputTag` 组件 `validate` 回调未对 `tokenSeparators` 触发的值更新生效的问题。  |  Fix the issue that `validate` callback of `InputTag` does not take effect for value updates triggered by `tokenSeparators`. |   Close #1758   |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->
## Checklist:

- [ ] Test suite passes (`npm run test`)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
