### PR TITLE
fix: time-picker use12Hours

### DIFF
--- a/components/TimePicker/__test__/index.test.tsx
+++ b/components/TimePicker/__test__/index.test.tsx
@@ -83,18 +83,41 @@ describe('TimePicker', () => {
     expect(getCells(component, 1)).toHaveLength(60);
   });
 
-  it('use12hours', () => {
-    const component = render(
-      <TimePicker
-        use12Hours
-        format="hh:mm:ss A"
-        defaultValue={dayjs('12:20:20 AM', 'hh:mm:ss A')}
-      />
-    );
+  describe('use12hours', () => {
+    it('use12Hours === true', () => {
+      const component = render(
+        <TimePicker
+          use12Hours
+          format="hh:mm:ss A"
+          defaultValue={dayjs('12:20:20 AM', 'hh:mm:ss A')}
+        />
+      );
 
-    fireEvent.click(component.find('.arco-picker')[0]);
+      fireEvent.click(component.find('.arco-picker')[0]);
 
-    expect(getCells(component, 3)).toHaveLength(2);
+      const time = document.querySelectorAll(
+        '.arco-timepicker .arco-timepicker-list:first-child .arco-timepicker-cell:last-child .arco-timepicker-cell-inner'
+      )[0].textContent;
+
+      expect(time).toBe('11');
+    });
+
+    it('use12Hours === false', () => {
+      const component = render(
+        <TimePicker
+          use12Hours={false}
+          format="hh:mm:ss A"
+          defaultValue={dayjs('12:20:20 AM', 'hh:mm:ss A')}
+        />
+      );
+      fireEvent.click(component.find('.arco-picker')[0]);
+
+      const time = document.querySelectorAll(
+        '.arco-timepicker .arco-timepicker-list:first-child .arco-timepicker-cell:last-child .arco-timepicker-cell-inner'
+      )[0].textContent;
+
+      expect(time).toBe('23');
+    });
   });
 
   it('step', () => {

--- a/components/TimePicker/time-picker.tsx
+++ b/components/TimePicker/time-picker.tsx
@@ -29,7 +29,7 @@ interface InnerTimePickerProps extends TimePickerProps {
 const AMPM = ['am', 'pm'];
 
 function isUse12Hours(props: InnerTimePickerProps) {
-  return props.use12Hours || getColumnsFromFormat(props.format).use12Hours;
+  return props.use12Hours ?? getColumnsFromFormat(props.format).use12Hours;
 }
 
 function TimePicker(props: InnerTimePickerProps) {


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context

<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

## Solution

<!-- Describe how the problem is fixed in detail -->

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
| TimePicker          |   修复 `TimePicker` 组件在传入的 `format` 中存在 `a` 或 `A` 时，`use12Hours` 传 `false` 也会强制开启 12 小时制的 bug。        |   Fix the bug that `use12Hours` passing `false` will also force the 12-hour format to be turned on when `a` or `A` exists in the passed `format` of the `TimePicker` component.  |   Close: https://github.com/arco-design/arco-design/issues/1769  |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->
## Checklist:

- [ ] Test suite passes (`npm run test`)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
