### PR TITLE
fix(InputTag): value format of onChange callback when validate result for tokenSeperators is not boolean

### DIFF
--- a/components/InputTag/__test__/index.test.tsx
+++ b/components/InputTag/__test__/index.test.tsx
@@ -105,9 +105,10 @@ describe('InputTag', () => {
     const wrapper = render(
       <InputTag
         tokenSeparators={[',', ';', '\n']}
+        labelInValue
         validate={async (text) => {
           // only allow number less than 10
-          return isNaN(+text) ? false : +text > 10 ? '10' : text;
+          return isNaN(+text) ? false : +text > 10 ? `+${text}` : text;
         }}
         onChange={onChange}
       />
@@ -116,6 +117,10 @@ describe('InputTag', () => {
 
     fireEvent.change(eleInput, { target: { value: 'a,b,1,2,12' } });
     await sleep(10);
-    expect(onChange.mock.calls[0][0]).toEqual(['1', '2', '10']);
+    expect(onChange.mock.calls[0][0]).toEqual([
+      { label: '1', value: '1' },
+      { label: '2', value: '2' },
+      { label: '12', value: '+12' },
+    ]);
   });
 });

--- a/components/InputTag/input-tag.tsx
+++ b/components/InputTag/input-tag.tsx
@@ -252,7 +252,7 @@ function InputTag(baseProps: InputTagProps<string | ObjectValueType>, ref) {
     if (isArray(tokenSeparators) && tokenSeparators.length) {
       const splitTextList = str.split(new RegExp(`[${tokenSeparators.join('')}]`));
       if (splitTextList.length > 1) {
-        const validatedTextList: string[] = [];
+        const validatedValueList: ObjectValueType[] = [];
 
         await Promise.all(
           splitTextList.map(async (text) => {
@@ -263,22 +263,16 @@ function InputTag(baseProps: InputTagProps<string | ObjectValueType>, ref) {
                 : true
               : false;
             if (validateResult) {
-              validatedTextList.push(validateResult === true ? text : validateResult);
+              validatedValueList.push({
+                value: validateResult === true ? text : validateResult,
+                label: text,
+              });
             }
           })
         );
 
-        if (validatedTextList.length) {
-          valueChangeHandler(
-            value.concat(
-              validatedTextList.map((text) => ({
-                value: text,
-                label: text,
-                closable: true,
-              }))
-            ),
-            'add'
-          );
+        if (validatedValueList.length) {
+          valueChangeHandler(value.concat(validatedValueList), 'add');
           hasSeparator = true;
         }
       }


### PR DESCRIPTION


## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Solution

<!-- Describe how the problem is fixed in detail -->

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|  InputTag   |  修复 `InputTag` 的 `validate` 回调返回非布尔值时，`onChange` 回调中的 `value.label` 值不为用户输入文本的问题。   |   Fix `value.label` value in `onChange` callback is not user input text when `validate` callback of `InputTag` returns non-boolean value.   |                |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->
## Checklist:

- [ ] Test suite passes (`npm run test`)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
