### PR TITLE
fix(InputTag): validate function will trigger twice while pasting if it validate result not pass

### DIFF
--- a/components/InputTag/__test__/index.test.tsx
+++ b/components/InputTag/__test__/index.test.tsx
@@ -123,4 +123,34 @@ describe('InputTag', () => {
       { label: '12', value: '+12' },
     ]);
   });
+
+  it('tokenSeparators validate failed', async () => {
+    const onValidate = jest.fn();
+    const value = [];
+    const wrapper = render(
+      <InputTag
+        tokenSeparators={[',']}
+        validate={(text) => {
+          const exist = value.indexOf(text) > -1;
+          onValidate(text);
+          return !exist;
+        }}
+      />
+    );
+
+    const simulatePaste = () => {
+      const eleInput = wrapper.querySelector('input');
+      fireEvent.paste(eleInput, { clipboardData: { getData: () => 'a,b,c' } });
+      fireEvent.change(eleInput, {
+        target: { value: 'a,b,c' },
+      });
+    };
+
+    simulatePaste();
+    await sleep(10);
+
+    expect(onValidate).toBeCalledTimes(6);
+    expect(wrapper.querySelectorAll('.arco-tag')).toHaveLength(3);
+    expect(wrapper.querySelector('input').getAttribute('value')).toBe('');
+  });
 });


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 


## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|  InputTag | 修复 `InputTag` 粘贴文本自动分词的校验结果全部不通过时 `validate` 函数会连续触发两轮的问题。    |     Fix the issue that `validate` function will trigger two consecutive rounds when all the verification results of the automatic word segmentation of the pasted text of `InputTag` fail.          |                |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->
## Checklist:

- [ ] Test suite passes (`npm run test`)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
