### PR TITLE
fix(Select): make sure Select option has height when its label is empty string

### DIFF
--- a/components/Select/option.tsx
+++ b/components/Select/option.tsx
@@ -40,7 +40,9 @@ function Option(props: OptionProps, ref) {
         [`${prefixCls}-option-selected`]: isChecked,
         [`${prefixCls}-option-disabled`]: disabled,
         [`${prefixCls}-option-hover`]: value === _valueActive,
-        [`${prefixCls}-option-empty`]: !childNode && childNode !== 0,
+        [`${prefixCls}-option-empty`]:
+          (!childNode && childNode !== 0) ||
+          (typeof childNode === 'string' && /^\s*$/.test(childNode)),
         [`${prefixCls}-option-rtl`]: rtl,
       },
       className


### PR DESCRIPTION


## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|  Select   |  修复 `Select` 选项内容为空字符串时，选项在下拉列表中不展示的问题。  |  Fix the problem that the option is not displayed in the drop-down list when the content of the `Select` option is an empty string.  |   #1802  |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->
## Checklist:

- [ ] Test suite passes (`npm run test`)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)
