### PR TITLE
enhance(InputNumber): disable BigInt usage in low-version browsers

### DIFF
--- a/components/InputNumber/index.tsx
+++ b/components/InputNumber/index.tsx
@@ -21,7 +21,7 @@ import { InputNumberProps } from './interface';
 import useMergeProps from '../_util/hooks/useMergeProps';
 import omit from '../_util/omit';
 import useSelectionRange from './useSelectionRange';
-import { Decimal } from './Decimal';
+import { getDecimal, Decimal } from './Decimal';
 
 // Value's auto change speed when user holds on plus or minus
 const AUTO_CHANGE_INTERVAL = 200;
@@ -86,7 +86,7 @@ function InputNumber(baseProps: InputNumberProps, ref) {
   })();
 
   const [innerValue, setInnerValue] = useState<Decimal>(() => {
-    return Decimal.from(
+    return getDecimal(
       'value' in props ? props.value : 'defaultValue' in props ? defaultValue : undefined
     );
   });
@@ -100,11 +100,11 @@ function InputNumber(baseProps: InputNumberProps, ref) {
   const refHasOperateSincePropValueChanged = useRef(false);
 
   const value = useMemo<Decimal>(() => {
-    return 'value' in props ? Decimal.from(props.value) : innerValue;
+    return 'value' in props ? getDecimal(props.value) : innerValue;
   }, [props.value, innerValue]);
 
   const [maxDecimal, minDecimal] = useMemo<Decimal[]>(() => {
-    return [Decimal.from(max), Decimal.from(min)];
+    return [getDecimal(max), getDecimal(min)];
   }, [max, min]);
 
   useImperativeHandle(ref, () => refInput.current, []);
@@ -174,7 +174,7 @@ function InputNumber(baseProps: InputNumberProps, ref) {
     }
 
     const finalValue = value.isInvalid
-      ? Decimal.from(min === -Infinity ? 0 : min)
+      ? getDecimal(min === -Infinity ? 0 : min)
       : value.add(method === 'plus' ? step : -step);
 
     setValue(getLegalValue(finalValue));
@@ -219,7 +219,7 @@ function InputNumber(baseProps: InputNumberProps, ref) {
 
       if (isNumber(+parsedValue) || parsedValue === '-' || !parsedValue || parsedValue === '.') {
         setInputValue(rawText);
-        setValue(getLegalValue(Decimal.from(parsedValue)));
+        setValue(getLegalValue(getDecimal(parsedValue)));
         updateSelectionRangePosition(event);
       }
     },

--- a/components/InputNumber/utils.ts
+++ b/components/InputNumber/utils.ts
@@ -6,6 +6,13 @@ export function isE(number: string | number) {
 }
 
 /**
+ * Judge whether BigInt is supported by current env
+ */
+export function supportBigInt() {
+  return typeof BigInt === 'function';
+}
+
+/**
  * Get precision of a number, include scientific notation like 1e-10
  */
 export function getNumberPrecision(number: string | number) {
@@ -32,8 +39,12 @@ export function toSafeString(number: number | string): string {
   let nativeNumberStr: string = String(number);
 
   if (isE(number)) {
-    if (number < Number.MIN_SAFE_INTEGER || number > Number.MAX_SAFE_INTEGER) {
-      return BigInt(number).toString();
+    if (number < Number.MIN_SAFE_INTEGER) {
+      return supportBigInt() ? BigInt(number).toString() : Number.MIN_SAFE_INTEGER.toString();
+    }
+
+    if (number > Number.MAX_SAFE_INTEGER) {
+      return supportBigInt() ? BigInt(number).toString() : Number.MAX_SAFE_INTEGER.toString();
     }
 
     // This may lose precision, but foFixed must accept argument in the range 0-100


### PR DESCRIPTION


## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [ ] Bug fix
- [x] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context

<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|   InputNumber  |  兼容不支持 `BigInt` 的旧时代浏览器。   |   Compatible with older browsers that don't support `BigInt`.   |  Close #1805       |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->
## Checklist:

- [ ] Test suite passes (`npm run test`)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
