### PR TITLE
fix: form value should keep equal when rerender

### DIFF
--- a/components/Form/__demo__/custom.md
+++ b/components/Form/__demo__/custom.md
@@ -18,19 +18,9 @@ import { useRef, useState, useEffect } from 'react';
 import { Form, Input, Select, Typography } from '@arco-design/web-react';
 
 function CustomInput(props) {
-  const [stateValue, setValue] = useState(props.value);
-  const value = props.value || stateValue || {};
-  useEffect(() => {
-    if (props.value !== stateValue && props.value === undefined) {
-      setValue(props.value);
-    }
-  }, [props.value]);
+  const value = props.value || {};
 
   const handleChange = (newValue) => {
-    if (!('value' in props)) {
-      setValue(newValue);
-    } // onChange is passed in by Form.Item and will update the fields bound to the form when triggered.
-
     props.onChange && props.onChange(newValue);
   };
 

--- a/components/Form/__test__/case.test.tsx
+++ b/components/Form/__test__/case.test.tsx
@@ -233,7 +233,7 @@ describe('form usewatch ', () => {
     expect(wrapper.querySelector('#text')?.textContent).toBe('123');
   });
 
-  describe('form reset & shouldupdate', () => {
+  it('form reset & shouldupdate', () => {
     let form;
     let renderCount = 0;
     let render2Count = 0;
@@ -266,5 +266,59 @@ describe('form usewatch ', () => {
 
     expect(renderCount).toBe(1);
     expect(render2Count).toBeGreaterThan(1); // 保持原有行为不变，避免 breaking change
+  });
+
+  it('value should keep equal', () => {
+    const changeMockFn = jest.fn();
+
+    const CustomInput = (props) => {
+      React.useEffect(() => {
+        changeMockFn(props.value);
+      }, [props.value]);
+
+      return (
+        <Input
+          value={props.value?.name}
+          onChange={(v) => props.onChange?.({ ...props.value, name: v })}
+        />
+      );
+    };
+
+    const wrapper = render(
+      <Form>
+        <Form.Item label="name" field="input">
+          <CustomInput />
+        </Form.Item>
+      </Form>
+    );
+
+    expect(changeMockFn).toBeCalledTimes(1);
+    expect(changeMockFn).toBeCalledWith(undefined);
+    fireEvent.change(wrapper.find('input')[0], {
+      target: {
+        value: 'aaa',
+      },
+    });
+
+    expect(changeMockFn).toBeCalledTimes(2);
+    wrapper.rerender(
+      <Form>
+        <Form.Item label="name" field="input">
+          <CustomInput />
+        </Form.Item>
+      </Form>
+    );
+    expect(changeMockFn).toBeCalledWith({ name: 'aaa' });
+
+    wrapper.rerender(
+      <Form>
+        <Form.Item label="name" field="input">
+          <CustomInput />
+        </Form.Item>
+      </Form>
+    );
+
+    // 引用地址不变，不出发 useEffect
+    expect(changeMockFn).toBeCalledTimes(2);
   });
 });

--- a/components/Form/context.ts
+++ b/components/Form/context.ts
@@ -31,6 +31,7 @@ export const FormContext = createContext<FormContextProps>({
     scrollToField: NOOP,
     getInnerMethods: () => ({
       registerField: NOOP,
+      innerGetStore: NOOP,
     }),
   } as any,
 });

--- a/components/Form/control.tsx
+++ b/components/Form/control.tsx
@@ -392,7 +392,8 @@ export default class Control<
     if (disabled !== undefined) {
       childProps.disabled = disabled;
     }
-    let _value = store.getFieldValue(field);
+    // 保持引用地址不变，fix https://github.com/arco-design/arco-design/issues/1800
+    let _value = get(store.getInnerMethods(true).innerGetStore(), field);
 
     if (isFunction(formatter)) {
       _value = formatter(_value);


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context

<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

## Solution

<!-- Describe how the problem is fixed in detail -->

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|     Form      |  修复 `Form.Item` 组件在 `rerender` 时注入到自定义表单控件的 `value` 引用地址改变的 bug。             |    Fix the bug that the `value` reference address of the `Form.Item` component injected into the custom form control changes when `rerender`.           |       close #1800          |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->
## Checklist:

- [ ] Test suite passes (`npm run test`)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
