### PR TITLE
fix(Select): dragToSort get wrong value when used with maxTagCount

### DIFF
--- a/components/_class/select-view.tsx
+++ b/components/_class/select-view.tsx
@@ -180,6 +180,8 @@ const SearchStatus = {
   NONE: 2,
 };
 
+const MAX_TAG_COUNT_VALUE_PLACEHOLDER = '__arco_value_tag_placeholder';
+
 export type SelectViewHandle = {
   dom: HTMLDivElement;
   focus: () => void;
@@ -451,7 +453,7 @@ export const SelectView = (props: SelectViewProps, ref) => {
         label: maxTagCountRender(invisibleTagCount),
         closable: false,
         // InputTag needs to extract value as key
-        value: '__arco_value_tag_placeholder',
+        value: MAX_TAG_COUNT_VALUE_PLACEHOLDER,
       });
     }
 
@@ -491,9 +493,18 @@ export const SelectView = (props: SelectViewProps, ref) => {
         tagClassName={`${prefixCls}-tag`}
         renderTag={renderTag}
         icon={{ removeIcon }}
-        onChange={(value, reason) => {
+        onChange={(newValue, reason) => {
           if (onSort && reason === 'sort') {
-            onSort(value);
+            const indexOfMaxTagCount = newValue.indexOf(MAX_TAG_COUNT_VALUE_PLACEHOLDER);
+            // inject the invisible values tags to middle after dragging the "+x" tag
+            if (indexOfMaxTagCount > -1) {
+              const headArr = newValue.slice(0, indexOfMaxTagCount);
+              const tailArr = newValue.slice(indexOfMaxTagCount + 1);
+              const midArr = usedValue.slice(-invisibleTagCount);
+              onSort(headArr.concat(midArr, tailArr));
+            } else {
+              onSort(newValue);
+            }
           }
         }}
         {...eventHandlers}


### PR DESCRIPTION
## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|  Select  |  修复 `Select` 组件 `dragToSort` 和 `maxTagCount` 配合使用时，拖拽排序结果异常的问题。   |   Fix the problem that when the `Select` component `dragToSort` and `maxTagCount` are used together, the drag sorting result is abnormal.  |  Close #1825  |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->
## Checklist:

- [ ] Test suite passes (`npm run test`)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
