### PR TITLE
Fix the layout jitter caused by the height change when Select is selected for the first time in multi-selection mode.

### DIFF
--- a/components/InputTag/style/index.less
+++ b/components/InputTag/style/index.less
@@ -205,7 +205,7 @@
       font-size: @font-size;
 
       .@{input-tag-prefix-cls}-view {
-        min-height: @height - @input-tag-border-width * 2;
+        height: @height - @input-tag-border-width * 2;
       }
 
       .@{input-tag-prefix-cls}-inner {


### PR DESCRIPTION
Fix the layout jitter caused by the height change when Select is selected for the first time in multi-selection mode.

<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [ ] Bug fix
- [x] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context

<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->


https://user-images.githubusercontent.com/31227919/226523761-0d4ac9f2-1000-4820-bf52-1974c617d41e.mp4


