### PR TITLE
fix: InputTag height jittering caused by input element width change

### DIFF
--- a/components/Input/input-element.tsx
+++ b/components/Input/input-element.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useImperativeHandle, useEffect, useState } from 'react';
+import React, { useRef, useImperativeHandle, useEffect } from 'react';
 import { InputComponentProps, RefInputType } from './interface';
 import cs from '../_util/classNames';
 import omit from '../_util/omit';
@@ -51,7 +51,6 @@ const InputComponent = React.forwardRef<RefInputType, InputComponentProps>(
     const refInput = useRef<HTMLInputElement>();
     const refInputMirror = useRef<HTMLSpanElement>();
     const refPrevInputWidth = useRef<number>(null);
-    const [inputElementWidth, setInputElementWidth] = useState<number>(null);
 
     const maxLength = isObject(propMaxLength)
       ? propMaxLength.errorOnly
@@ -110,13 +109,8 @@ const InputComponent = React.forwardRef<RefInputType, InputComponentProps>(
 
     const updateInputWidth = () => {
       if (refInputMirror.current && refInput.current) {
-        // Unset width when need to show placeholder
-        if (!inputProps.value && placeholder) {
-          setInputElementWidth(null);
-        } else {
-          const width = refInputMirror.current.offsetWidth;
-          setInputElementWidth(width + (width ? 8 : 4));
-        }
+        const width = refInputMirror.current.offsetWidth;
+        refInput.current.style.width = `${width + (width ? 8 : 4)}px`;
       }
     };
 
@@ -168,7 +162,6 @@ const InputComponent = React.forwardRef<RefInputType, InputComponentProps>(
                 : {
                     ...style,
                     ...('height' in props ? { height } : {}),
-                    ...(typeof inputElementWidth === 'number' ? { width: inputElementWidth } : {}),
                   }
             }
           />

--- a/components/Transfer/__demo__/with-table.md
+++ b/components/Transfer/__demo__/with-table.md
@@ -34,11 +34,11 @@ const TableTransfer = ({ sourceColumns, targetColumns, ...restProps }) => (
             pointerEvents: listDisabled ? 'none' : null,
             borderRadius: 0,
           }}
-          checkCrossPage
           pagination={false}
           data={filteredItems}
           columns={columns}
           rowSelection={{
+            checkCrossPage: true,
             selectedRowKeys: listSelectedKeys,
             checkboxProps: (item) => {
               return {


### PR DESCRIPTION

## Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context

撤销 [此提交](https://github.com/arco-design/arco-design/commit/46ba4945e2fc5b21768de4c86af235f80838a8fa) 的改动，`<input>` 标签的宽度变化导致了 `InputTag` 的换行，引发下拉框抖动。

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|   Select    |  修复 `Select` 多选模式下，选择第一个选项时下拉框抖动问题。  |   Fix `Select` multi-selection mode, when the first option is selected, the drop-down box shakes.   |                |
