### PR TITLE
fix(Select): Select will be focused after clicking the close icon of value-tag

### DIFF
--- a/components/InputTag/input-tag.tsx
+++ b/components/InputTag/input-tag.tsx
@@ -240,6 +240,7 @@ function InputTag(baseProps: InputTagProps<string | ObjectValueType>, ref) {
         closeIcon={icon && icon.removeIcon}
         title={typeof label === 'string' ? label : undefined}
         onClose={onClose}
+        onMouseDown={keepFocus}
       >
         {fillNBSP(label)}
       </Tag>
@@ -306,7 +307,6 @@ function InputTag(baseProps: InputTagProps<string | ObjectValueType>, ref) {
           }
           onClear && onClear();
         }}
-        onMouseDown={keepFocus}
       >
         {(icon && icon.clearIcon) || <IconClose />}
       </IconHover>


### PR DESCRIPTION

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 



## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|  Select   |   修复 `Select` 组件多选模式下点击 `Tag` 的关闭按钮删除选项时，`Select` 会变为 Focus 状态的问题。   |   Fix the problem that `Select` will be focused when clicking the close button of `Tag` to delete the option in the multi-select mode.  |                |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->
## Checklist:

- [ ] Test suite passes (`npm run test`)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)
