### PR TITLE
fix(Select): triggerProps.trigger=focus not works

### DIFF
--- a/components/_class/select-view.tsx
+++ b/components/_class/select-view.tsx
@@ -189,436 +189,464 @@ export type SelectViewHandle = {
   getWidth: () => number;
 };
 
-export const SelectView = (props: SelectViewProps, ref) => {
-  const {
-    style,
-    className,
-    size,
-    bordered,
-    allowClear,
-    allowCreate,
-    status,
-    loading,
-    disabled,
-    animation,
-    prefixCls,
-    suffixIcon,
-    arrowIcon,
-    removeIcon,
-    clearIcon,
-    placeholder,
-    renderView,
-    renderText,
-    value,
-    inputValue,
-    popupVisible,
-    maxTagCount,
-    isMultiple,
-    isEmptyValue,
-    prefix,
-    ariaControls,
-    renderTag,
-    dragToSort,
-    addBefore,
-    // addAfter,
-    onKeyDown,
-    onChangeInputValue,
-    onPaste,
-    onClear,
-    onFocus,
-    onBlur,
-    onRemoveCheckedItem,
-    onSort,
-    rtl,
-    ...rest
-  } = props;
+const CoreSelectView = React.forwardRef(
+  (props: SelectViewProps & { htmlDataAttributes: Record<string, string> }, ref) => {
+    const {
+      style,
+      className,
+      size,
+      bordered,
+      allowClear,
+      allowCreate,
+      status,
+      loading,
+      disabled,
+      animation,
+      prefixCls,
+      suffixIcon,
+      arrowIcon,
+      removeIcon,
+      clearIcon,
+      placeholder,
+      renderText,
+      value,
+      inputValue,
+      popupVisible,
+      maxTagCount,
+      isMultiple,
+      isEmptyValue,
+      prefix,
+      ariaControls,
+      renderTag,
+      dragToSort,
+      rtl,
+      htmlDataAttributes,
+      onKeyDown,
+      onChangeInputValue,
+      onPaste,
+      onClear,
+      onFocus,
+      onBlur,
+      onRemoveCheckedItem,
+      onSort,
+      ...rest
+    } = props;
 
-  // refs
-  const refInput = useRef(null);
-  const refWrapper = useRef(null);
+    // refs
+    const refInput = useRef(null);
+    const refWrapper = useRef(null);
 
-  // state
-  const { size: ctxSize, getPrefixCls } = useContext(ConfigContext);
-  const [searchStatus, setSearchStatus] = useState(SearchStatus.NONE);
-  const [focused, setFocused] = useState(false);
+    // state
+    const { size: ctxSize, getPrefixCls } = useContext(ConfigContext);
+    const [searchStatus, setSearchStatus] = useState(SearchStatus.NONE);
+    const [focused, setFocused] = useState(false);
 
-  const forceUpdate = useForceUpdate();
+    const forceUpdate = useForceUpdate();
 
-  // TODO：Will the search be completely controlled by showSearch? Next major version needs to be considered
-  const showSearch = 'showSearch' in props ? props.showSearch : isMultiple;
-  const canFocusInput = showSearch || allowCreate;
-  const mergedSize = size || ctxSize;
-  const mergedFocused = focused || popupVisible;
-  const isRetainInputValueSearch = isObject(showSearch) && showSearch.retainInputValue;
-  // the formatted text of value.
-  const renderedValue = !isMultiple && value !== undefined ? renderText(value).text : '';
+    // TODO：Will the search be completely controlled by showSearch? Next major version needs to be considered
+    const showSearch = 'showSearch' in props ? props.showSearch : isMultiple;
+    const canFocusInput = showSearch || allowCreate;
+    const mergedSize = size || ctxSize;
+    const mergedFocused = focused || popupVisible;
+    const isRetainInputValueSearch = isObject(showSearch) && showSearch.retainInputValue;
+    // the formatted text of value.
+    const renderedValue = !isMultiple && value !== undefined ? renderText(value).text : '';
 
-  // Avoid losing focus caused by clicking certain icons
-  const keepFocus = (event) => {
-    event && event.preventDefault();
-  };
-
-  const handleFocus = (action: 'focus' | 'blur') => {
-    const element = canFocusInput ? refInput.current : refWrapper.current;
-    if (element) {
-      action === 'focus' ? element.focus() : element.blur();
-    }
-  };
-
-  const tryTriggerFocusChange = (action: 'focus' | 'blur', event) => {
-    // The focus event at this time should be triggered by the input element
-    if (canFocusInput && event.target === refWrapper.current) {
-      return;
-    }
-    if (action === 'focus') {
-      setFocused(true);
-      onFocus && onFocus(event);
-    } else {
-      setFocused(false);
-      onBlur && onBlur(event);
-    }
-  };
-
-  const tryTriggerKeyDown = (event) => {
-    // The keyboard event at this time should be triggered by the input element, ignoring the bubbling up keyboard event
-    if (canFocusInput && event.currentTarget === refWrapper.current) {
-      return;
-    }
-
-    // Prevent the default behavior of the browser when pressing Enter, to avoid submit event in <form>
-    const keyCode = event.keyCode || event.which;
-    if (keyCode === Enter.code) {
-      event.preventDefault();
-    }
-
-    onKeyDown && onKeyDown(event);
-  };
-
-  useEffect(() => {
-    handleFocus(popupVisible ? 'focus' : 'blur');
-    if (canFocusInput) {
-      setSearchStatus(popupVisible ? SearchStatus.BEFORE : SearchStatus.NONE);
-    }
-  }, [popupVisible]);
-
-  useImperativeHandle<any, SelectViewHandle>(ref, () => ({
-    dom: refWrapper.current,
-    focus: handleFocus.bind(null, 'focus'),
-    blur: handleFocus.bind(null, 'blur'),
-    getWidth: () => refWrapper.current && refWrapper.current.clientWidth,
-  }));
-
-  const mergedArrowIcon =
-    'arrowIcon' in props ? (
-      arrowIcon === null ? null : (
-        <div className={`${prefixCls}-arrow-icon`}>{arrowIcon}</div>
-      )
-    ) : (
-      <div className={`${prefixCls}-arrow-icon`}>
-        <IconDown />
-      </div>
-    );
-
-  const mergedSuffixIcon = loading ? (
-    <span className={`${prefixCls}-loading-icon`}>
-      <IconLoading />
-    </span>
-  ) : suffixIcon ? (
-    <span className={`${prefixCls}-suffix-icon`}>{suffixIcon}</span>
-  ) : props.showSearch && popupVisible ? (
-    <div className={`${prefixCls}-search-icon`}>
-      <IconSearch />
-    </div>
-  ) : (
-    mergedArrowIcon
-  );
-
-  // event handling of input box
-  const inputEventHandlers = {
-    paste: onPaste,
-    keyDown: tryTriggerKeyDown,
-    focus: (event) => {
-      event.stopPropagation();
-      tryTriggerFocusChange('focus', event);
-    },
-    blur: (event) => {
-      event.stopPropagation();
-      tryTriggerFocusChange('blur', event);
-    },
-    change: (newValue, event) => {
-      setSearchStatus(SearchStatus.EDITING);
-      onChangeInputValue && onChangeInputValue(newValue, event);
-    },
-  };
-
-  const renderSingle = () => {
-    let _inputValue: string;
-
-    switch (searchStatus) {
-      case SearchStatus.BEFORE:
-        _inputValue = inputValue || (isRetainInputValueSearch ? renderedValue : '');
-        break;
-      case SearchStatus.EDITING:
-        _inputValue = inputValue || '';
-        break;
-      default:
-        _inputValue = renderedValue;
-        break;
-    }
-
-    const inputProps: InputComponentProps = {
-      style: { width: '100%' },
-      // _inputValue after renderText(value) may be rich text, but the value of <input> cannot be object
-      value: typeof _inputValue !== 'object' ? _inputValue : '',
-      // Allow placeholder to display the selected value first when searching
-      placeholder:
-        canFocusInput && renderedValue && typeof renderedValue !== 'object'
-          ? renderedValue
-          : placeholder,
+    // Avoid losing focus caused by clicking certain icons
+    const keepFocus = (event) => {
+      event && event.preventDefault();
     };
 
-    if (canFocusInput) {
-      inputProps.onPaste = inputEventHandlers.paste;
-      inputProps.onKeyDown = inputEventHandlers.keyDown;
-      inputProps.onFocus = inputEventHandlers.focus;
-      inputProps.onBlur = inputEventHandlers.blur;
-      inputProps.onChange = inputEventHandlers.change;
-    } else {
-      // Avoid input getting focus by Tab
-      // Do NOT pass [disabled] to <input>, otherwise the click event will not be triggered
-      // https://stackoverflow.com/questions/7833854/jquery-detect-click-on-disabled-submit-button
-      inputProps.tabIndex = -1;
-      inputProps.style.pointerEvents = 'none';
-    }
+    const handleFocus = (action: 'focus' | 'blur') => {
+      const element = canFocusInput ? refInput.current : refWrapper.current;
+      if (element) {
+        action === 'focus' ? element.focus() : element.blur();
+      }
+    };
 
-    // <input> is used to input and display placeholder, in other cases use <span> to display value to support displaying rich text
-    const needShowInput = !!((mergedFocused && canFocusInput) || isEmptyValue);
+    const tryTriggerFocusChange = (action: 'focus' | 'blur', event) => {
+      // The focus event at this time should be triggered by the input element
+      if (canFocusInput && event.target === refWrapper.current) {
+        return;
+      }
+      if (action === 'focus') {
+        setFocused(true);
+        onFocus && onFocus(event);
+      } else {
+        setFocused(false);
+        onBlur && onBlur(event);
+      }
+    };
 
-    return (
-      <span className={`${prefixCls}-view-selector`}>
-        <InputComponent
-          aria-hidden={!needShowInput || undefined}
-          ref={refInput}
-          disabled={disabled}
-          className={cs(`${prefixCls}-view-input`, {
-            [`${prefixCls}-hidden`]: !needShowInput,
-          })}
-          autoComplete="off"
-          {...inputProps}
-        />
+    const tryTriggerKeyDown = (event) => {
+      // The keyboard event at this time should be triggered by the input element, ignoring the bubbling up keyboard event
+      if (canFocusInput && event.currentTarget === refWrapper.current) {
+        return;
+      }
 
-        <span
-          className={cs(`${prefixCls}-view-value`, {
-            [`${prefixCls}-view-value-mirror`]: needShowInput,
-          })}
-        >
-          {fillNBSP(isEmptyValue ? inputProps.placeholder : _inputValue)}
-        </span>
+      // Prevent the default behavior of the browser when pressing Enter, to avoid submit event in <form>
+      const keyCode = event.keyCode || event.which;
+      if (keyCode === Enter.code) {
+        event.preventDefault();
+      }
+
+      onKeyDown && onKeyDown(event);
+    };
+
+    useEffect(() => {
+      handleFocus(popupVisible ? 'focus' : 'blur');
+      if (canFocusInput) {
+        setSearchStatus(popupVisible ? SearchStatus.BEFORE : SearchStatus.NONE);
+      }
+    }, [popupVisible]);
+
+    useImperativeHandle<any, SelectViewHandle>(ref, () => ({
+      dom: refWrapper.current,
+      focus: handleFocus.bind(null, 'focus'),
+      blur: handleFocus.bind(null, 'blur'),
+      getWidth: () => refWrapper.current && refWrapper.current.clientWidth,
+    }));
+
+    const mergedArrowIcon =
+      'arrowIcon' in props ? (
+        arrowIcon === null ? null : (
+          <div className={`${prefixCls}-arrow-icon`}>{arrowIcon}</div>
+        )
+      ) : (
+        <div className={`${prefixCls}-arrow-icon`}>
+          <IconDown />
+        </div>
+      );
+
+    const mergedSuffixIcon = loading ? (
+      <span className={`${prefixCls}-loading-icon`}>
+        <IconLoading />
       </span>
+    ) : suffixIcon ? (
+      <span className={`${prefixCls}-suffix-icon`}>{suffixIcon}</span>
+    ) : props.showSearch && popupVisible ? (
+      <div className={`${prefixCls}-search-icon`}>
+        <IconSearch />
+      </div>
+    ) : (
+      mergedArrowIcon
     );
-  };
 
-  const renderMultiple = () => {
-    const usedValue = isUndefined(value) ? [] : [].concat(value as []);
-    const maxTagCountNumber = isObject(maxTagCount) ? maxTagCount.count : maxTagCount;
-
-    const maxTagCountRender =
-      isObject(maxTagCount) && isFunction(maxTagCount.render)
-        ? maxTagCount.render
-        : (invisibleCount) => `+${invisibleCount}...`;
-
-    const usedMaxTagCount =
-      typeof maxTagCountNumber === 'number' ? Math.max(maxTagCountNumber, 0) : usedValue.length;
-    const tagsToShow: ObjectValueType[] = [];
-    let lastClosableTagIndex = -1;
-
-    for (let i = usedValue.length - 1; i >= 0; i--) {
-      const v = usedValue[i];
-      const result = renderText(v);
-      if (i < usedMaxTagCount) {
-        tagsToShow.unshift({
-          value: v,
-          label: result.text,
-          closable: !result.disabled,
-        });
-      }
-      if (!result.disabled && lastClosableTagIndex === -1) {
-        lastClosableTagIndex = i;
-      }
-    }
-
-    const invisibleTagCount = usedValue.length - usedMaxTagCount;
-    if (invisibleTagCount > 0) {
-      tagsToShow.push({
-        label: maxTagCountRender(invisibleTagCount),
-        closable: false,
-        // InputTag needs to extract value as key
-        value: MAX_TAG_COUNT_VALUE_PLACEHOLDER,
-      });
-    }
-
-    const eventHandlers = {
-      onPaste: inputEventHandlers.paste,
-      onKeyDown: inputEventHandlers.keyDown,
-      onFocus: inputEventHandlers.focus,
-      onBlur: inputEventHandlers.blur,
-      onInputChange: inputEventHandlers.change,
-      onRemove: (value, index, event) => {
-        // Should always delete the last option value when press Backspace
-        const keyCode = event.keyCode || event.which;
-        if (keyCode === Backspace.code && lastClosableTagIndex > -1) {
-          value = usedValue[lastClosableTagIndex];
-          index = lastClosableTagIndex;
-        }
-
-        // If there is a limit on the maximum number of tags, the parameters passed into InputTag need to be recalculated
-        maxTagCount && forceUpdate();
-        onRemoveCheckedItem && onRemoveCheckedItem(value, index, event);
+    // event handling of input box
+    const inputEventHandlers = {
+      paste: onPaste,
+      keyDown: tryTriggerKeyDown,
+      focus: (event) => {
+        event.stopPropagation();
+        tryTriggerFocusChange('focus', event);
+      },
+      blur: (event) => {
+        event.stopPropagation();
+        tryTriggerFocusChange('blur', event);
+      },
+      change: (newValue, event) => {
+        setSearchStatus(SearchStatus.EDITING);
+        onChangeInputValue && onChangeInputValue(newValue, event);
       },
     };
 
+    const renderSingle = () => {
+      let _inputValue: string;
+
+      switch (searchStatus) {
+        case SearchStatus.BEFORE:
+          _inputValue = inputValue || (isRetainInputValueSearch ? renderedValue : '');
+          break;
+        case SearchStatus.EDITING:
+          _inputValue = inputValue || '';
+          break;
+        default:
+          _inputValue = renderedValue;
+          break;
+      }
+
+      const inputProps: InputComponentProps = {
+        style: { width: '100%' },
+        // _inputValue after renderText(value) may be rich text, but the value of <input> cannot be object
+        value: typeof _inputValue !== 'object' ? _inputValue : '',
+        // Allow placeholder to display the selected value first when searching
+        placeholder:
+          canFocusInput && renderedValue && typeof renderedValue !== 'object'
+            ? renderedValue
+            : placeholder,
+      };
+
+      if (canFocusInput) {
+        inputProps.onPaste = inputEventHandlers.paste;
+        inputProps.onKeyDown = inputEventHandlers.keyDown;
+        inputProps.onFocus = inputEventHandlers.focus;
+        inputProps.onBlur = inputEventHandlers.blur;
+        inputProps.onChange = inputEventHandlers.change;
+      } else {
+        // Avoid input getting focus by Tab
+        // Do NOT pass [disabled] to <input>, otherwise the click event will not be triggered
+        // https://stackoverflow.com/questions/7833854/jquery-detect-click-on-disabled-submit-button
+        inputProps.tabIndex = -1;
+        inputProps.style.pointerEvents = 'none';
+      }
+
+      // <input> is used to input and display placeholder, in other cases use <span> to display value to support displaying rich text
+      const needShowInput = !!((mergedFocused && canFocusInput) || isEmptyValue);
+
+      return (
+        <span className={`${prefixCls}-view-selector`}>
+          <InputComponent
+            aria-hidden={!needShowInput || undefined}
+            ref={refInput}
+            disabled={disabled}
+            className={cs(`${prefixCls}-view-input`, {
+              [`${prefixCls}-hidden`]: !needShowInput,
+            })}
+            autoComplete="off"
+            {...inputProps}
+          />
+
+          <span
+            className={cs(`${prefixCls}-view-value`, {
+              [`${prefixCls}-view-value-mirror`]: needShowInput,
+            })}
+          >
+            {fillNBSP(isEmptyValue ? inputProps.placeholder : _inputValue)}
+          </span>
+        </span>
+      );
+    };
+
+    const renderMultiple = () => {
+      const usedValue = isUndefined(value) ? [] : [].concat(value as []);
+      const maxTagCountNumber = isObject(maxTagCount) ? maxTagCount.count : maxTagCount;
+
+      const maxTagCountRender =
+        isObject(maxTagCount) && isFunction(maxTagCount.render)
+          ? maxTagCount.render
+          : (invisibleCount) => `+${invisibleCount}...`;
+
+      const usedMaxTagCount =
+        typeof maxTagCountNumber === 'number' ? Math.max(maxTagCountNumber, 0) : usedValue.length;
+      const tagsToShow: ObjectValueType[] = [];
+      let lastClosableTagIndex = -1;
+
+      for (let i = usedValue.length - 1; i >= 0; i--) {
+        const v = usedValue[i];
+        const result = renderText(v);
+        if (i < usedMaxTagCount) {
+          tagsToShow.unshift({
+            value: v,
+            label: result.text,
+            closable: !result.disabled,
+          });
+        }
+        if (!result.disabled && lastClosableTagIndex === -1) {
+          lastClosableTagIndex = i;
+        }
+      }
+
+      const invisibleTagCount = usedValue.length - usedMaxTagCount;
+      if (invisibleTagCount > 0) {
+        tagsToShow.push({
+          label: maxTagCountRender(invisibleTagCount),
+          closable: false,
+          // InputTag needs to extract value as key
+          value: MAX_TAG_COUNT_VALUE_PLACEHOLDER,
+        });
+      }
+
+      const eventHandlers = {
+        onPaste: inputEventHandlers.paste,
+        onKeyDown: inputEventHandlers.keyDown,
+        onFocus: inputEventHandlers.focus,
+        onBlur: inputEventHandlers.blur,
+        onInputChange: inputEventHandlers.change,
+        onRemove: (value, index, event) => {
+          // Should always delete the last option value when press Backspace
+          const keyCode = event.keyCode || event.which;
+          if (keyCode === Backspace.code && lastClosableTagIndex > -1) {
+            value = usedValue[lastClosableTagIndex];
+            index = lastClosableTagIndex;
+          }
+
+          // If there is a limit on the maximum number of tags, the parameters passed into InputTag need to be recalculated
+          maxTagCount && forceUpdate();
+          onRemoveCheckedItem && onRemoveCheckedItem(value, index, event);
+        },
+      };
+
+      return (
+        <InputTag
+          // Avoid when clicking outside the browser window, InputTag out of focus
+          className={mergedFocused ? `${getPrefixCls('input-tag')}-focus` : ''}
+          ref={refInput}
+          disabled={disabled}
+          dragToSort={dragToSort}
+          disableInput={!showSearch}
+          animation={animation}
+          placeholder={placeholder}
+          value={tagsToShow}
+          inputValue={inputValue}
+          size={mergedSize}
+          tagClassName={`${prefixCls}-tag`}
+          renderTag={renderTag}
+          icon={{ removeIcon }}
+          onChange={(newValue, reason) => {
+            if (onSort && reason === 'sort') {
+              const indexOfMaxTagCount = newValue.indexOf(MAX_TAG_COUNT_VALUE_PLACEHOLDER);
+              // inject the invisible values tags to middle after dragging the "+x" tag
+              if (indexOfMaxTagCount > -1) {
+                const headArr = newValue.slice(0, indexOfMaxTagCount);
+                const tailArr = newValue.slice(indexOfMaxTagCount + 1);
+                const midArr = usedValue.slice(-invisibleTagCount);
+                onSort(headArr.concat(midArr, tailArr));
+              } else {
+                onSort(newValue);
+              }
+            }
+          }}
+          {...eventHandlers}
+        />
+      );
+    };
+
+    const selectStatus = status || (props.error ? 'error' : undefined);
+
+    const mergedClearIcon =
+      !disabled && !isEmptyValue && allowClear ? (
+        <IconHover
+          size={mergedSize}
+          key="clearIcon"
+          className={`${prefixCls}-clear-icon`}
+          onClick={onClear}
+          onMouseDown={keepFocus}
+        >
+          {clearIcon !== undefined && clearIcon !== null ? clearIcon : <IconClose />}
+        </IconHover>
+      ) : null;
+    const classNameStr = cs(
+      prefixCls,
+      `${prefixCls}-${isMultiple ? 'multiple' : 'single'}`,
+      {
+        [`${prefixCls}-show-search`]: showSearch,
+        [`${prefixCls}-open`]: popupVisible,
+        [`${prefixCls}-size-${mergedSize}`]: mergedSize,
+        [`${prefixCls}-focused`]: mergedFocused,
+        [`${prefixCls}-${selectStatus}`]: selectStatus,
+        [`${prefixCls}-disabled`]: disabled,
+        [`${prefixCls}-no-border`]: !bordered,
+        [`${prefixCls}-rtl`]: rtl,
+      },
+      className
+    );
+
     return (
-      <InputTag
-        // Avoid when clicking outside the browser window, InputTag out of focus
-        className={mergedFocused ? `${getPrefixCls('input-tag')}-focus` : ''}
-        ref={refInput}
-        disabled={disabled}
-        dragToSort={dragToSort}
-        disableInput={!showSearch}
-        animation={animation}
-        placeholder={placeholder}
-        value={tagsToShow}
-        inputValue={inputValue}
-        size={mergedSize}
-        tagClassName={`${prefixCls}-tag`}
-        renderTag={renderTag}
-        icon={{ removeIcon }}
-        onChange={(newValue, reason) => {
-          if (onSort && reason === 'sort') {
-            const indexOfMaxTagCount = newValue.indexOf(MAX_TAG_COUNT_VALUE_PLACEHOLDER);
-            // inject the invisible values tags to middle after dragging the "+x" tag
-            if (indexOfMaxTagCount > -1) {
-              const headArr = newValue.slice(0, indexOfMaxTagCount);
-              const tailArr = newValue.slice(indexOfMaxTagCount + 1);
-              const midArr = usedValue.slice(-invisibleTagCount);
-              onSort(headArr.concat(midArr, tailArr));
+      <div
+        role="combobox"
+        aria-haspopup="listbox"
+        aria-autocomplete="list"
+        aria-expanded={popupVisible}
+        aria-disabled={disabled}
+        aria-controls={ariaControls}
+        {...include(rest, ['onClick', 'onMouseEnter', 'onMouseLeave'])}
+        {...htmlDataAttributes}
+        ref={refWrapper}
+        tabIndex={disabled ? -1 : 0}
+        style={style}
+        className={classNameStr}
+        // When there is an input box, the keyboard events are handled inside the input box to avoid triggering redundant events in the Chinese input method
+        onKeyDown={tryTriggerKeyDown}
+        onFocus={(event) => {
+          if (!disabled && !dragToSort) {
+            // Focus on the input, otherwise you need to press the Tab key twice to focus on the input box
+            if (canFocusInput) {
+              refInput.current && refInput.current.focus();
             } else {
-              onSort(newValue);
+              tryTriggerFocusChange('focus', event);
             }
           }
         }}
-        {...eventHandlers}
-      />
+        onBlur={(event) => tryTriggerFocusChange('blur', event)}
+      >
+        <div
+          title={typeof renderedValue === 'string' ? renderedValue : undefined}
+          className={cs(`${prefixCls}-view`, {
+            [`${prefixCls}-view-with-prefix`]: prefix,
+          })}
+          onClick={(e) => popupVisible && canFocusInput && e.stopPropagation()}
+        >
+          {prefix && (
+            <div
+              aria-hidden="true"
+              className={cs(`${prefixCls}-prefix`)}
+              onMouseDown={(event) => focused && keepFocus(event)}
+            >
+              {prefix}
+            </div>
+          )}
+
+          {isMultiple ? renderMultiple() : renderSingle()}
+
+          <div
+            aria-hidden="true"
+            className={`${prefixCls}-suffix`}
+            onMouseDown={(event) => focused && keepFocus(event)}
+          >
+            {mergedClearIcon}
+            {mergedSuffixIcon}
+          </div>
+        </div>
+      </div>
     );
-  };
+  }
+);
+
+const SelectView = (props: SelectViewProps, ref) => {
+  const { prefixCls, style, className, addBefore, rtl, renderView, ...rest } = props;
+
+  const refCoreSelectView = useRef<SelectViewHandle>(null);
 
   const needAddBefore = addBefore !== null && addBefore !== undefined;
   // const needAddAfter = addAfter !== null && addAfter !== undefined;
   const needAddAfter = false;
   const needWrapper = needAddBefore || needAddAfter;
-  const selectStatus = status || (props.error ? 'error' : undefined);
-  const innerClassNames = cs(prefixCls, `${prefixCls}-${isMultiple ? 'multiple' : 'single'}`, {
-    [`${prefixCls}-show-search`]: showSearch,
-    [`${prefixCls}-open`]: popupVisible,
-    [`${prefixCls}-size-${mergedSize}`]: mergedSize,
-    [`${prefixCls}-focused`]: mergedFocused,
-    [`${prefixCls}-${selectStatus}`]: selectStatus,
-    [`${prefixCls}-disabled`]: disabled,
-    [`${prefixCls}-no-border`]: !bordered,
-    [`${prefixCls}-rtl`]: rtl,
-  });
-  const dataAttributes = pickDataAttributes(rest);
-  const propsAppendToRoot = { style, className, ...dataAttributes };
+  const propsAppliedToRoot = { style, className };
+  const htmlDataAttributes = pickDataAttributes(rest);
 
-  const mergedClearIcon =
-    !disabled && !isEmptyValue && allowClear ? (
-      <IconHover
-        size={mergedSize}
-        key="clearIcon"
-        className={`${prefixCls}-clear-icon`}
-        onClick={onClear}
-        onMouseDown={keepFocus}
-      >
-        {clearIcon !== undefined && clearIcon !== null ? clearIcon : <IconClose />}
-      </IconHover>
-    ) : null;
+  useImperativeHandle<any, SelectViewHandle>(ref, () => refCoreSelectView.current);
 
-  let eleSelectView = (
-    <div
-      role="combobox"
-      aria-haspopup="listbox"
-      aria-autocomplete="list"
-      aria-expanded={popupVisible}
-      aria-disabled={disabled}
-      aria-controls={ariaControls}
-      {...include(rest, ['onClick', 'onMouseEnter', 'onMouseLeave'])}
-      ref={refWrapper}
-      tabIndex={disabled ? -1 : 0}
-      {...(needWrapper ? {} : propsAppendToRoot)}
-      className={needWrapper ? innerClassNames : cs(innerClassNames, propsAppendToRoot.className)}
-      // When there is an input box, the keyboard events are handled inside the input box to avoid triggering redundant events in the Chinese input method
-      onKeyDown={tryTriggerKeyDown}
-      onFocus={(event) => {
-        if (!disabled && !dragToSort) {
-          // Focus on the input, otherwise you need to press the Tab key twice to focus on the input box
-          if (canFocusInput) {
-            refInput.current && refInput.current.focus();
-          } else {
-            tryTriggerFocusChange('focus', event);
-          }
-        }
-      }}
-      onBlur={(event) => tryTriggerFocusChange('blur', event)}
-    >
-      <div
-        title={typeof renderedValue === 'string' ? renderedValue : undefined}
-        className={cs(`${prefixCls}-view`, {
-          [`${prefixCls}-view-with-prefix`]: prefix,
-        })}
-        onClick={(e) => popupVisible && canFocusInput && e.stopPropagation()}
-      >
-        {prefix && (
-          <div
-            aria-hidden="true"
-            className={cs(`${prefixCls}-prefix`)}
-            onMouseDown={(event) => focused && keepFocus(event)}
-          >
-            {prefix}
-          </div>
-        )}
-
-        {isMultiple ? renderMultiple() : renderSingle()}
-
-        <div
-          aria-hidden="true"
-          className={`${prefixCls}-suffix`}
-          onMouseDown={(event) => focused && keepFocus(event)}
-        >
-          {mergedClearIcon}
-          {mergedSuffixIcon}
-        </div>
-      </div>
-    </div>
+  let eleCoreSelectView = (
+    <CoreSelectView
+      {...props}
+      ref={refCoreSelectView}
+      style={needWrapper ? undefined : propsAppliedToRoot.style}
+      className={needWrapper ? undefined : propsAppliedToRoot.className}
+      htmlDataAttributes={needWrapper ? {} : htmlDataAttributes}
+    />
   );
-  eleSelectView = typeof renderView === 'function' ? renderView(eleSelectView) : eleSelectView;
+  if (typeof renderView === 'function') {
+    eleCoreSelectView = renderView(eleCoreSelectView);
+  }
 
   if (!needWrapper) {
-    return eleSelectView;
+    return eleCoreSelectView;
   }
 
   return (
     <div
-      {...propsAppendToRoot}
+      {...htmlDataAttributes}
+      {...propsAppliedToRoot}
       className={cs(
         `${prefixCls}-wrapper`,
         {
           [`${prefixCls}-wrapper-rtl`]: rtl,
         },
-        propsAppendToRoot.className
+        propsAppliedToRoot.className
       )}
     >
       {needAddBefore && <div className={`${prefixCls}-addbefore`}>{addBefore}</div>}
-      {eleSelectView}
+      {eleCoreSelectView}
       {/* {needAddAfter && <div className={`${prefixCls}-addafter`}>{addAfter}</div>} */}
     </div>
   );


### PR DESCRIPTION

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|   Select     |  修复 `Select` 组件弹窗触发方式设置为 `focus` 不生效的 bug。  |   Fix the bug that setting the trigger mode of `Select` popup window to `focus` does not take effect.  |  Close #1905     |

