### PR TITLE
fix: Select width changes slowly after selected value tags are cleared

### DIFF
--- a/components/Input/input-element.tsx
+++ b/components/Input/input-element.tsx
@@ -109,8 +109,14 @@ const InputComponent = React.forwardRef<RefInputType, InputComponentProps>(
 
     const updateInputWidth = () => {
       if (refInputMirror.current && refInput.current) {
-        const width = refInputMirror.current.offsetWidth;
-        refInput.current.style.width = `${width + (width ? 8 : 4)}px`;
+        const needToShowPlaceholder = !inputProps.value && placeholder;
+        // use default width of input when placeholder is visible
+        if (needToShowPlaceholder) {
+          refInput.current.style.width = null;
+        } else {
+          const width = refInputMirror.current.offsetWidth;
+          refInput.current.style.width = `${width + (width ? 8 : 4)}px`;
+        }
       }
     };
 

--- a/components/InputTag/style/index.less
+++ b/components/InputTag/style/index.less
@@ -80,7 +80,7 @@
   }
 
   &-input {
-    width: 100%;
+    width: 4px;
     // width might be overwrite by inline-style, max-width make text-ellipsis work
     max-width: 100%;
     padding: 0;
@@ -91,6 +91,13 @@
     cursor: inherit;
     color: inherit;
     .text-ellipsis();
+
+    // input is the first child means that input-tag has an empty value
+    // we set width of input to 4px by default, and 100% when input-tag is empty to avoid wrap
+    // see https://github.com/arco-design/arco-design/pull/1863
+    &:first-child {
+      width: 100%;
+    }
 
     .@{prefix}-tag + &[disabled] {
       width: 0 !important;


### PR DESCRIPTION

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context

<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

## Solution

<!-- Describe how the problem is fixed in detail -->

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|   Select  |   修复 `Select` 多选模式下值被清空之后，其宽度缓慢恢复的问题。            |   Fix the problem that the width of `Select` is slowly restored after the value is cleared in multi-selection mode.    |                |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->
## Checklist:

- [ ] Test suite passes (`npm run test`)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
