### PR TITLE
fix(InputTag): dragToSort not work

### DIFF
--- a/components/InputTag/input-tag.tsx
+++ b/components/InputTag/input-tag.tsx
@@ -246,9 +246,11 @@ function InputTag(baseProps: InputTagProps<string | ObjectValueType>, ref) {
         })}
         closable={closable}
         closeIcon={icon && icon.removeIcon}
+        __closeIconProps={{
+          onMouseDown: keepFocus,
+        }}
         title={typeof label === 'string' ? label : undefined}
         onClose={onClose}
-        onMouseDown={keepFocus}
       >
         {fillNBSP(label)}
       </Tag>

--- a/components/Tag/index.tsx
+++ b/components/Tag/index.tsx
@@ -48,6 +48,7 @@ function Tag(baseProps: TagProps, ref) {
     icon,
     closeIcon,
     bordered,
+    __closeIconProps,
     ...rest
   } = props;
 
@@ -135,6 +136,7 @@ function Tag(baseProps: TagProps, ref) {
           tabIndex={0}
           {...getKeyboardEvents({ onPressEnter: onHandleClose })}
           aria-label="Close"
+          {...__closeIconProps}
         >
           {closeIcon !== undefined ? closeIcon : <IconClose />}
         </IconHover>

--- a/components/Tag/interface.ts
+++ b/components/Tag/interface.ts
@@ -69,4 +69,5 @@ export interface TagProps extends Omit<HTMLAttributes<HTMLDivElement>, 'classNam
    */
   onCheck?: (checked: boolean) => void;
   fill?: boolean; // 防止 1.0 用法报错，无实际作用
+  __closeIconProps?: HTMLAttributes<any>;
 }

--- a/stories/InputTag.story.tsx
+++ b/stories/InputTag.story.tsx
@@ -3,7 +3,7 @@ import { InputTag } from '@self';
 
 export const Demo = () => {
   const placeholder = 'Please input';
-  return <InputTag disabled readOnly error placeholder={placeholder} />;
+  return <InputTag defaultValue={['1', '2', '3']} dragToSort placeholder={placeholder} />;
 };
 
 export default {


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|  InputTag |  修复 `InputTag` 组件 `dragToSort` 功能不可用的问题。  |    Fix the issue that `dragToSort` of `InputTag` not work.  |     Close #1927  |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->
## Checklist:

- [ ] Test suite passes (`npm run test`)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
