### PR TITLE
style(List): dropdown of pager is not visible if trigger position is set to bottom

### DIFF
--- a/components/List/style/index.less
+++ b/components/List/style/index.less
@@ -14,7 +14,9 @@
   overflow-y: auto;
 
   &-wrapper {
-    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
   }
 
   .size(@size) {


### PR DESCRIPTION


<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|    List   | 修复 `List` 允许分页并设置页码下拉框向下弹出时，弹出框不可见的问题。         |  Fix the problem that the pop-up box is not visible when `List` allows pagination and sets the pager drop-down to pop up downwards.  |    Close #1933   |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->
## Checklist:

- [ ] Test suite passes (`npm run test`)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
