### PR TITLE
fix(Image): Image not update after Image.previewProps updated

### DIFF
--- a/components/Image/image.tsx
+++ b/components/Image/image.tsx
@@ -83,12 +83,9 @@ function Image(baseProps: ImagePropsType, ref: LegacyRef<HTMLDivElement>) {
   });
 
   // Props passed directly into Preview component
-  const availablePreviewProps = omit(previewProps, [
-    'visible',
-    'defaultVisible',
-    'src',
-    'onVisibleChange',
-  ]);
+  const availablePreviewProps = useMemo(() => {
+    return omit(previewProps, ['visible', 'defaultVisible', 'src', 'onVisibleChange']);
+  }, [previewProps]);
 
   const prefixCls = getPrefixCls('image');
   const isControlled = !isUndefined(previewProps.visible);
@@ -155,18 +152,15 @@ function Image(baseProps: ImagePropsType, ref: LegacyRef<HTMLDivElement>) {
 
   useEffect(() => {
     if (!previewGroup) return;
-    const unRegister = registerPreviewUrl(id, previewSrc, preview);
-    const unRegisterPreviewProps = registerPreviewProps(id, availablePreviewProps);
-    return () => {
-      unRegister(id);
-      unRegisterPreviewProps(id);
-    };
-  }, [previewGroup]);
+    const unRegister = registerPreviewProps(id, availablePreviewProps);
+    return () => unRegister(id);
+  }, [id, previewGroup, availablePreviewProps]);
 
   useEffect(() => {
     if (!previewGroup) return;
-    registerPreviewUrl(id, previewSrc, preview);
-  }, [previewSrc, preview, previewGroup]);
+    const unRegister = registerPreviewUrl(id, previewSrc, preview);
+    return () => unRegister(id);
+  }, [id, previewGroup, previewSrc, preview]);
 
   const defaultError = (
     <div className={`${prefixCls}-error`}>


### PR DESCRIPTION

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|  Image  |  修复 `Image.previewProps` 字段更新后组件 UI 实际未更新的 bug。   |  Fix the bug that the component UI is not actually updated after the `Image.previewProps` field is updated.  |   Close #1971  |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->
## Checklist:

- [ ] Test suite passes (`npm run test`)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
