### PR TITLE
fix(Input.TextArea): TextArea autoResize not work while composition updating

### DIFF
--- a/components/Input/textarea.tsx
+++ b/components/Input/textarea.tsx
@@ -73,6 +73,7 @@ const TextArea = (props: TextAreaProps, ref) => {
     },
   });
 
+  const textareaDisplayedText = compositionValue || value || '';
   const { getPrefixCls, rtl } = useContext(ConfigContext);
   const prefixCls = getPrefixCls('textarea');
   if (disabled) {
@@ -107,7 +108,7 @@ const TextArea = (props: TextAreaProps, ref) => {
 
   useIsomorphicLayoutEffect(() => {
     resizeTextAreaHeight();
-  }, [value]);
+  }, [textareaDisplayedText]);
 
   useImperativeHandle(
     ref,
@@ -155,7 +156,7 @@ const TextArea = (props: TextAreaProps, ref) => {
       className={classNames}
       placeholder={placeholder}
       disabled={disabled}
-      value={compositionValue || value || ''}
+      value={textareaDisplayedText}
       onChange={valueChangeHandler}
       onKeyDown={keyDownHandler}
       onCompositionStart={compositionHandler}


### PR DESCRIPTION

<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|  Input |  修复 `Input.TextArea` 组件 `autoSize` 属性在非英文输入法时可能不生效的问题。   |   Fix the issue that the `autoSize` of the `Input.TextArea` may not take effect while typing non-English texts. |   Close #1084  |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->
## Checklist:

- [ ] Test suite passes (`npm run test`)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
