### PR TITLE
fix: time-picker disabled error

### DIFF
--- a/components/TimePicker/time-picker.tsx
+++ b/components/TimePicker/time-picker.tsx
@@ -207,8 +207,6 @@ function TimePicker(props: InnerTimePickerProps) {
         'en'
       );
     }
-    console.log('--2', hour, minute, second);
-
     newValue = dayjs(newValue, valueFormat).locale(dayjs.locale());
 
     onSelect &&

--- a/components/TimePicker/time-picker.tsx
+++ b/components/TimePicker/time-picker.tsx
@@ -106,7 +106,16 @@ function TimePicker(props: InnerTimePickerProps) {
   const selectedSecond = valueShow && valueShow.second();
 
   const getDefaultStr = useCallback(
-    (type: 'hour' | 'minute' | 'second') => {
+    (
+      type: 'hour' | 'minute' | 'second',
+      {
+        hour,
+        minute,
+      }: {
+        hour?: number;
+        minute?: number;
+      } = {}
+    ) => {
       switch (type) {
         case 'hour':
           return typeof disabledHours === 'function'
@@ -115,7 +124,7 @@ function TimePicker(props: InnerTimePickerProps) {
         case 'minute':
           return typeof disabledMinutes === 'function'
             ? padStart(
-                MINUTES.find((m) => disabledMinutes(selectedHour).indexOf(m) === -1) || 0,
+                MINUTES.find((m) => disabledMinutes(hour ?? selectedHour).indexOf(m) === -1) || 0,
                 2,
                 '0'
               )
@@ -124,7 +133,9 @@ function TimePicker(props: InnerTimePickerProps) {
           return typeof disabledSeconds === 'function'
             ? padStart(
                 SECONDS.find(
-                  (s) => disabledSeconds(selectedHour, selectedMinute).indexOf(s) === -1
+                  (s) =>
+                    disabledSeconds(hour ?? selectedHour, minute ?? selectedMinute).indexOf(s) ===
+                    -1
                 ) || 0,
                 2,
                 '0'
@@ -149,10 +160,17 @@ function TimePicker(props: InnerTimePickerProps) {
 
   function onHandleSelect(selectedValue: number | string, unit: string) {
     const isUpperCase = getColumnsFromFormat(format).list.indexOf('A') !== -1;
+    const defaultConfig = {
+      hour: unit === 'hour' ? Number(selectedValue) : undefined,
+      minute: unit === 'minute' ? Number(selectedValue) : undefined,
+    };
     const _valueShow =
       valueShow ||
       dayjs(
-        `${getDefaultStr('hour')}:${getDefaultStr('minute')}:${getDefaultStr('second')}`,
+        `${getDefaultStr('hour')}:${getDefaultStr('minute', defaultConfig)}:${getDefaultStr(
+          'second',
+          defaultConfig
+        )}`,
         'HH:mm:ss'
       );
     let hour = _valueShow.hour();


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context

<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

## Solution

<!-- Describe how the problem is fixed in detail -->

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
| TimePicker   | 修复 `TimePicker` 组件选中默认值没有兼容 `disabledHours` `disabledMinites` `DisabledSeconds` 的 bug。       | Fix the bug that the default value of `TimePicker` component is not compatible with `disabledHours` `disabledMinites` `DisabledSeconds`.   |                |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->
## Checklist:

- [ ] Test suite passes (`npm run test`)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

当我组件是这样，需要禁用某一天的一段时间，且在外部不受控的时候：
<img width="749" alt="image" src="https://github.com/arco-design/arco-design/assets/51100990/5347fbc0-c830-446e-a18a-b5add4eeb07c">
此时当我选了8点，他会默认选择0分钟：
<img width="148" alt="image" src="https://github.com/arco-design/arco-design/assets/51100990/e7d20026-7e1c-41dd-a1ba-549be6a8239e">
但是00其实是被disabled了不应该被选中的
<img width="562" alt="image" src="https://github.com/arco-design/arco-design/assets/51100990/b0f3325d-d438-42e4-9201-96655b47e0cf">

