### PR TITLE
fix(Statistics): prefix is not rendered if value is not a number

### DIFF
--- a/components/Statistic/index.tsx
+++ b/components/Statistic/index.tsx
@@ -123,6 +123,17 @@ function Statistic(baseProps: StatisticProps, ref) {
   const valueFormatted = isFunction(renderFormat)
     ? renderFormat
     : (_, formattedValue) => formattedValue;
+
+  const isNumberValue = isNumber(Number(value));
+  const eleValueWithPrefix = (
+    <>
+      {prefix !== null && prefix !== undefined ? (
+        <span className={`${prefixCls}-value-prefix`}>{prefix}</span>
+      ) : null}
+      {valueFormatted(value, isNumberValue ? int : value)}
+    </>
+  );
+
   return (
     <div
       className={cs(`${prefixCls}`, { [`${prefixCls}-rtl`]: rtl }, className)}
@@ -133,15 +144,10 @@ function Statistic(baseProps: StatisticProps, ref) {
       <div className={`${prefixCls}-content`}>
         <Skeleton animation loading={!!loading} text={{ rows: 1, width: '100%' }}>
           <div className={`${prefixCls}-value`} style={styleValue}>
-            {!isNumber(Number(value)) ? (
-              valueFormatted(value, value)
+            {isNumberValue ? (
+              <span className={`${prefixCls}-value-int`}>{eleValueWithPrefix}</span>
             ) : (
-              <span className={`${prefixCls}-value-int`}>
-                {prefix !== null && prefix !== undefined ? (
-                  <span className={`${prefixCls}-value-prefix`}>{prefix}</span>
-                ) : null}
-                {valueFormatted(value, int)}
-              </span>
+              eleValueWithPrefix
             )}
 
             {decimal !== undefined || suffix ? (


### PR DESCRIPTION

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context

<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

## Solution

<!-- Describe how the problem is fixed in detail -->

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|  Statistics   |   修复 `Statistics` 组件 `value` 不为数字时，传入的 `prefix` 未被渲染的问题。  |  Fix the problem that `prefix` passed in is not rendered when `value` of `Statistics` is not a number.   |      Close #2031          |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->
## Checklist:

- [ ] Test suite passes (`npm run test`)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
