### PR TITLE
enhance(Select): judgement about whether to enable virtual list

### DIFF
--- a/components/Select/select.tsx
+++ b/components/Select/select.tsx
@@ -490,7 +490,9 @@ function Select(baseProps: SelectProps, ref) {
 
   const renderPopup = () => {
     // 没有设置弹出框的 width 时，需要在虚拟列表渲染的瞬间获得子元素的最大宽度
-    const needMeasureLongestItem = triggerProps?.autoAlignPopupWidth === false;
+    const needMeasureLongestItem =
+      triggerProps?.autoAlignPopupWidth === false &&
+      (!triggerProps?.style || triggerProps?.style === 'auto');
     // Option 存在复杂子元素时，让获得最长子元素变得困难，此时直接禁用虚拟滚动
     const needForbidVirtual = needMeasureLongestItem && hasComplexLabelInOptions;
 

--- a/stories/Select.story.tsx
+++ b/stories/Select.story.tsx
@@ -1,7 +1,5 @@
 /* eslint-disable no-console */
-
-import React from 'react';
-import { useState, useRef, useCallback } from 'react';
+import React, { useState, useRef, useCallback } from 'react';
 import debounce from 'lodash/debounce';
 import { Select, Spin, Avatar } from '@self';
 


### PR DESCRIPTION


## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [ ] Bug fix
- [x] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|    Select   |  `Select` 在选项 `label` 为富文本但通过 `triggerProps.style` 设置了弹出框宽度时，仍然保持其开启虚拟列表的能力。             |  `Select` still maintains its ability to open a virtual list when the option `label` is rich text but the width of the popup is set by `triggerProps.style`.    |    Close #2085  |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->
## Checklist:

- [ ] Test suite passes (`npm run test`)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
