### PR TITLE
fix(modal): clear wrapper dom after close modal(unmountOnExit=true)

### DIFF
--- a/components/Modal/__test__/index.test.tsx
+++ b/components/Modal/__test__/index.test.tsx
@@ -180,4 +180,25 @@ describe('Modal', () => {
     expect(onCancel).toHaveBeenCalledTimes(0);
     jest.useRealTimers();
   });
+
+  it('clear Modal dom ', () => {
+    jest.useFakeTimers();
+    const wrapper = render(
+      <Modal visible unmountOnExit>
+        haha
+      </Modal>
+    );
+
+    expect(document.querySelectorAll(`.arco-modal-wrapper`)).toHaveLength(1);
+
+    wrapper.rerender(
+      <Modal visible={false} unmountOnExit>
+        haha
+      </Modal>
+    );
+
+    jest.runAllTimers();
+    expect(document.querySelectorAll(`.arco-modal-wrapper`)).toHaveLength(0);
+    jest.useRealTimers();
+  });
 });


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context

<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

## Solution

<!-- Describe how the problem is fixed in detail -->

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|   Modal        |  修复 `Modal` 组件设置 `unmountOnExit=true` 并关闭弹窗后，弹窗外层节点未被 `unmount` 的 bug。             |     Fix the bug that when the `Modal` component sets `unmountOnExit=true` and closes the pop-up window, the outer node of the pop-up window is not `unmount` bug.          |       close #2055         |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->
## Checklist:

- [ ] Test suite passes (`npm run test`)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
