### PR TITLE
fix(Select): container lose width after focused if Select has a default value

### DIFF
--- a/components/_class/select-view.tsx
+++ b/components/_class/select-view.tsx
@@ -394,6 +394,11 @@ const CoreSelectView = React.forwardRef(
         inputProps.style.pointerEvents = 'none';
       }
 
+      // mirror should provide select-width if there is only placeholder in input
+      const valueMirrorText = fillNBSP(
+        needShowInput && !inputProps.value ? inputProps.placeholder : _inputValue
+      );
+
       return (
         <span className={`${prefixCls}-view-selector`}>
           <InputComponent
@@ -412,7 +417,7 @@ const CoreSelectView = React.forwardRef(
               [`${prefixCls}-view-value-mirror`]: needShowInput,
             })}
           >
-            {fillNBSP(isEmptyValue ? inputProps.placeholder : _inputValue)}
+            {valueMirrorText}
           </span>
         </span>
       );


### PR DESCRIPTION


<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 


## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
| Select  |  修复 `Select` 组件宽度为 `auto` 且存在选中值时，聚焦后宽度丢失的问题。  | Fix the issue that `Select` lost width after focusing if its width is `auto` and has a selected value.  |                |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->
## Checklist:

- [ ] Test suite passes (`npm run test`)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
