### PR TITLE
fix(Menu): avoid tranforming single child to array while processing menu children

### DIFF
--- a/components/Menu/__test__/index.test.tsx
+++ b/components/Menu/__test__/index.test.tsx
@@ -5,6 +5,7 @@ import mountTest from '../../../tests/mountTest';
 import componentConfigTest from '../../../tests/componentConfigTest';
 import { MenuProps } from '../interface';
 import { render, sleep } from '../../../tests/util';
+import Popover from '../../Popover';
 
 const SubMenu = Menu.SubMenu;
 const MenuItem = Menu.Item;
@@ -260,6 +261,9 @@ describe('Menu', () => {
   it('SubMenu selectable', () => {
     const wrapper = render(
       <Menu mode="vertical" defaultSelectedKeys={['submenu']}>
+        <Popover content="test">
+          <span>test</span>
+        </Popover>
         <SubMenu selectable title="submenu" key="submenu">
           <Menu.Item key="1">1</Menu.Item>
         </SubMenu>

--- a/components/Menu/util.ts
+++ b/components/Menu/util.ts
@@ -96,10 +96,11 @@ export const processChildren = (
     // 处理 <div> 包裹 MenuItem 之类的情况
     if (!isMenuSubComponent && item.props.children) {
       const _props = isHTMLElement ? {} : props;
+      const itemChildrenList = processChildren(item.props.children, props);
       return React.cloneElement(item, {
         ..._props,
         _key: item.key,
-        children: processChildren(item.props.children, props),
+        children: itemChildrenList.length === 1 ? itemChildrenList[0] : itemChildrenList,
       });
     }
 


### PR DESCRIPTION
## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 


## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|    Menu   |   修复 `Popover` 作为 `Menu` 直接子节点报错的问题。  |   Fix the problem that `Popover` is reported as a direct child node of `Menu`.   |   Close #2129    |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->
## Checklist:

- [ ] Test suite passes (`npm run test`)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
