### PR TITLE
fix(trigger): 删除废弃的context用法

### DIFF
--- a/components/Form/control.tsx
+++ b/components/Form/control.tsx
@@ -58,13 +58,10 @@ export default class Control<
 
   private removeRegisterField: () => void;
 
-  constructor(
-    props: FormControlProps<FormData, FieldValue, FieldKey>,
-    context: FormItemContextProps<FormData, FieldValue, FieldKey>
-  ) {
+  constructor(props: FormControlProps<FormData, FieldValue, FieldKey>) {
     super(props);
     if ('initialValue' in props && this.hasFieldProps()) {
-      const innerMethods = context.store.getInnerMethods(true);
+      const innerMethods = this.context.store.getInnerMethods(true);
       innerMethods.innerSetInitialValue(props.field, props.initialValue);
     }
   }

--- a/components/Form/control.tsx
+++ b/components/Form/control.tsx
@@ -58,10 +58,13 @@ export default class Control<
 
   private removeRegisterField: () => void;
 
-  constructor(props: FormControlProps<FormData, FieldValue, FieldKey>) {
+  constructor(
+    props: FormControlProps<FormData, FieldValue, FieldKey>,
+    context?: FormItemContextProps<FormData, FieldValue, FieldKey>
+  ) {
     super(props);
     if ('initialValue' in props && this.hasFieldProps()) {
-      const innerMethods = this.context.store.getInnerMethods(true);
+      const innerMethods = context.store.getInnerMethods(true);
       innerMethods.innerSetInitialValue(props.field, props.initialValue);
     }
   }

--- a/components/Tree/index.tsx
+++ b/components/Tree/index.tsx
@@ -112,12 +112,12 @@ class Tree extends Component<TreeProps, TreeState> {
     }, {});
   };
 
-  constructor(props) {
-    super(props);
+  constructor(props, context?) {
+    super(props, context);
 
     this.state = {};
     const treeData = this.getTreeData();
-    const nodeList = this.getNodeList(treeData, this.context.getPrefixCls('tree'));
+    const nodeList = this.getNodeList(treeData, context.getPrefixCls('tree'));
     const { checkedKeys, halfCheckedKeys } = this.getInitCheckedKeys(
       props.checkedKeys || props.defaultCheckedKeys || []
     );

--- a/components/Tree/index.tsx
+++ b/components/Tree/index.tsx
@@ -112,12 +112,12 @@ class Tree extends Component<TreeProps, TreeState> {
     }, {});
   };
 
-  constructor(props, context) {
-    super(props, context);
+  constructor(props) {
+    super(props);
 
     this.state = {};
     const treeData = this.getTreeData();
-    const nodeList = this.getNodeList(treeData, context.getPrefixCls('tree'));
+    const nodeList = this.getNodeList(treeData, this.context.getPrefixCls('tree'));
     const { checkedKeys, halfCheckedKeys } = this.getInitCheckedKeys(
       props.checkedKeys || props.defaultCheckedKeys || []
     );

--- a/components/Trigger/index.tsx
+++ b/components/Trigger/index.tsx
@@ -174,8 +174,8 @@ class Trigger extends PureComponent<TriggerProps, TriggerState> {
     return props;
   };
 
-  constructor(props, context) {
-    super(props, context);
+  constructor(props) {
+    super(props);
 
     const mergedProps = this.getMergedProps(props);
 

--- a/components/Trigger/index.tsx
+++ b/components/Trigger/index.tsx
@@ -174,8 +174,8 @@ class Trigger extends PureComponent<TriggerProps, TriggerState> {
     return props;
   };
 
-  constructor(props) {
-    super(props);
+  constructor(props, context?) {
+    super(props, context);
 
     const mergedProps = this.getMergedProps(props);
 


### PR DESCRIPTION
## Types of changes
- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context
在React18+TS的项目里使用Trigger组件的时候，会报一个TS的类型错误 `'Trigger' cannot be used as a JSX component.`
具体可以看 [CodeSandBox 的例子](https://codesandbox.io/p/sandbox/stoic-pasteur-d34wzj?file=/src/App.tsx:1,1)，用的就是官方的第一个Demo。
定位到原因就是因为 Trigger组件在实现的时候，在constructor中传入了context参数，这个用法已经被废弃了，可以看[react的官方文档](https://legacy.reactjs.org/docs/legacy-context.html)。
另外 组件 `Tree` 和 `Form.Control` 也是一样的问题。

## Solution
删除 `constructor(props, context)` 中的 context

