### PR TITLE
fix(Select): dropdown-menu won't show if click the disabled input-element of Select

### DIFF
--- a/components/Select/style/mixin.less
+++ b/components/Select/style/mixin.less
@@ -141,6 +141,12 @@
         &::placeholder {
           color: @select-color-placeholder_default;
         }
+
+        // since Chrome 116 <input disabled /> won't trigger onClick callback
+        // remove all events of disabled <input /> to make sure Trigger works correctly
+        &[disabled] {
+          pointer-events: none;
+        }
       }
     }
 


### PR DESCRIPTION


<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|  Select  | 修复多选 `Select` 在 Chrome 116+ 设置 `showSearch=false` 时点击 `<input>` 区域下拉框无法展开的问题。 | Fix the problem that the drop-down box in the `<input>` area cannot be expanded when the multi-selection `Select` is set to `showSearch=false` in Chrome 116+.     |     |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->
## Checklist:

- [ ] Test suite passes (`npm run test`)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
