### PR TITLE
docs(Tree): setState只接收一个参数

### DIFF
--- a/components/Tree/__demo__/controled.md
+++ b/components/Tree/__demo__/controled.md
@@ -83,15 +83,15 @@ function App() {
         expandedKeys={expandedKeys}
         onSelect={(keys, extra) => {
           console.log(keys, extra);
-          setSelectedKeys(keys, extra);
+          setSelectedKeys(keys);
         }}
         onCheck={(keys, extra) => {
           console.log(keys, extra);
-          setCheckedKeys(keys, extra);
+          setCheckedKeys(keys);
         }}
         onExpand={(keys, extra) => {
           console.log(keys, extra);
-          setExpandedKeys(keys, extra);
+          setExpandedKeys(keys);
         }}
         treeData={TreeData}
       ></Tree>


### PR DESCRIPTION
## Types of changes

- [ ] New feature
- [ ] Bug fix
- [ ] Enhancement
- [x] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context

`setSelectedKeys(keys, extra)` 这个函数，第二个参数是没有意义的，`setState` 只接收一个参数

## Solution

移除多余的参数
