### PR TITLE
fix: image defaultLoader

### DIFF
--- a/components/Image/image.tsx
+++ b/components/Image/image.tsx
@@ -184,6 +184,7 @@ function Image(baseProps: ImagePropsType, ref: LegacyRef<HTMLDivElement>) {
   );
 
   const renderLoader = () => {
+    if (loader === true) return defaultLoader;
     const loadElem: React.ReactNode = loader || defaultLoader;
     // 懒加载展示占位。
     if (_lazyload || loader) {


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context

<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

## Solution

<!-- Describe how the problem is fixed in detail -->

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|  image         |   修复 `Image` 组件 `loader = true` 时加载状态未展示的问题。     |   Fix the problem that the loading status of `Image` is not displayed when `loader = true`.   |                |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->
## Checklist:

- [ ] Test suite passes (`npm run test`)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information
看了代码，4个月前在支持lazyload的时候把173干掉了，导致loader为true时也无法进去defaultLoader。
<img width="1412" alt="image" src="https://github.com/arco-design/arco-design/assets/51100990/2c208a9b-338e-4104-9553-0f6671078f51">

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
