### PR TITLE
docs(typography): update size from middle to medium

### DIFF
--- a/components/Typography/__demo__/ellipsis-controlled.md
+++ b/components/Typography/__demo__/ellipsis-controlled.md
@@ -58,7 +58,7 @@ const App = () => {
             <Input />
           </Form.Item>
           <Form.Item label="省略展示">
-            <Space size="middle">
+            <Space size="medium">
               <Button onClick={() => setRows(Math.max(1, rows - 1))}> row- </Button>
               <Button onClick={() => setRows(rows + 1)}> row+ </Button>
             </Space>


### PR DESCRIPTION
## Types of changes

- [ ] New feature
- [ ] Bug fix
- [ ] Enhancement
- [x] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context

`Space` 的 `size` 属性没有 `"middle"` 这个值，应该为 `"medium"`