### PR TITLE
docs(Transfer): remove useless prop defaultExpandAll

### DIFF
--- a/components/Transfer/__demo__/with-tree.md
+++ b/components/Transfer/__demo__/with-tree.md
@@ -54,7 +54,6 @@ const TreeTransfer = ({ dataSource, targetKeys, ...restProps }) => {
               blockNode
               checkable
               checkStrictly
-              defaultExpandAll
               treeData={treeData}
               checkedKeys={checkedKeys}
               onCheck={(_, { node: { key } }) => {


### PR DESCRIPTION
## Types of changes

- [ ] New feature
- [ ] Bug fix
- [ ] Enhancement
- [x] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context

`Tree` 组件上不存在 `defaultExpandAll`，默认就是展开父级节点的，即展开所有。