### PR TITLE
docs(Timeline):  remove useless position prop

### DIFF
--- a/components/Timeline/__demo__/labelPosition.md
+++ b/components/Timeline/__demo__/labelPosition.md
@@ -70,7 +70,7 @@ function App() {
         <TimelineItem label="2018-05-12" dotColor="#F5222D" labelPosition="same">
           The second milestone
         </TimelineItem>
-        <TimelineItem label="2020-09-30" position="bottom">
+        <TimelineItem label="2020-09-30">
           The third milestone
         </TimelineItem>
       </Timeline>

--- a/components/Timeline/__demo__/mode.md
+++ b/components/Timeline/__demo__/mode.md
@@ -22,7 +22,7 @@ function Demo({ mode }) {
     <Timeline mode={mode} style={{ flex: 1 }}>
       <TimelineItem label="2017-03-10">The first milestone</TimelineItem>
       <TimelineItem label="2018-05-12">The second milestone</TimelineItem>
-      <TimelineItem label="2020-09-30" position="bottom">
+      <TimelineItem label="2020-09-30">
         The third milestone
       </TimelineItem>
     </Timeline>

--- a/components/Timeline/__demo__/pending.md
+++ b/components/Timeline/__demo__/pending.md
@@ -33,7 +33,7 @@ function App() {
           onChange={(v) => {
             setPendingProps({
               ...pendingProps,
-              direction: v ? 'horizontal' : '',
+              direction: v ? 'horizontal' : 'vertical',
             });
           }}
         >


### PR DESCRIPTION
## Types of changes

- [ ] New feature
- [ ] Bug fix
- [ ] Enhancement
- [x] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context

`TimelineItem` 的 `position` 属性没有 `bottom` 这个值，应该移除。