### PR TITLE
fix(List): pagination's dropdown is hidden caused by list wrapper's [overflow: hidden] style

### DIFF
--- a/components/List/style/index.less
+++ b/components/List/style/index.less
@@ -13,8 +13,12 @@
   color: @list-color-text;
   overflow-y: auto;
 
-  &-wrapper {
-    overflow: hidden;
+  // clear float caused by Pagination in list wrapper
+  &-wrapper::after {
+    content: '';
+    display: block;
+    visibility: hidden;
+    clear: both;
   }
 
   .size(@size) {


### PR DESCRIPTION


## Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 


## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
| List  |  修复 `List` 组件设置可翻页时，切换 `pageSize` 的下拉框有时无法展开的问题。  |   Fix the issue that the drop-down for switching `pageSize` sometimes cannot be expanded when `List` enables pagination.   |    Close #2175   |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->
## Checklist:

- [ ] Test suite passes (`npm run test`)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
