### PR TITLE
fix(Table): the second parameter of the render function is undefined

### DIFF
--- a/components/Table/__test__/components.test.tsx
+++ b/components/Table/__test__/components.test.tsx
@@ -164,6 +164,6 @@ describe('Table components', () => {
     const { rowData } = Cell.mock.calls[0][0];
 
     expect(Object.keys(rowData).includes('__ORIGIN_DATA')).toBe(false);
-    expect('__ORIGIN_DATA' in { ...rowData }).toBe(false);
+    expect('__ORIGIN_DATA' in rowData).toBe(false);
   });
 });

--- a/components/Table/tbody/td.tsx
+++ b/components/Table/tbody/td.tsx
@@ -161,7 +161,7 @@ function Td(props: TdType) {
         </ComponentBodyCell>
       ) : (
         <ComponentBodyCell
-          rowData={record}
+          rowData={getOriginData(record)}
           className={`${prefixCls}-cell-wrap-value`}
           column={column}
           onHandleSave={onHandleSave}

--- a/components/Table/utils.tsx
+++ b/components/Table/utils.tsx
@@ -37,10 +37,7 @@ export function deepCloneData(data, childrenColumnName) {
         newData.push(d);
       } else {
         const _d = { ...d };
-        Object.defineProperty(_d, '__ORIGIN_DATA', {
-          enumerable: false,
-          value: d,
-        });
+        _d.__ORIGIN_DATA = d;
         const children = _d[childrenColumnName];
         if (isObject(_d) && children && isArray(children)) {
           _d[childrenColumnName] = travel(children);


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context

<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

## Solution
https://github.com/arco-design/arco-design/issues/2170
<!-- Describe how the problem is fixed in detail -->

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|    Table       |     修复 `Table` 组件的 render 属性第二个参数可能为 `undefined` 的 bug (该问题在 `2.50.2` 引入)          |    Fix the bug that the second parameter of the render attribute of the `Table` component may be `undefined`           |                |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->
## Checklist:

- [ ] Test suite passes (`npm run test`)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
