### PR TITLE
fix(Select): dropdown-down won't show after clicking if use renderFormat with showSearch

### DIFF
--- a/components/Cascader/__test__/__snapshots__/demo.test.ts.snap
+++ b/components/Cascader/__test__/__snapshots__/demo.test.ts.snap
@@ -41,7 +41,13 @@ exports[`renders Cascader/demo/addon.md correctly 1`] = `
               value=""
             />
             <span
-              class="arco-cascader-view-value arco-cascader-view-value-mirror"
+              class="arco-cascader-view-value-mirror"
+            >
+              Please select ...
+            </span>
+            <span
+              class="arco-cascader-view-value"
+              style="display:none"
             >
               Please select ...
             </span>
@@ -182,7 +188,13 @@ exports[`renders Cascader/demo/basic.md correctly 1`] = `
               value=""
             />
             <span
-              class="arco-cascader-view-value arco-cascader-view-value-mirror"
+              class="arco-cascader-view-value-mirror"
+            >
+              Please select ...
+            </span>
+            <span
+              class="arco-cascader-view-value"
+              style="display:none"
             >
               Please select ...
             </span>
@@ -240,7 +252,13 @@ exports[`renders Cascader/demo/basic.md correctly 1`] = `
               value=""
             />
             <span
-              class="arco-cascader-view-value arco-cascader-view-value-mirror"
+              class="arco-cascader-view-value-mirror"
+            >
+              Hover to expand
+            </span>
+            <span
+              class="arco-cascader-view-value"
+              style="display:none"
             >
               Hover to expand
             </span>
@@ -304,7 +322,13 @@ exports[`renders Cascader/demo/basic.md correctly 1`] = `
               value=""
             />
             <span
-              class="arco-cascader-view-value arco-cascader-view-value-mirror"
+              class="arco-cascader-view-value-mirror"
+            >
+              Please select ...
+            </span>
+            <span
+              class="arco-cascader-view-value"
+              style="display:none"
             >
               Please select ...
             </span>
@@ -362,7 +386,13 @@ exports[`renders Cascader/demo/basic.md correctly 1`] = `
               value=""
             />
             <span
-              class="arco-cascader-view-value arco-cascader-view-value-mirror"
+              class="arco-cascader-view-value-mirror"
+            >
+              Hover to expand
+            </span>
+            <span
+              class="arco-cascader-view-value"
+              style="display:none"
             >
               Hover to expand
             </span>
@@ -428,7 +458,13 @@ exports[`renders Cascader/demo/change_on_select.md correctly 1`] = `
             value=""
           />
           <span
-            class="arco-cascader-view-value arco-cascader-view-value-mirror"
+            class="arco-cascader-view-value-mirror"
+          >
+            Please select ...
+          </span>
+          <span
+            class="arco-cascader-view-value"
+            style="display:none"
           >
             Please select ...
           </span>
@@ -632,7 +668,13 @@ exports[`renders Cascader/demo/control.md correctly 1`] = `
             value=""
           />
           <span
-            class="arco-cascader-view-value arco-cascader-view-value-mirror"
+            class="arco-cascader-view-value-mirror"
+          >
+            Please select ...
+          </span>
+          <span
+            class="arco-cascader-view-value"
+            style="display:none"
           >
             Please select ...
           </span>
@@ -1085,7 +1127,13 @@ exports[`renders Cascader/demo/dropdown.md correctly 1`] = `
             value=""
           />
           <span
-            class="arco-cascader-view-value arco-cascader-view-value-mirror"
+            class="arco-cascader-view-value-mirror"
+          >
+            Please select ...
+          </span>
+          <span
+            class="arco-cascader-view-value"
+            style="display:none"
           >
             Please select ...
           </span>
@@ -1142,7 +1190,11 @@ exports[`renders Cascader/demo/dropdown.md correctly 1`] = `
             value=""
           />
           <span
-            class="arco-cascader-view-value arco-cascader-view-value-mirror"
+            class="arco-cascader-view-value-mirror"
+          />
+          <span
+            class="arco-cascader-view-value"
+            style="display:none"
           />
         </span>
         <div
@@ -1774,7 +1826,13 @@ exports[`renders Cascader/demo/loadmore.md correctly 1`] = `
             value=""
           />
           <span
-            class="arco-cascader-view-value arco-cascader-view-value-mirror"
+            class="arco-cascader-view-value-mirror"
+          >
+            Please select ...
+          </span>
+          <span
+            class="arco-cascader-view-value"
+            style="display:none"
           >
             Please select ...
           </span>
@@ -2106,7 +2164,13 @@ exports[`renders Cascader/demo/onSearch.md correctly 1`] = `
               value=""
             />
             <span
-              class="arco-cascader-view-value arco-cascader-view-value-mirror"
+              class="arco-cascader-view-value-mirror"
+            >
+              Please enter ...
+            </span>
+            <span
+              class="arco-cascader-view-value"
+              style="display:none"
             >
               Please enter ...
             </span>
@@ -2618,7 +2682,13 @@ exports[`renders Cascader/demo/showEmptyChildren.md correctly 1`] = `
           value=""
         />
         <span
-          class="arco-cascader-view-value arco-cascader-view-value-mirror"
+          class="arco-cascader-view-value-mirror"
+        >
+          Please select ...
+        </span>
+        <span
+          class="arco-cascader-view-value"
+          style="display:none"
         >
           Please select ...
         </span>
@@ -2741,7 +2811,13 @@ exports[`renders Cascader/demo/size.md correctly 1`] = `
             value=""
           />
           <span
-            class="arco-cascader-view-value arco-cascader-view-value-mirror"
+            class="arco-cascader-view-value-mirror"
+          >
+            Please select ...
+          </span>
+          <span
+            class="arco-cascader-view-value"
+            style="display:none"
           >
             Please select ...
           </span>
@@ -2873,7 +2949,13 @@ exports[`renders Cascader/demo/visible.md correctly 1`] = `
           value=""
         />
         <span
-          class="arco-cascader-view-value arco-cascader-view-value-mirror"
+          class="arco-cascader-view-value-mirror"
+        >
+          Please select ...
+        </span>
+        <span
+          class="arco-cascader-view-value"
+          style="display:none"
         >
           Please select ...
         </span>

--- a/components/Cascader/__test__/__snapshots__/index.test.tsx.snap
+++ b/components/Cascader/__test__/__snapshots__/index.test.tsx.snap
@@ -24,7 +24,11 @@ exports[`ConfigProvider componentConfig.Cascader default 1`] = `
         value=""
       />
       <span
-        class="arco-cascader-view-value arco-cascader-view-value-mirror"
+        class="arco-cascader-view-value-mirror"
+      />
+      <span
+        class="arco-cascader-view-value"
+        style="display:none"
       />
     </span>
     <div
@@ -77,7 +81,11 @@ exports[`ConfigProvider componentConfig.Cascader set className globally 1`] = `
         value=""
       />
       <span
-        class="arco-cascader-view-value arco-cascader-view-value-mirror"
+        class="arco-cascader-view-value-mirror"
+      />
+      <span
+        class="arco-cascader-view-value"
+        style="display:none"
       />
     </span>
     <div
@@ -130,7 +138,11 @@ exports[`ConfigProvider componentConfig.Cascader set className globally and comp
         value=""
       />
       <span
-        class="arco-cascader-view-value arco-cascader-view-value-mirror"
+        class="arco-cascader-view-value-mirror"
+      />
+      <span
+        class="arco-cascader-view-value"
+        style="display:none"
       />
     </span>
     <div
@@ -184,7 +196,11 @@ exports[`ConfigProvider componentConfig.Cascader set data-* property 1`] = `
         value=""
       />
       <span
-        class="arco-cascader-view-value arco-cascader-view-value-mirror"
+        class="arco-cascader-view-value-mirror"
+      />
+      <span
+        class="arco-cascader-view-value"
+        style="display:none"
       />
     </span>
     <div

--- a/components/ConfigProvider/__test__/__snapshots__/demo.test.ts.snap
+++ b/components/ConfigProvider/__test__/__snapshots__/demo.test.ts.snap
@@ -1180,7 +1180,13 @@ Array [
               value=""
             />
             <span
-              class="arco-cascader-view-value arco-cascader-view-value-mirror"
+              class="arco-cascader-view-value-mirror"
+            >
+              Cascader
+            </span>
+            <span
+              class="arco-cascader-view-value"
+              style="display:none"
             >
               Cascader
             </span>
@@ -1239,7 +1245,13 @@ Array [
               value=""
             />
             <span
-              class="arco-select-view-value arco-select-view-value-mirror"
+              class="arco-select-view-value-mirror"
+            >
+              Select
+            </span>
+            <span
+              class="arco-select-view-value"
+              style="display:none"
             >
               Select
             </span>
@@ -1297,7 +1309,13 @@ Array [
               value=""
             />
             <span
-              class="arco-tree-select-view-value arco-tree-select-view-value-mirror"
+              class="arco-tree-select-view-value-mirror"
+            >
+              TreeSelect
+            </span>
+            <span
+              class="arco-tree-select-view-value"
+              style="display:none"
             >
               TreeSelect
             </span>

--- a/components/Form/__test__/__snapshots__/demo.test.ts.snap
+++ b/components/Form/__test__/__snapshots__/demo.test.ts.snap
@@ -565,7 +565,13 @@ exports[`renders Form/demo/control.md correctly 1`] = `
                       value=""
                     />
                     <span
-                      class="arco-cascader-view-value arco-cascader-view-value-mirror"
+                      class="arco-cascader-view-value-mirror"
+                    >
+                      please select
+                    </span>
+                    <span
+                      class="arco-cascader-view-value"
+                      style="display:none"
                     >
                       please select
                     </span>
@@ -730,7 +736,13 @@ exports[`renders Form/demo/control.md correctly 1`] = `
                       value=""
                     />
                     <span
-                      class="arco-select-view-value arco-select-view-value-mirror"
+                      class="arco-select-view-value-mirror"
+                    >
+                      please select
+                    </span>
+                    <span
+                      class="arco-select-view-value"
+                      style="display:none"
                     >
                       please select
                     </span>
@@ -960,7 +972,13 @@ exports[`renders Form/demo/control.md correctly 1`] = `
                       value=""
                     />
                     <span
-                      class="arco-tree-select-view-value arco-tree-select-view-value-mirror"
+                      class="arco-tree-select-view-value-mirror"
+                    >
+                      please select
+                    </span>
+                    <span
+                      class="arco-tree-select-view-value"
+                      style="display:none"
                     >
                       please select
                     </span>
@@ -2069,7 +2087,13 @@ exports[`renders Form/demo/custom.md correctly 1`] = `
                             value=""
                           />
                           <span
-                            class="arco-select-view-value arco-select-view-value-mirror"
+                            class="arco-select-view-value-mirror"
+                          >
+                            Please select ...
+                          </span>
+                          <span
+                            class="arco-select-view-value"
+                            style="display:none"
                           >
                             Please select ...
                           </span>
@@ -2449,7 +2473,13 @@ exports[`renders Form/demo/disabled.md correctly 1`] = `
                       value=""
                     />
                     <span
-                      class="arco-cascader-view-value arco-cascader-view-value-mirror"
+                      class="arco-cascader-view-value-mirror"
+                    >
+                      please select
+                    </span>
+                    <span
+                      class="arco-cascader-view-value"
+                      style="display:none"
                     >
                       please select
                     </span>
@@ -2617,7 +2647,13 @@ exports[`renders Form/demo/disabled.md correctly 1`] = `
                       value=""
                     />
                     <span
-                      class="arco-select-view-value arco-select-view-value-mirror"
+                      class="arco-select-view-value-mirror"
+                    >
+                      please select
+                    </span>
+                    <span
+                      class="arco-select-view-value"
+                      style="display:none"
                     >
                       please select
                     </span>
@@ -3929,7 +3965,13 @@ exports[`renders Form/demo/form-provider.md correctly 1`] = `
                           value=""
                         />
                         <span
-                          class="arco-select-view-value arco-select-view-value-mirror"
+                          class="arco-select-view-value-mirror"
+                        >
+                          select gender
+                        </span>
+                        <span
+                          class="arco-select-view-value"
+                          style="display:none"
                         >
                           select gender
                         </span>
@@ -6014,7 +6056,13 @@ exports[`renders Form/demo/nest-form-item.md correctly 1`] = `
                         value=""
                       />
                       <span
-                        class="arco-select-view-value arco-select-view-value-mirror"
+                        class="arco-select-view-value-mirror"
+                      >
+                        please enter you gender
+                      </span>
+                      <span
+                        class="arco-select-view-value"
+                        style="display:none"
                       >
                         please enter you gender
                       </span>
@@ -6127,7 +6175,13 @@ exports[`renders Form/demo/nest-form-item.md correctly 1`] = `
                       value=""
                     />
                     <span
-                      class="arco-select-view-value arco-select-view-value-mirror"
+                      class="arco-select-view-value-mirror"
+                    >
+                      please select
+                    </span>
+                    <span
+                      class="arco-select-view-value"
+                      style="display:none"
                     >
                       please select
                     </span>
@@ -7400,7 +7454,13 @@ exports[`renders Form/demo/size.md correctly 1`] = `
                       value=""
                     />
                     <span
-                      class="arco-cascader-view-value arco-cascader-view-value-mirror"
+                      class="arco-cascader-view-value-mirror"
+                    >
+                      please select
+                    </span>
+                    <span
+                      class="arco-cascader-view-value"
+                      style="display:none"
                     >
                       please select
                     </span>
@@ -7530,7 +7590,13 @@ exports[`renders Form/demo/size.md correctly 1`] = `
                       value=""
                     />
                     <span
-                      class="arco-select-view-value arco-select-view-value-mirror"
+                      class="arco-select-view-value-mirror"
+                    >
+                      please select
+                    </span>
+                    <span
+                      class="arco-select-view-value"
+                      style="display:none"
                     >
                       please select
                     </span>
@@ -7696,7 +7762,13 @@ exports[`renders Form/demo/size.md correctly 1`] = `
                       value=""
                     />
                     <span
-                      class="arco-tree-select-view-value arco-tree-select-view-value-mirror"
+                      class="arco-tree-select-view-value-mirror"
+                    >
+                      please select
+                    </span>
+                    <span
+                      class="arco-tree-select-view-value"
+                      style="display:none"
                     >
                       please select
                     </span>
@@ -9313,7 +9385,13 @@ exports[`renders Form/demo/validate-status.md correctly 1`] = `
                       value=""
                     />
                     <span
-                      class="arco-cascader-view-value arco-cascader-view-value-mirror"
+                      class="arco-cascader-view-value-mirror"
+                    >
+                      Cascader...
+                    </span>
+                    <span
+                      class="arco-cascader-view-value"
+                      style="display:none"
                     >
                       Cascader...
                     </span>
@@ -9620,7 +9698,13 @@ exports[`renders Form/demo/validate-status.md correctly 1`] = `
                       value=""
                     />
                     <span
-                      class="arco-tree-select-view-value arco-tree-select-view-value-mirror"
+                      class="arco-tree-select-view-value-mirror"
+                    >
+                      TreeSelect...
+                    </span>
+                    <span
+                      class="arco-tree-select-view-value"
+                      style="display:none"
                     >
                       TreeSelect...
                     </span>

--- a/components/Input/__test__/__snapshots__/demo.test.ts.snap
+++ b/components/Input/__test__/__snapshots__/demo.test.ts.snap
@@ -1694,7 +1694,13 @@ exports[`renders Input/demo/size.md correctly 1`] = `
                   value=""
                 />
                 <span
-                  class="arco-select-view-value arco-select-view-value-mirror"
+                  class="arco-select-view-value-mirror"
+                >
+                  Please select
+                </span>
+                <span
+                  class="arco-select-view-value"
+                  style="display:none"
                 >
                   Please select
                 </span>

--- a/components/Select/__test__/__snapshots__/demo.test.ts.snap
+++ b/components/Select/__test__/__snapshots__/demo.test.ts.snap
@@ -41,7 +41,13 @@ exports[`renders Select/demo/addbefore.md correctly 1`] = `
               value=""
             />
             <span
-              class="arco-select-view-value arco-select-view-value-mirror"
+              class="arco-select-view-value-mirror"
+            >
+              Please select
+            </span>
+            <span
+              class="arco-select-view-value"
+              style="display:none"
             >
               Please select
             </span>
@@ -177,7 +183,13 @@ exports[`renders Select/demo/allow-create.md correctly 1`] = `
             value=""
           />
           <span
-            class="arco-select-view-value arco-select-view-value-mirror"
+            class="arco-select-view-value-mirror"
+          >
+            Create an item
+          </span>
+          <span
+            class="arco-select-view-value"
+            style="display:none"
           >
             Create an item
           </span>
@@ -426,7 +438,13 @@ exports[`renders Select/demo/basic.md correctly 1`] = `
               value=""
             />
             <span
-              class="arco-select-view-value arco-select-view-value-mirror"
+              class="arco-select-view-value-mirror"
+            >
+              Please select
+            </span>
+            <span
+              class="arco-select-view-value"
+              style="display:none"
             >
               Please select
             </span>
@@ -552,7 +570,13 @@ exports[`renders Select/demo/basic.md correctly 1`] = `
               value=""
             />
             <span
-              class="arco-select-view-value arco-select-view-value-mirror"
+              class="arco-select-view-value-mirror"
+            >
+              Please select
+            </span>
+            <span
+              class="arco-select-view-value"
+              style="display:none"
             >
               Please select
             </span>
@@ -671,7 +695,13 @@ exports[`renders Select/demo/clear.md correctly 1`] = `
         value=""
       />
       <span
-        class="arco-select-view-value arco-select-view-value-mirror"
+        class="arco-select-view-value-mirror"
+      >
+        Please select
+      </span>
+      <span
+        class="arco-select-view-value"
+        style="display:none"
       >
         Please select
       </span>
@@ -735,7 +765,13 @@ exports[`renders Select/demo/custom-popup-width.md correctly 1`] = `
             value=""
           />
           <span
-            class="arco-select-view-value arco-select-view-value-mirror"
+            class="arco-select-view-value-mirror"
+          >
+            Please select
+          </span>
+          <span
+            class="arco-select-view-value"
+            style="display:none"
           >
             Please select
           </span>
@@ -793,7 +829,13 @@ exports[`renders Select/demo/custom-popup-width.md correctly 1`] = `
             value=""
           />
           <span
-            class="arco-select-view-value arco-select-view-value-mirror"
+            class="arco-select-view-value-mirror"
+          >
+            Please select
+          </span>
+          <span
+            class="arco-select-view-value"
+            style="display:none"
           >
             Please select
           </span>
@@ -1048,7 +1090,13 @@ exports[`renders Select/demo/dropdown-render.md correctly 1`] = `
         value=""
       />
       <span
-        class="arco-select-view-value arco-select-view-value-mirror"
+        class="arco-select-view-value-mirror"
+      >
+        Select city
+      </span>
+      <span
+        class="arco-select-view-value"
+        style="display:none"
       >
         Select city
       </span>
@@ -1105,7 +1153,13 @@ exports[`renders Select/demo/group.md correctly 1`] = `
           value=""
         />
         <span
-          class="arco-select-view-value arco-select-view-value-mirror"
+          class="arco-select-view-value-mirror"
+        >
+          Select drink
+        </span>
+        <span
+          class="arco-select-view-value"
+          style="display:none"
         >
           Select drink
         </span>
@@ -1764,7 +1818,13 @@ exports[`renders Select/demo/no-border.md correctly 1`] = `
             value=""
           />
           <span
-            class="arco-select-view-value arco-select-view-value-mirror"
+            class="arco-select-view-value-mirror"
+          >
+            Please select
+          </span>
+          <span
+            class="arco-select-view-value"
+            style="display:none"
           >
             Please select
           </span>
@@ -2267,7 +2327,13 @@ exports[`renders Select/demo/render-format.md correctly 1`] = `
             value=""
           />
           <span
-            class="arco-select-view-value arco-select-view-value-mirror"
+            class="arco-select-view-value-mirror"
+          >
+            Select city
+          </span>
+          <span
+            class="arco-select-view-value"
+            style="display:none"
           >
             Select city
           </span>
@@ -2628,7 +2694,13 @@ exports[`renders Select/demo/show-search.md correctly 1`] = `
             value=""
           />
           <span
-            class="arco-select-view-value arco-select-view-value-mirror"
+            class="arco-select-view-value-mirror"
+          >
+            Select city
+          </span>
+          <span
+            class="arco-select-view-value"
+            style="display:none"
           >
             Select city
           </span>
@@ -2686,7 +2758,13 @@ exports[`renders Select/demo/show-search.md correctly 1`] = `
             value=""
           />
           <span
-            class="arco-select-view-value arco-select-view-value-mirror"
+            class="arco-select-view-value-mirror"
+          >
+            Filter option
+          </span>
+          <span
+            class="arco-select-view-value"
+            style="display:none"
           >
             Filter option
           </span>
@@ -2743,7 +2821,13 @@ exports[`renders Select/demo/show-search.md correctly 1`] = `
             value=""
           />
           <span
-            class="arco-select-view-value arco-select-view-value-mirror"
+            class="arco-select-view-value-mirror"
+          >
+            Retain input value
+          </span>
+          <span
+            class="arco-select-view-value"
+            style="display:none"
           >
             Retain input value
           </span>
@@ -2866,7 +2950,13 @@ exports[`renders Select/demo/size.md correctly 1`] = `
             value=""
           />
           <span
-            class="arco-select-view-value arco-select-view-value-mirror"
+            class="arco-select-view-value-mirror"
+          >
+            Please select
+          </span>
+          <span
+            class="arco-select-view-value"
+            style="display:none"
           >
             Please select
           </span>

--- a/components/Select/__test__/__snapshots__/index.test.tsx.snap
+++ b/components/Select/__test__/__snapshots__/index.test.tsx.snap
@@ -24,7 +24,11 @@ exports[`ConfigProvider componentConfig.Select default 1`] = `
         value=""
       />
       <span
-        class="arco-select-view-value arco-select-view-value-mirror"
+        class="arco-select-view-value-mirror"
+      />
+      <span
+        class="arco-select-view-value"
+        style="display:none"
       />
     </span>
     <div
@@ -77,7 +81,11 @@ exports[`ConfigProvider componentConfig.Select set className globally 1`] = `
         value=""
       />
       <span
-        class="arco-select-view-value arco-select-view-value-mirror"
+        class="arco-select-view-value-mirror"
+      />
+      <span
+        class="arco-select-view-value"
+        style="display:none"
       />
     </span>
     <div
@@ -130,7 +138,11 @@ exports[`ConfigProvider componentConfig.Select set className globally and compon
         value=""
       />
       <span
-        class="arco-select-view-value arco-select-view-value-mirror"
+        class="arco-select-view-value-mirror"
+      />
+      <span
+        class="arco-select-view-value"
+        style="display:none"
       />
     </span>
     <div
@@ -184,7 +196,11 @@ exports[`ConfigProvider componentConfig.Select set data-* property 1`] = `
         value=""
       />
       <span
-        class="arco-select-view-value arco-select-view-value-mirror"
+        class="arco-select-view-value-mirror"
+      />
+      <span
+        class="arco-select-view-value"
+        style="display:none"
       />
     </span>
     <div

--- a/components/Select/style/mixin.less
+++ b/components/Select/style/mixin.less
@@ -209,7 +209,8 @@
         }
       }
 
-      &-value {
+      &-value,
+      &-value-mirror {
         display: inline-block;
         box-sizing: border-box;
         width: 100%;

--- a/components/TreeSelect/__test__/__snapshots__/demo.test.ts.snap
+++ b/components/TreeSelect/__test__/__snapshots__/demo.test.ts.snap
@@ -40,7 +40,11 @@ exports[`renders TreeSelect/demo/addon.md correctly 1`] = `
               value=""
             />
             <span
-              class="arco-tree-select-view-value arco-tree-select-view-value-mirror"
+              class="arco-tree-select-view-value-mirror"
+            />
+            <span
+              class="arco-tree-select-view-value"
+              style="display:none"
             />
           </span>
           <div
@@ -709,7 +713,13 @@ exports[`renders TreeSelect/demo/dropdownRender.md correctly 1`] = `
         value=""
       />
       <span
-        class="arco-tree-select-view-value arco-tree-select-view-value-mirror"
+        class="arco-tree-select-view-value-mirror"
+      >
+        Please select ...
+      </span>
+      <span
+        class="arco-tree-select-view-value"
+        style="display:none"
       >
         Please select ...
       </span>
@@ -1152,7 +1162,13 @@ exports[`renders TreeSelect/demo/popupVisible.md correctly 1`] = `
         value=""
       />
       <span
-        class="arco-tree-select-view-value arco-tree-select-view-value-mirror"
+        class="arco-tree-select-view-value-mirror"
+      >
+        hover to show options
+      </span>
+      <span
+        class="arco-tree-select-view-value"
+        style="display:none"
       >
         hover to show options
       </span>
@@ -1286,7 +1302,13 @@ exports[`renders TreeSelect/demo/search.md correctly 1`] = `
             value=""
           />
           <span
-            class="arco-tree-select-view-value arco-tree-select-view-value-mirror"
+            class="arco-tree-select-view-value-mirror"
+          >
+            Please select ...
+          </span>
+          <span
+            class="arco-tree-select-view-value"
+            style="display:none"
           >
             Please select ...
           </span>
@@ -1343,7 +1365,13 @@ exports[`renders TreeSelect/demo/search.md correctly 1`] = `
             value=""
           />
           <span
-            class="arco-tree-select-view-value arco-tree-select-view-value-mirror"
+            class="arco-tree-select-view-value-mirror"
+          >
+            Please select ...
+          </span>
+          <span
+            class="arco-tree-select-view-value"
+            style="display:none"
           >
             Please select ...
           </span>
@@ -1540,7 +1568,13 @@ exports[`renders TreeSelect/demo/treeData.md correctly 1`] = `
         value=""
       />
       <span
-        class="arco-tree-select-view-value arco-tree-select-view-value-mirror"
+        class="arco-tree-select-view-value-mirror"
+      >
+        请选择...
+      </span>
+      <span
+        class="arco-tree-select-view-value"
+        style="display:none"
       >
         请选择...
       </span>
@@ -1596,7 +1630,11 @@ exports[`renders TreeSelect/demo/virtual.md correctly 1`] = `
           value=""
         />
         <span
-          class="arco-tree-select-view-value arco-tree-select-view-value-mirror"
+          class="arco-tree-select-view-value-mirror"
+        />
+        <span
+          class="arco-tree-select-view-value"
+          style="display:none"
         />
       </span>
       <div

--- a/components/_class/select-view.tsx
+++ b/components/_class/select-view.tsx
@@ -394,11 +394,6 @@ const CoreSelectView = React.forwardRef(
         inputProps.style.pointerEvents = 'none';
       }
 
-      // mirror should provide select-width if there is only placeholder in input
-      const valueMirrorText = fillNBSP(
-        needShowInput && !inputProps.value ? inputProps.placeholder : _inputValue
-      );
-
       return (
         <span className={`${prefixCls}-view-selector`}>
           <InputComponent
@@ -412,12 +407,19 @@ const CoreSelectView = React.forwardRef(
             {...inputProps}
           />
 
+          {/* mirror should provide select-width if there is only placeholder in input */}
+          {needShowInput ? (
+            <span className={`${prefixCls}-view-value-mirror`}>
+              {fillNBSP(inputProps.value ? _inputValue : inputProps.placeholder)}
+            </span>
+          ) : null}
+
+          {/* this node should NOT unmount, otherwise its click event won't bubble and dropdown-list won't show */}
           <span
-            className={cs(`${prefixCls}-view-value`, {
-              [`${prefixCls}-view-value-mirror`]: needShowInput,
-            })}
+            style={needShowInput ? { display: 'none' } : {}}
+            className={`${prefixCls}-view-value`}
           >
-            {valueMirrorText}
+            {fillNBSP(isEmptyValue ? inputProps.placeholder : _inputValue)}
           </span>
         </span>
       );


### PR DESCRIPTION


<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 


## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
| Select |  修复 `Select` 单选模式配合 `renderFormat` 和 `showSearch` 使用时，下拉框需要点击两次才能弹出的问题。  |   Fix the issue that when the `Select` is used with `renderFormat` and `showSearch`, the drop-down box needs to be clicked twice to pop up.  | |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->
## Checklist:

- [ ] Test suite passes (`npm run test`)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
