### PR TITLE
fix(Select): active option should change after input value changed

### DIFF
--- a/components/Select/__test__/index.test.tsx
+++ b/components/Select/__test__/index.test.tsx
@@ -469,17 +469,31 @@ describe('Select', () => {
   });
 
   it('defaultActiveFirstOption works correctly', async () => {
-    wrapper = render(
+    const wrapper = render(
       <Select popupVisible mode="multiple" defaultActiveFirstOption={false}>
         <Option key="1" value="1">
           1
         </Option>
       </Select>
     );
+    const wrapper2 = render(
+      <Select
+        popupVisible
+        allowCreate
+        mode="multiple"
+        defaultValue={['1']}
+        inputValue="hello"
+        options={['1', '2', '3', '4']}
+      />
+    );
 
     await sleep(100);
 
-    const eleOption = wrapper.querySelector('.arco-select-option');
-    expect(eleOption.className.indexOf('arco-select-option-hover')).toBe(-1);
+    expect(
+      (wrapper.querySelector('.arco-select-option') as any).className?.indexOf(
+        'arco-select-option-hover'
+      )
+    ).toBe(-1);
+    expect(wrapper2.querySelector('.arco-select-option-hover')).toHaveTextContent('hello');
   });
 });

--- a/components/Select/select.tsx
+++ b/components/Select/select.tsx
@@ -182,13 +182,18 @@ function Select(baseProps: SelectProps, ref) {
   const valueActiveDefault = useMemo<string | number | undefined>(() => {
     if (defaultActiveFirstOption) {
       const firstValue = isArray(value) ? value[0] : value;
-      return !isNoOptionSelected && optionValueList.indexOf(firstValue) > -1
+      // only valid option will render in option list
+      // if it's not rendered (e.g. filtered by user-search), ignore it
+      const isFirstValueOptionSelectable =
+        !isNoOptionSelected && optionInfoMap.get(firstValue)?._valid;
+      return isFirstValueOptionSelectable
         ? firstValue
         : optionValueList[optionIndexListForArrowKey[0]];
     }
     return undefined;
   }, [
     value,
+    optionInfoMap,
     optionValueList,
     optionIndexListForArrowKey,
     defaultActiveFirstOption,


### PR DESCRIPTION

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|  Select   |  修复 `Select` 搜索文本改变后，回车会将之前选中的选项取消选中的 bug。  |   Fix the bug that after the `Select` search text is changed, pressing Enter will uncheck the previously selected option.   |    Close   #2209   |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->
## Checklist:

- [ ] Test suite passes (`npm run test`)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
