### PR TITLE
feat: Upload supports accept.strict

### DIFF
--- a/components/Form/README.en-US.md
+++ b/components/Form/README.en-US.md
@@ -55,7 +55,7 @@ A form with data collection, verification and submission functions, including ch
 |help|Custom help text|ReactNode |`-`|-|
 |label|Label text|ReactNode |`-`|-|
 |className|Additional css class|string \| string[] |`-`|-|
-|dependencies|the dependency fields|string[] |`-`|2.40.0|
+|dependencies|the dependency fields. When the value of the dependent field changes, trigger its own validation.If you want to dynamically render a form control/form area, use shouldUpdate|string[] |`-`|2.40.0|
 |field|Unique identification of controlled components|FieldKey |`-`|-|
 |initialValue|Default value|FieldValue |`-`|-|
 |labelCol|The layout of `<label>`, the same as the props received by the `<Grid.Col>`.The values of `span` and `offset` can be configured, which will override the global `labelCol` setting|[ColProps](grid#col) |`-`|-|

--- a/components/Form/README.zh-CN.md
+++ b/components/Form/README.zh-CN.md
@@ -55,7 +55,7 @@
 |help|自定义校验文案|ReactNode |`-`|-|
 |label|标签的文本|ReactNode |`-`|-|
 |className|节点类名|string \| string[] |`-`|-|
-|dependencies|依赖的字段。|string[] |`-`|2.40.0|
+|dependencies|设置依赖字段。当依赖的字段值改变时，触发自身的校验。如果是想动态渲染某个表单控件/表单区域，使用 shouldUpdate|string[] |`-`|2.40.0|
 |field|受控组件的唯一标示|FieldKey |`-`|-|
 |initialValue|设置控件初始值.(初始值，请不要使用受控组件的defaultValue了)|FieldValue |`-`|-|
 |labelCol|`<label>`标签布局，同[<Grid.Col>](/react/components/grid)组件接收的参数相同，可以配置`span`和`offset`值，会覆盖全局的`labelCol`设置|[ColProps](grid#col) |`-`|-|

--- a/components/Form/interface.tsx
+++ b/components/Form/interface.tsx
@@ -354,8 +354,8 @@ export interface FormItemProps<
    */
   formatter?: (value: FieldValue | undefined) => any;
   /**
-   * @zh 依赖的字段。
-   * @en the dependency fields
+   * @zh 设置依赖字段。当依赖的字段值改变时，触发自身的校验。如果是想动态渲染某个表单控件/表单区域，使用 shouldUpdate
+   * @en the dependency fields. When the value of the dependent field changes, trigger its own validation.If you want to dynamically render a form control/form area, use shouldUpdate
    * @version 2.40.0
    */
   dependencies?: string[];

--- a/components/Input/README.en-US.md
+++ b/components/Input/README.en-US.md
@@ -38,10 +38,10 @@ The basic form components have been expanded on the basis of native controls and
 |height|Custom input height|number \| string |`-`|-|
 |maxLength|The max content length；After setting `errorOnly` to `true`, if `maxLength` is exceeded, the `error` status will be displayed, and user input will not be restricted.|number \| { length: number; errorOnly?: boolean } |`-`|`errorOnly` in 2.23.0|
 |style|Additional style|CSSProperties |`-`|-|
+|normalize|Format the value entered by the user at the specified time, and when the previous and subsequent values are inconsistent, onChange will be triggered|(value: string) => string |`-`|2.50.0|
 |onChange|Callback when user input|(value: string, e) => void |`-`|-|
 |onClear|Callback when click clear button|() => void |`-`|-|
 |onPressEnter|Callback when press enter key|(e) => void |`-`|-|
-|normalize|Format the value entered by the user at the specified time, and when the previous and subsequent values are inconsistent, onChange will be triggered|(value: string) => string |`-`|2.50.0|
 
 ### Input.TextArea
 

--- a/components/Input/README.zh-CN.md
+++ b/components/Input/README.zh-CN.md
@@ -38,10 +38,10 @@
 |height|自定义输入框高度|number \| string |`-`|-|
 |maxLength|输入框最大输入的长度；设置 `errorOnly`为 `true` 后，超过 `maxLength` 会展示 `error` 状态，并不限制用户输入。|number \| { length: number; errorOnly?: boolean } |`-`|`errorOnly` in 2.23.0|
 |style|节点样式|CSSProperties |`-`|-|
+|normalize|在指定时机对用户输入的值进行格式化处理。前后值不一致时，会触发 onChange|(value: string) => string |`-`|2.50.0|
 |onChange|输入时的回调|(value: string, e) => void |`-`|-|
 |onClear|点击清除按钮的回调|() => void |`-`|-|
 |onPressEnter|按下回车键的回调|(e) => void |`-`|-|
-|normalize|在指定时机对用户输入的值进行格式化处理。前后值不一致时，会触发 onChange|(value: string) => string |`-`|2.50.0|
 
 ### Input.TextArea
 

--- a/components/Upload/README.en-US.md
+++ b/components/Upload/README.en-US.md
@@ -21,16 +21,17 @@ Upload file by selecting or dragging.
 |imagePreview|Enable built-in image preview, only works when listType='picture-card'. (`v2.41.0`)|boolean |`-`|-|
 |multiple|Whether to allow multiple files to be selected|boolean |`-`|-|
 |withCredentials|Whether to carry cookies when uploading requests|boolean |`-`|-|
-|accept|Accepted [file types](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#accept)|string |`-`|-|
 |action|Uploading URL|string |`-`|-|
 |listType|Upload list Style|'text' \| 'picture-list' \| 'picture-card' |`text`|-|
 |tip|The tip text|string \| React.ReactNode |`-`|-|
+|accept|Accepted [file types](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#accept)（`strict` in `2.53.0`, defaultValue is true. When set to false, accept behaves the same as native. When set to true, file extensions will be strictly matched and files that do not meet the accept rules will be filtered out. )|string \| { type: string; strict?: boolean } |`-`|-|
 |beforeUpload|Callback before uploading. Uploading will be aborted when the return value is false or a Promise which resolve(false) or reject.|(file: File, filesList: File[]) =&gt; boolean \| Promise&lt;any&gt; |`() => true`|-|
 |className|Additional css class|string \| string[] |`-`|-|
 |defaultFileList|Default list of files that have been uploaded|[UploadItem](upload#uploaditem)[] |`-`|-|
 |fileList|List of files that have been uploaded|[UploadItem](upload#uploaditem)[] |`-`|-|
 |headers|Set request headers|object |`-`|-|
 |limit|maximum number of uploads allowed. Object type is supported in `2.28.0`|number \| { maxCount: number; hideOnExceedLimit?: boolean } |`-`|-|
+|onRemove|Callback when the remove icon is clicked.Remove actions will be aborted when the return value is false or a Promise which resolve(false) or reject.|(file: [UploadItem](upload#uploaditem), fileList: [UploadItem](upload#uploaditem)[]) =&gt; void \| boolean \| Promise&lt;void \| boolean&gt; |`-`|-|
 |progressProps|The props of [Progress component](/react/en-US/components/progress).|Partial&lt;[ProgressProps](progress#progress)&gt; |`-`|-|
 |showUploadList|Whether to show upload list.It can be an object to customize the `previewIcon`, `removeIcon`,`fileIcon`, `reuploadIcon`, `cancelIcon`, `startIcon`, `errorIcon` and `fileName`|boolean \| [CustomIconType](#customicontype) |`true`|-|
 |style|Additional style|CSSProperties |`-`|-|
@@ -44,7 +45,6 @@ Upload file by selecting or dragging.
 |onExceedLimit|Callback when limit is exceeded|(files: File[], fileList: [UploadItem](upload#uploaditem)[]) => void |`-`|-|
 |onPreview|Callback when the preview icon is clicked|(file: [UploadItem](upload#uploaditem)) => void |`-`|-|
 |onProgress|Callback when uploading progress is changing|(file: [UploadItem](upload#uploaditem), e?: ProgressEvent) => void |`-`|-|
-|onRemove|Callback when the remove icon is clicked.Remove actions will be aborted when the return value is false or a Promise which resolve(false) or reject.|(file: [UploadItem](upload#uploaditem), fileList: [UploadItem](upload#uploaditem)[]) => void |`-`|-|
 |onReupload|Callback when the re-upload icon is clicked|(file: [UploadItem](upload#uploaditem)) => void |`-`|-|
 |renderUploadItem|Custom item of uploadList|(originNode: ReactNode, file: [UploadItem](upload#uploaditem), fileList: [UploadItem](upload#uploaditem)[]) => ReactNode |`-`|-|
 |renderUploadList|Custom uploadList|(fileList: [UploadItem](upload#uploaditem)[], uploadListProps: [UploadListProps](upload#uploadlistprops)) => ReactNode |`-`|-|
@@ -56,9 +56,9 @@ File upload list display
 |Property|Description|Type|DefaultValue|
 |---|---|---|---|
 |disabled|Whether to disable|boolean |`-`|
+|onRemove|Callback when the remove icon is clicked.Remove actions will be aborted when the return value is false or a Promise which resolve(false) or reject|(file: [UploadItem](upload#uploaditem)) =&gt; void \| boolean \| Promise&lt;void \| boolean&gt; |`-`|
 |onAbort|Callback when the cancel icon is clicked|(file: [UploadItem](upload#uploaditem)) => void |`-`|
 |onPreview|Callback when the preview icon is clicked|(file: [UploadItem](upload#uploaditem)) => void |`-`|
-|onRemove|Callback when the remove icon is clicked.Remove actions will be aborted when the return value is false or a Promise which resolve(false) or reject|(file: [UploadItem](upload#uploaditem)) => void |`-`|
 |onReupload|Callback when the re-upload icon is clicked|(file: [UploadItem](upload#uploaditem)) => void |`-`|
 
 ### UploadItem

--- a/components/Upload/README.zh-CN.md
+++ b/components/Upload/README.zh-CN.md
@@ -21,16 +21,17 @@
 |imagePreview|启用内置的图片预览，仅在 listType='picture-card' 时生效。(`v2.41.0`)|boolean |`-`|-|
 |multiple|文件多选|boolean |`-`|-|
 |withCredentials|上传请求是否携带 cookie|boolean |`-`|-|
-|accept|接受上传的类型 [详细请参考](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#accept)|string |`-`|-|
-|action|action|string |`-`|-|
+|action|上传接口地址|string |`-`|-|
 |listType|展示类型|'text' \| 'picture-list' \| 'picture-card' |`text`|-|
 |tip|提示文字，listType 不同，展示会有区别|string \| React.ReactNode |`-`|-|
+|accept|接受上传的类型 [详细请参考](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#accept)。（`strict` in `2.53.0`，默认为 true。设置为 false 时，accept 表现和原生一致。设置为 true 时，会严格匹配文件后缀名，过滤掉不符合 accept 规则的文件。)|string \| { type: string; strict?: boolean } |`-`|-|
 |beforeUpload|上传文件之前的回调。返回 false 或者 promise抛出异常的时候会取消上传。|(file: File, filesList: File[]) =&gt; boolean \| Promise&lt;any&gt; |`() => true`|-|
 |className|节点类名|string \| string[] |`-`|-|
 |defaultFileList|默认已上传的文件列表|[UploadItem](upload#uploaditem)[] |`-`|-|
 |fileList|已上传的文件列表|[UploadItem](upload#uploaditem)[] |`-`|-|
 |headers|上传时使用的 headers|object |`-`|-|
 |limit|限制上传数量。默认超出后会隐藏上传节点。对象类型在 `2.28.0` 支持|number \| { maxCount: number; hideOnExceedLimit?: boolean } |`-`|-|
+|onRemove|点击删除文件时的回调。返回 `false` 或者 `Promise.reject` 的时候不会执行删除。|(file: [UploadItem](upload#uploaditem), fileList: [UploadItem](upload#uploaditem)[]) =&gt; void \| boolean \| Promise&lt;void \| boolean&gt; |`-`|-|
 |progressProps|进度条属性，接收所有进度条的 props。|Partial&lt;[ProgressProps](progress#progress)&gt; |`-`|-|
 |showUploadList|是否展示上传文件列表。预览图标，删除图标，文件图标，重新上传图标，取消上传图标。|boolean \| [CustomIconType](#customicontype) |`true`|-|
 |style|节点样式|CSSProperties |`-`|-|
@@ -44,7 +45,6 @@
 |onExceedLimit|超出上传数量限制时触发|(files: File[], fileList: [UploadItem](upload#uploaditem)[]) => void |`-`|-|
 |onPreview|点击预览时候的回调|(file: [UploadItem](upload#uploaditem)) => void |`-`|-|
 |onProgress|文件上传进度的回调|(file: [UploadItem](upload#uploaditem), e?: ProgressEvent) => void |`-`|-|
-|onRemove|点击删除文件时的回调。返回 `false` 或者 `Promise.reject` 的时候不会执行删除。|(file: [UploadItem](upload#uploaditem), fileList: [UploadItem](upload#uploaditem)[]) => void |`-`|-|
 |onReupload|文件重新上传时触发的回调|(file: [UploadItem](upload#uploaditem)) => void |`-`|-|
 |renderUploadItem|自定义上传列表项|(originNode: ReactNode, file: [UploadItem](upload#uploaditem), fileList: [UploadItem](upload#uploaditem)[]) => ReactNode |`-`|-|
 |renderUploadList|自定义展示上传文件列表|(fileList: [UploadItem](upload#uploaditem)[], uploadListProps: [UploadListProps](upload#uploadlistprops)) => ReactNode |`-`|-|
@@ -56,9 +56,9 @@
 |参数名|描述|类型|默认值|
 |---|---|---|---|
 |disabled|禁用|boolean |`-`|
+|onRemove|点击删除文件时的回调。返回 false 或者 Promise.reject 的时候不会执行删除|(file: [UploadItem](upload#uploaditem)) =&gt; void \| boolean \| Promise&lt;void \| boolean&gt; |`-`|
 |onAbort|中止文件上传的回调|(file: [UploadItem](upload#uploaditem)) => void |`-`|
 |onPreview|点击预览时候的回调。|(file: [UploadItem](upload#uploaditem)) => void |`-`|
-|onRemove|点击删除文件时的回调。返回 false 或者 Promise.reject 的时候不会执行删除|(file: [UploadItem](upload#uploaditem)) => void |`-`|
 |onReupload|重新上传的回调|(file: [UploadItem](upload#uploaditem)) => void |`-`|
 
 ### UploadItem

--- a/components/Upload/__test__/apis.test.tsx
+++ b/components/Upload/__test__/apis.test.tsx
@@ -231,4 +231,50 @@ describe('Upload api callbacks', function () {
     expect(wrapper.find('.arco-upload-trigger')).toHaveLength(1);
     expect(wrapper.find('.arco-upload-trigger .arco-btn-disabled')).toHaveLength(1);
   });
+
+  it('accept xxx/* strict=true', async function () {
+    const mockFn = jest.fn();
+    const wrapper = render(<Upload multiple accept=".txt" action="/sss" onChange={mockFn} />);
+    const triggerNode = wrapper.find('.arco-btn');
+    expect(triggerNode).toHaveLength(1);
+    const files = [
+      new File([new Blob(['aaa'], { type: 'text/plain' })], 'a.txt', { type: 'text/plain' }),
+      new File([new Blob(['bbb'], { type: 'text/csv' })], 'b.csv', { type: 'text/csv' }),
+    ];
+
+    await act(() => {
+      fireEvent.drop(triggerNode.item(0), {
+        dataTransfer: {
+          files,
+        },
+      });
+    });
+    await sleep(100);
+
+    expect(wrapper.find('.arco-upload-list-item')).toHaveLength(1);
+  });
+
+  it('accept xxx/* strict=false', async function () {
+    const mockFn = jest.fn();
+    const wrapper = render(
+      <Upload multiple accept={{ type: '.txt', strict: false }} action="/sss" onChange={mockFn} />
+    );
+    const triggerNode = wrapper.find('.arco-btn');
+    expect(triggerNode).toHaveLength(1);
+    const files = [
+      new File([new Blob(['aaa'], { type: 'text/plain' })], 'a.txt', { type: 'text/plain' }),
+      new File([new Blob(['bbb'], { type: 'text/csv' })], 'b.csv', { type: 'text/csv' }),
+    ];
+
+    await act(() => {
+      fireEvent.drop(triggerNode.item(0), {
+        dataTransfer: {
+          files,
+        },
+      });
+    });
+    await sleep(100);
+
+    expect(wrapper.find('.arco-upload-list-item')).toHaveLength(2);
+  });
 });

--- a/components/Upload/interface.tsx
+++ b/components/Upload/interface.tsx
@@ -74,10 +74,10 @@ export interface UploadProps {
    */
   directory?: boolean;
   /**
-   * @zh 接受上传的类型 [详细请参考](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#accept)
-   * @en Accepted [file types](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#accept)
+   * @zh 接受上传的类型 [详细请参考](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#accept)。（`strict` in `2.53.0`，默认为 true。设置为 false 时，accept 表现和原生一致。设置为 true 时，会严格匹配文件后缀名，过滤掉不符合 accept 规则的文件。)
+   * @en Accepted [file types](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#accept)（`strict` in `2.53.0`, defaultValue is true. When set to false, accept behaves the same as native. When set to true, file extensions will be strictly matched and files that do not meet the accept rules will be filtered out. )
    */
-  accept?: string;
+  accept?: string | { type: string; strict?: boolean };
   /**
    * @zh 通过覆盖默认的上传行为，可以自定义自己的上传实现
    * @en Provide an override for the default xhr behavior for additional customization
@@ -110,7 +110,7 @@ export interface UploadProps {
    */
   autoUpload?: boolean;
   /**
-   * @zh action
+   * @zh 上传接口地址
    * @en Uploading URL
    */
   action?: string;
@@ -188,7 +188,7 @@ export interface UploadProps {
    * @zh 点击删除文件时的回调。返回 `false` 或者 `Promise.reject` 的时候不会执行删除。
    * @en Callback when the remove icon is clicked.Remove actions will be aborted when the return value is false or a Promise which resolve(false) or reject.
    */
-  onRemove?: (file: UploadItem, fileList: UploadItem[]) => void;
+  onRemove?: (file: UploadItem, fileList: UploadItem[]) => void | boolean | Promise<void | boolean>;
   /**
    * @zh 文件上传进度的回调
    * @en Callback when uploading progress is changing
@@ -251,7 +251,7 @@ export interface UploadListProps {
    * @zh 点击删除文件时的回调。返回 false 或者 Promise.reject 的时候不会执行删除
    * @en Callback when the remove icon is clicked.Remove actions will be aborted when the return value is false or a Promise which resolve(false) or reject
    */
-  onRemove?: (file: UploadItem) => void;
+  onRemove?: (file: UploadItem) => void | boolean | Promise<void | boolean>;
   /**
    * @zh 重新上传的回调
    * @en Callback when the re-upload icon is clicked
@@ -327,7 +327,7 @@ export interface UploaderProps extends UploadProps {
 export type TriggerProps = {
   tip?: string | React.ReactNode;
   multiple?: boolean;
-  accept?: string;
+  accept?: UploadProps['accept'];
   disabled?: boolean;
   directory?: boolean;
   drag?: boolean;

--- a/components/Upload/upload.tsx
+++ b/components/Upload/upload.tsx
@@ -111,7 +111,7 @@ const Upload: React.ForwardRefRenderFunction<UploadInstance, PropsWithChildren<U
   const removeFile = (file: UploadItem) => {
     if (file) {
       const { onRemove } = props;
-      Promise.resolve(isFunction(onRemove) ? onRemove(file) : onRemove)
+      Promise.resolve(isFunction(onRemove) ? onRemove(file, mergeFileList) : onRemove)
         .then((val) => {
           if (val !== false) {
             uploaderRef.current && uploaderRef.current.abort(file);

--- a/components/Upload/uploader.tsx
+++ b/components/Upload/uploader.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { CSSTransition } from 'react-transition-group';
 import uploadRequest from './request';
 import { UploaderProps, STATUS, UploadItem, UploadRequestReturn } from './interface';
-import { isNumber, isFunction, isFile } from '../_util/is';
+import { isNumber, isFunction, isFile, isObject } from '../_util/is';
 import TriggerNode from './trigger-node';
 import { isAcceptFile } from './util';
 
@@ -228,7 +228,7 @@ class Uploader extends React.Component<React.PropsWithChildren<UploaderProps>, U
           ref={(node) => (this.inputRef = node)}
           style={{ display: 'none' }}
           type="file"
-          accept={accept}
+          accept={isObject(accept) ? accept?.type : accept}
           multiple={multiple}
           {...(directory ? { webkitdirectory: 'true' } : {})}
           onChange={(e: React.ChangeEvent<HTMLInputElement>) => {

--- a/components/Upload/util.tsx
+++ b/components/Upload/util.tsx
@@ -1,7 +1,11 @@
-import { isArray } from '../_util/is';
+import { isArray, isObject } from '../_util/is';
+import { UploadProps } from './interface';
 
-export const isAcceptFile = (file: File, accept?: string | string[]): boolean => {
-  if (accept && file) {
+export const isAcceptFile = (file: File, propsAccept?: UploadProps['accept']): boolean => {
+  const accept = isObject(propsAccept) ? propsAccept?.type : propsAccept;
+  // 显示设置 strict=false，才是非严格模式，不走过滤逻辑
+  const strict = !(isObject(propsAccept) && propsAccept.strict === false);
+  if (strict && accept && file) {
     const accepts = isArray(accept)
       ? accept
       : accept


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [x] New feature
- [ ] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context

<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

## Solution

<!-- Describe how the problem is fixed in detail -->

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|    Upload       |      `Upload` 支持通过 `accept.strict` 设置 `accept` 属性遵循浏览器原生表现，不对文件后缀名进行严格匹配过滤         |    `Upload` supports setting the `accept` attribute through `accept.strict` to follow the browser's native behavior and does not strictly match and filter file extensions.           |      close #2196          |
|    Upload       |      `Upload`  组件 `onRemove` 方法支持回调参数传入当前文件列表     |    The `onRemove` method of the `Upload` component supports passing the callback parameter into the current file list     |       |
|    Upload       |      `Upload`  组件 `onRemove` 方法返回值的 TS 类型修正，`void` 调整为 `void \| boolean \| Promise<void \| boolean>`     |    The TS type correction of the return value of `onRemove` method of `Upload` component, `void` is adjusted to `void \| boolean \| Promise<void \| boolean>`    |       |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->
## Checklist:

- [ ] Test suite passes (`npm run test`)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
