### PR TITLE
fix: tree-select should rerender Text when treeData change

### DIFF
--- a/components/TreeSelect/__test__/index.test.tsx
+++ b/components/TreeSelect/__test__/index.test.tsx
@@ -801,4 +801,34 @@ describe('TreeSelect', () => {
       `-- ${treeData[1].title}`
     );
   });
+
+  it('renderFormat correctly async', async () => {
+    const wrapper = render(
+      <TreeSelect
+        id="async-data"
+        value={TrunkTreeData[0].key}
+        treeData={[]}
+        renderFormat={(option, value) => (
+          <span id="render-text">{`aaa-${option?.title || value}`}</span>
+        )}
+      />
+    );
+
+    expect(document.querySelector('#render-text')?.textContent).toBe(`aaa-${TrunkTreeData[0].key}`);
+
+    wrapper.rerender(
+      <TreeSelect
+        id="async-data"
+        value={TrunkTreeData[0].key}
+        treeData={TrunkTreeData}
+        renderFormat={(option, value) => (
+          <span id="render-text">{`aaa-${option?.title || value}`}</span>
+        )}
+      />
+    );
+
+    expect(document.querySelector('#render-text')?.textContent).toBe(
+      `aaa-${TrunkTreeData[0].title}`
+    );
+  });
 });

--- a/components/TreeSelect/tree-select.tsx
+++ b/components/TreeSelect/tree-select.tsx
@@ -267,7 +267,7 @@ const TreeSelect: ForwardRefRenderFunction<
       }
       return { text: label || value || '', disabled };
     },
-    [props.renderFormat, props.labelInValue]
+    [props.renderFormat, props.labelInValue, key2nodeProps]
   );
 
   const tryUpdateSelectValue = (value: LabelValue[]) => {


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context

<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

## Solution

<!-- Describe how the problem is fixed in detail -->

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|   TreeSelect        |     修复 `TreeSelect` 组件的 `TreeData` 改变，未触发 `renderFormat` 重渲染的 bug。         |      Fixed the bug that the `renderFormat` re-rendering was not triggered when the `TreeData` of the `TreeSelect` component was changed.         |  #2214               |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->
## Checklist:

- [ ] Test suite passes (`npm run test`)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
