### PR TITLE
fix(Select): dropdown-box need click twice to show in Firefox

### DIFF
--- a/components/Select/style/mixin.less
+++ b/components/Select/style/mixin.less
@@ -157,7 +157,10 @@
       // https://github.com/arco-design/arco-design/issues/1232
       opacity: 0;
       position: absolute;
-      pointer-events: none;
+      // 避免绝对定位的元素位于所有同级节点的最上层，遮挡其他元素的鼠标操作（例如被 Tooltip 包裹的 value 文本）
+      // 不要使用 pointer-events: none，会导致火狐浏览器下下拉弹窗需要点击两次才可弹出
+      // https://github.com/arco-design/arco-design/issues/2127
+      z-index: -1;
     }
 
     &-multiple,


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 


## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|   Select   |   修复 Firefox 浏览器中 `Select` 需要点击两次才能出现下拉框的问题。   |  Fixed the issue that `Select` needs to be clicked twice to display the drop-down box in Firefox.   |   Close #2127    |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->
## Checklist:

- [ ] Test suite passes (`npm run test`)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
