### PR TITLE
enhance(Image): enter drag-mode only when mouse left button is pressed

### DIFF
--- a/components/Image/__test__/__snapshots__/demo.test.ts.snap
+++ b/components/Image/__test__/__snapshots__/demo.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`renders Image/demo/basic.md correctly 1`] = `
 <div
-  class="arco-image"
+  class="arco-image arco-image-before-load"
   style="width:200px"
 >
   <img
@@ -27,7 +27,7 @@ exports[`renders Image/demo/caption.md correctly 1`] = `
     style="margin-right:60px"
   >
     <div
-      class="arco-image"
+      class="arco-image arco-image-before-load"
       style="width:200px"
     >
       <img
@@ -47,7 +47,7 @@ exports[`renders Image/demo/caption.md correctly 1`] = `
     class="arco-space-item"
   >
     <div
-      class="arco-image"
+      class="arco-image arco-image-before-load"
       style="width:200px"
     >
       <img
@@ -94,7 +94,7 @@ exports[`renders Image/demo/component-preview-group.md correctly 1`] = `
 
 exports[`renders Image/demo/custom-preview-actions.md correctly 1`] = `
 <div
-  class="arco-image"
+  class="arco-image arco-image-before-load"
   style="width:200px"
 >
   <img
@@ -119,7 +119,7 @@ exports[`renders Image/demo/error.md correctly 1`] = `
     style="margin-right:20px"
   >
     <div
-      class="arco-image"
+      class="arco-image arco-image-before-load"
       style="width:400px;height:300px"
     >
       <img
@@ -139,7 +139,7 @@ exports[`renders Image/demo/error.md correctly 1`] = `
     class="arco-space-item"
   >
     <div
-      class="arco-image"
+      class="arco-image arco-image-before-load"
       style="width:400px;height:300px"
     >
       <img
@@ -168,7 +168,7 @@ exports[`renders Image/demo/extra-actions.md correctly 1`] = `
       style="margin-right:20px"
     >
       <div
-        class="arco-image"
+        class="arco-image arco-image-before-load"
         style="width:300px"
       >
         <img
@@ -188,7 +188,7 @@ exports[`renders Image/demo/extra-actions.md correctly 1`] = `
       class="arco-space-item"
     >
       <div
-        class="arco-image arco-image-simple"
+        class="arco-image arco-image-simple arco-image-before-load"
         style="width:200px;vertical-align:top"
       >
         <img
@@ -214,7 +214,7 @@ exports[`renders Image/demo/extra-actions.md correctly 1`] = `
       style="margin-right:20px"
     >
       <div
-        class="arco-image"
+        class="arco-image arco-image-before-load"
         style="width:300px"
       >
         <img
@@ -234,7 +234,7 @@ exports[`renders Image/demo/extra-actions.md correctly 1`] = `
       class="arco-space-item"
     >
       <div
-        class="arco-image arco-image-simple"
+        class="arco-image arco-image-simple arco-image-before-load"
         style="width:200px;vertical-align:top"
       >
         <img
@@ -263,7 +263,7 @@ exports[`renders Image/demo/lazyload.md correctly 1`] = `
     style="margin-bottom:50px"
   >
     <div
-      class="arco-image"
+      class="arco-image arco-image-before-load"
       style="width:380px;height:150px"
     >
       <img
@@ -283,7 +283,7 @@ exports[`renders Image/demo/lazyload.md correctly 1`] = `
     style="margin-bottom:50px"
   >
     <div
-      class="arco-image"
+      class="arco-image arco-image-before-load"
       style="width:380px;height:150px"
     >
       <img
@@ -303,7 +303,7 @@ exports[`renders Image/demo/lazyload.md correctly 1`] = `
     style="margin-bottom:50px"
   >
     <div
-      class="arco-image"
+      class="arco-image arco-image-before-load"
       style="width:380px;height:150px"
     >
       <img
@@ -322,7 +322,7 @@ exports[`renders Image/demo/lazyload.md correctly 1`] = `
     class="arco-space-item"
   >
     <div
-      class="arco-image"
+      class="arco-image arco-image-before-load"
       style="width:380px;height:150px"
     >
       <img
@@ -361,7 +361,7 @@ exports[`renders Image/demo/loader.md correctly 1`] = `
       style="margin-right:20px"
     >
       <div
-        class="arco-image"
+        class="arco-image arco-image-before-load"
         style="width:200px;height:200px"
       >
         <img
@@ -381,7 +381,7 @@ exports[`renders Image/demo/loader.md correctly 1`] = `
       class="arco-space-item"
     >
       <div
-        class="arco-image"
+        class="arco-image arco-image-before-load"
         style="width:200px;height:200px;margin-left:67px"
       >
         <img
@@ -406,7 +406,7 @@ exports[`renders Image/demo/preview-get-popup-container.md correctly 1`] = `
   style="width:100%;height:400px;background-color:var(--color-fill-2);position:relative;overflow:hidden;line-height:400px;text-align:center"
 >
   <div
-    class="arco-image"
+    class="arco-image arco-image-before-load"
     style="width:200px"
   >
     <img
@@ -439,7 +439,7 @@ exports[`renders Image/demo/preview-group.md correctly 1`] = `
           style="margin-right:8px"
         >
           <div
-            class="arco-image"
+            class="arco-image arco-image-before-load"
             style="width:200px"
           >
             <img
@@ -459,7 +459,7 @@ exports[`renders Image/demo/preview-group.md correctly 1`] = `
           style="margin-right:8px"
         >
           <div
-            class="arco-image"
+            class="arco-image arco-image-before-load"
             style="width:200px"
           >
             <img
@@ -479,7 +479,7 @@ exports[`renders Image/demo/preview-group.md correctly 1`] = `
           style="margin-right:8px"
         >
           <div
-            class="arco-image"
+            class="arco-image arco-image-before-load"
             style="width:200px"
           >
             <img
@@ -498,7 +498,7 @@ exports[`renders Image/demo/preview-group.md correctly 1`] = `
           class="arco-space-item"
         >
           <div
-            class="arco-image"
+            class="arco-image arco-image-before-load"
             style="width:200px"
           >
             <img
@@ -533,7 +533,7 @@ exports[`renders Image/demo/progressive-loader.md correctly 1`] = `
     </button>
   </div>
   <div
-    class="arco-image"
+    class="arco-image arco-image-before-load"
     style="width:200px"
   >
     <img

--- a/components/Image/__test__/__snapshots__/index.test.tsx.snap
+++ b/components/Image/__test__/__snapshots__/index.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`ConfigProvider componentConfig.Image default 1`] = `
 <div
-  class="arco-image"
+  class="arco-image arco-image-before-load"
 >
   <img
     class="arco-image-img"
@@ -16,7 +16,7 @@ exports[`ConfigProvider componentConfig.Image default 1`] = `
 
 exports[`ConfigProvider componentConfig.Image set className globally 1`] = `
 <div
-  class="arco-image global-default-class"
+  class="arco-image arco-image-before-load global-default-class"
 >
   <img
     class="arco-image-img"
@@ -30,7 +30,7 @@ exports[`ConfigProvider componentConfig.Image set className globally 1`] = `
 
 exports[`ConfigProvider componentConfig.Image set className globally and component set className itself. 1`] = `
 <div
-  class="arco-image component-class"
+  class="arco-image arco-image-before-load component-class"
 >
   <img
     class="arco-image-img"
@@ -44,7 +44,7 @@ exports[`ConfigProvider componentConfig.Image set className globally and compone
 
 exports[`ConfigProvider componentConfig.Image set data-* property 1`] = `
 <div
-  class="arco-image"
+  class="arco-image arco-image-before-load"
 >
   <img
     class="arco-image-img"

--- a/components/Image/image-preview.tsx
+++ b/components/Image/image-preview.tsx
@@ -314,7 +314,7 @@ function Preview(baseProps: ImagePreviewProps, ref) {
 
   // Record position data on move start
   const onMoveStart = (e) => {
-    e.preventDefault && e.preventDefault();
+    e.preventDefault?.();
     setMoving(true);
 
     const ev = e.type === 'touchstart' ? e.touches[0] : e;
@@ -322,7 +322,7 @@ function Preview(baseProps: ImagePreviewProps, ref) {
     refMoveData.current.pageY = ev.pageY;
     refMoveData.current.originX = translate.x;
     refMoveData.current.originY = translate.y;
-    onMouseDown && onMouseDown(e);
+    onMouseDown?.(e);
   };
 
   useEffect(() => {
@@ -483,7 +483,10 @@ function Preview(baseProps: ImagePreviewProps, ref) {
                     {...restImgAttributes}
                     onLoad={onImgLoaded}
                     onError={onImgLoadError}
-                    onMouseDown={onMoveStart}
+                    onMouseDown={(event) => {
+                      // only trigger onMoveStart when press mouse left button
+                      event.button === 0 && onMoveStart(event);
+                    }}
                     key={previewImgSrc}
                     src={previewImgSrc}
                   />

--- a/components/Image/image.tsx
+++ b/components/Image/image.tsx
@@ -83,7 +83,8 @@ function Image(baseProps: ImagePropsType, ref: LegacyRef<HTMLDivElement>) {
 
   const previewSrc = previewProps.src || src;
   const [showFooter] = useShowFooter({ title, description, actions });
-  const { isLoading, isError, isLoaded, setStatus, isLazyLoad } = useImageStatus('beforeLoad');
+  const { isLoading, isError, isLoaded, isLazyLoad, isBeforeLoad, setStatus } =
+    useImageStatus('beforeLoad');
   const [previewVisible, setPreviewVisible] = useMergeValue(false, {
     defaultValue: previewProps.defaultVisible,
     value: previewProps.visible,
@@ -101,6 +102,7 @@ function Image(baseProps: ImagePropsType, ref: LegacyRef<HTMLDivElement>) {
     {
       [`${prefixCls}-rtl`]: rtl,
       [`${prefixCls}-simple`]: simple,
+      [`${prefixCls}-before-load`]: isBeforeLoad,
       [`${prefixCls}-loading`]: isLoading,
       [`${prefixCls}-loading-error`]: isError,
       [`${prefixCls}-with-footer-inner`]: isLoaded && showFooter && footerPosition === 'inner',

--- a/components/Image/style/image.less
+++ b/components/Image/style/image.less
@@ -199,6 +199,7 @@
     }
   }
 
+  &-before-load,
   &-loading,
   &-loading-error {
     .@{image-prefix-cls}-img {


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [ ] Bug fix
- [x] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|   Image   |   避免鼠标右键按下时错误触发的图片拖拽。    |  Avoid image dragging that is triggered incorrectly when the right mouse button is pressed.   |    Close  #2231     |
| Image | 优化 Image 在 SSR 且开启 `lazyload` 时首次渲染出现裂图的问题。  | Optimize the problem of cracked image in the first rendering of Image in SSR and `lazyload` is enabled. |  Close #2215 |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->
## Checklist:

- [ ] Test suite passes (`npm run test`)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
