### PR TITLE
fix(Input): 修复Search组件受控状态异常问题

### DIFF
--- a/components/Input/search.tsx
+++ b/components/Input/search.tsx
@@ -8,18 +8,23 @@ import omit from '../_util/omit';
 import { ConfigContext } from '../ConfigProvider';
 import useMergeValue from '../_util/hooks/useMergeValue';
 import IconLoading from '../../icon/react-icon/IconLoading';
+import { isObject } from '../_util/is';
 
 const Search = React.forwardRef<RefInputType, InputSearchProps>((props: InputSearchProps, ref) => {
   const { getPrefixCls } = useContext(ConfigContext);
 
-  const [value, setValue] = useMergeValue('', {
-    defaultValue:
-      'defaultValue' in props ? formatValue(props.defaultValue, props.maxLength) : undefined,
-    value: 'value' in props ? formatValue(props.value, props.maxLength) : undefined,
-  });
-
   const { className, style, placeholder, disabled, searchButton, loading, defaultValue, ...rest } =
     props;
+  
+  const trueMaxLength = isObject(props.maxLength) ? props.maxLength.length : props.maxLength;
+  const mergedMaxLength = isObject(props.maxLength) && props.maxLength.errorOnly ? undefined : trueMaxLength;
+
+  const [value, setValue] = useMergeValue('', {
+    defaultValue:
+      'defaultValue' in props ? formatValue(props.defaultValue, mergedMaxLength) : undefined,
+    value: 'value' in props ? formatValue(props.value, mergedMaxLength) : undefined,
+  });
+
   const prefixCls = getPrefixCls('input-search');
   const classNames = cs(
     prefixCls,


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context
主要问题：Input.Search组件在受控状态下，并且maxLength设置为对象，onSearch函数不能接收到任何值，也就是搜索触发函数无法正确接收到Input.Search框里的值。

问题复现步骤：
- 1、使用Input.Search组件
- 2、设置props为受控组件，属性如下(主要是maxLength设为对象，value保证为受控状态，onSearch监测异常搜索)
```
      <Input.Search
        maxLength={{ errorOnly: true }}
        value="受控状态OnSearch没有值"
        onSearch={(v) => console.log(v)}
        placeholder="Enter keyword to search"
        style={{ width: 350 }}
      />
```
然后点击 放大镜图标，触发onSearch函数，此时控制台打印空字符串。

demo地址：https://codesandbox.io/s/friendly-satoshi-fkkg2m?file=/demo.js:0-450

## Solution

代码没有正确处理 maxLength 参数为对象的情况，我主要加入了判断如果maxLength是对象的话，如何正确处理maxLength的逻辑。这个逻辑本身在Input组件上就使用了，我只是copy了这两行代码。

## How is the change tested?


## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|    Input       | 修复 `Input.Search` 组件在 `value` 受控且传入了对象类型的 `maxLength`并直接触发 `onSearch`时， 回调参数错误的 bug                |          Fixed the bug of incorrect callback parameters in the `Input.Search` component when `value` is controlled and `maxLength` of the object type is passed in and `onSearch` is triggered directly.     |                |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->
## Checklist:

- [x] Test suite passes (`npm run test`)
- [x] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [x] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
