### PR TITLE
feat(Select): allowCreate support formatter fn to customize user-created option label

### DIFF
--- a/components/Cascader/interface.ts
+++ b/components/Cascader/interface.ts
@@ -8,8 +8,7 @@ import { VirtualListProps } from '../_class/VirtualList';
 /**
  * @title Cascader
  */
-export interface CascaderProps<T = any>
-  extends Omit<SelectViewCommonProps, 'allowCreate' | 'showSearch'> {
+export interface CascaderProps<T = any> extends Omit<SelectViewCommonProps, 'showSearch'> {
   /**
    * @zh 选择框的默认值
    * @en Initial value

--- a/components/Select/README.en-US.md
+++ b/components/Select/README.en-US.md
@@ -15,7 +15,6 @@ When users need to select one or more from a group of similar data, they can use
 |Property|Description|Type|DefaultValue|Version|
 |---|---|---|---|---|
 |allowClear|Whether allow to clear selected options|boolean |`-`|-|
-|allowCreate|Whether to allow new options to be created by input.|boolean |`-`|2.13.0|
 |animation|Whether to add animation for internal label changes|boolean |`true`|2.15.0|
 |bordered|Whether to render border|boolean |`true`|-|
 |defaultActiveFirstOption|Whether to highlight the first option by default|boolean |`true`|-|
@@ -29,6 +28,7 @@ When users need to select one or more from a group of similar data, they can use
 |unmountOnExit|Whether to destroy the DOM when hiding|boolean |`true`|-|
 |inputValue|To set input value|string |`-`|-|
 |placeholder|Placeholder of element|string |`-`|-|
+|allowCreate|Whether to allow new options to be created by input.|\| boolean\| {formatter: (inputValue: string, creating: boolean) => [SelectProps](select#select)['options'][number];} |`-`|2.13.0, `{ formatter }` in 2.54.0|
 |mode|Set mode of Select(**`tags` recommends using `mode: multiple; allowCreate: true` instead, this mode will be removed in the next major version**)|'multiple' \| 'tags' |`-`|-|
 |size|Height of element, `24px` `28px` `32px` `36px`|'mini' \| 'small' \| 'default' \| 'large' |`-`|-|
 |status|Status|'error' \| 'warning' |`-`|2.45.0|

--- a/components/Select/README.zh-CN.md
+++ b/components/Select/README.zh-CN.md
@@ -15,7 +15,6 @@
 |参数名|描述|类型|默认值|版本|
 |---|---|---|---|---|
 |allowClear|允许清除值。|boolean |`-`|-|
-|allowCreate|是否允许通过输入创建新的选项。|boolean |`-`|2.13.0|
 |animation|是否为内部标签变化添加动画。|boolean |`true`|2.15.0|
 |bordered|是否需要边框|boolean |`true`|-|
 |defaultActiveFirstOption|是否默认高亮第一个选项|boolean |`true`|-|
@@ -29,6 +28,7 @@
 |unmountOnExit|是否在隐藏的时候销毁 DOM 结构|boolean |`true`|-|
 |inputValue|输入框的值（受控模式）|string |`-`|-|
 |placeholder|选择框默认文字。|string |`-`|-|
+|allowCreate|是否允许通过输入创建新的选项。|\| boolean\| {formatter: (inputValue: string, creating: boolean) => [SelectProps](select#select)['options'][number];} |`-`|2.13.0, `{ formatter }` in 2.54.0|
 |mode|是否开启多选模式或标签模式 (**`tags` 推荐使用 `mode: multiple; allowCreate: true` 替代，下一大版本将移除此模式**)|'multiple' \| 'tags' |`-`|-|
 |size|分别不同尺寸的选择器。对应 `24px`, `28px`, `32px`, `36px`|'mini' \| 'small' \| 'default' \| 'large' |`-`|-|
 |status|状态|'error' \| 'warning' |`-`|2.45.0|

--- a/components/Select/__demo__/allow-create.md
+++ b/components/Select/__demo__/allow-create.md
@@ -7,11 +7,11 @@ title:
 
 ## zh-CN
 
-指定 `allowCreate` 为 `true`，即可创建选项中不存在的条目。
+指定 `allowCreate` 为 `true`，即可创建选项中不存在的条目。通过 `allowCreate.formatter` 格式化用户创建的选项。
 
 ## en-US
 
-Specify `allowCreate` as `true` to create entries that do not exist in the options.
+Specify `allowCreate` as `true` to create entries that do not exist in the options. Format user creations via `allowCreate.formatter`.
 
 ```js
 import { Select, Space } from '@arco-design/web-react';
@@ -34,11 +34,18 @@ function App() {
       </Select>
 
       <Select
-        allowCreate
+        allowClear
         mode="multiple"
         placeholder="Create an item"
         defaultValue={['a10', 'b11']}
-        allowClear
+        allowCreate={{
+          formatter: (inputValue, creating) => {
+            return {
+              value: inputValue,
+              label: `${creating ? 'Enter to create: ' : 'Created: '}${inputValue}`
+            };
+          },
+        }}
         style={{ width: 345 }}
       >
         {options.map((option) => (

--- a/components/Select/__test__/index.test.tsx
+++ b/components/Select/__test__/index.test.tsx
@@ -496,4 +496,25 @@ describe('Select', () => {
     ).toBe(-1);
     expect(wrapper2.querySelector('.arco-select-option-hover')).toHaveTextContent('hello');
   });
+
+  it('allowCreate with custom formatter', async () => {
+    const wrapper = render(
+      <Select
+        popupVisible
+        allowCreate={{
+          formatter: (inputValue, creating) => {
+            return {
+              label: `${creating ? 'Enter to create' : 'Created'} ${inputValue}`,
+              value: inputValue,
+            };
+          },
+        }}
+        mode="multiple"
+        inputValue="hello"
+      />
+    );
+
+    await sleep(100);
+    expect(wrapper.querySelector('.arco-select-option')).toHaveTextContent('Enter to create hello');
+  });
 });

--- a/components/Select/interface.tsx
+++ b/components/Select/interface.tsx
@@ -86,6 +86,16 @@ export interface SelectProps extends SelectViewCommonProps {
    */
   defaultActiveFirstOption?: boolean;
   /**
+   * @zh 是否允许通过输入创建新的选项。
+   * @en Whether to allow new options to be created by input.
+   * @version 2.13.0, `{ formatter }` in 2.54.0
+   */
+  allowCreate?:
+    | boolean
+    | {
+        formatter: (inputValue: string, creating: boolean) => SelectProps['options'][number];
+      };
+  /**
    * @zh 是否在隐藏的时候销毁 DOM 结构
    * @en Whether to destroy the DOM when hiding
    * @defaultValue true

--- a/components/Select/utils.tsx
+++ b/components/Select/utils.tsx
@@ -61,8 +61,8 @@ function flatChildren(
     prefixCls,
   }: {
     inputValue: string;
-    userCreatedOptions?: string[];
-    userCreatingOption?: string;
+    userCreatedOptions?: SelectProps['options'];
+    userCreatingOption?: SelectProps['options'][number];
     prefixCls: string;
   },
   // 递归过程中需要持续传递的数据
@@ -174,13 +174,13 @@ function flatChildren(
   const extendChildren = (arr, origin: OptionInfo['_origin']) => {
     if (origin && isArray(arr) && arr.length) {
       (arr as OptionsType).forEach((option) => {
-        option =
-          isString(option) || isNumber(option)
-            ? {
-                label: option,
-                value: option,
-              }
-            : option;
+        if (isString(option) || isNumber(option)) {
+          option = {
+            label: option,
+            value: option,
+          };
+        }
+
         const child = (
           <Option
             _key={getChildKey(option)}

--- a/components/TreeSelect/interface.ts
+++ b/components/TreeSelect/interface.ts
@@ -9,7 +9,7 @@ export type LabelValue = { label: ReactNode; value: string; disabled?: boolean }
 /**
  * @title TreeSelect
  */
-export interface TreeSelectProps extends Omit<SelectViewCommonProps, 'allowCreate'> {
+export interface TreeSelectProps extends SelectViewCommonProps {
   /**
    * @zh 是否多选
    * @en Whether to select multiple

--- a/components/_class/select-view.tsx
+++ b/components/_class/select-view.tsx
@@ -86,12 +86,6 @@ export interface SelectViewCommonProps
    */
   allowClear?: boolean;
   /**
-   * @zh 是否允许通过输入创建新的选项。
-   * @en Whether to allow new options to be created by input.
-   * @version 2.13.0
-   */
-  allowCreate?: boolean;
-  /**
    * @zh 最多显示多少个 `tag`，仅在多选或标签模式有效。
    * @en The maximum number of `tags` is displayed, only valid in `multiple` and `label` mode.
    * @version Object type in 2.37.0
@@ -159,6 +153,7 @@ export interface SelectViewProps extends SelectViewCommonProps {
   value?: any;
   popupVisible?: boolean;
   // other ⬇️
+  allowCreate?: boolean;
   isEmptyValue: boolean;
   isMultiple?: boolean;
   prefixCls: string;


### PR DESCRIPTION

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [x] New feature
- [ ] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context

<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

## Solution

<!-- Describe how the problem is fixed in detail -->

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|   Select   |   `Select` 组件 `allowCreate` 属性允许传入 `formatter` 以格式化用户创建的选项。   |   The `allowCreate` property of `Select` allows passing in a `formatter` to format user-created options.   |     Close #2238    |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->
## Checklist:

- [ ] Test suite passes (`npm run test`)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
