### PR TITLE
feat: input and select all support autoWidth

### DIFF
--- a/components/Cascader/README.en-US.md
+++ b/components/Cascader/README.en-US.md
@@ -29,6 +29,7 @@ Display options in a multi-level cascading dropdown component.
 |unmountOnExit|Whether destroy popup when hidden.|boolean |`-`|-|
 |inputValue|Input Value|string |`-`|2.34.0|
 |placeholder|Placeholder of element|string |`-`|-|
+|autoWidth|auto width. minWidth defaults to 0, maxWidth defaults to 100%|\| boolean\| { minWidth?: CSSProperties['minWidth']; maxWidth?: CSSProperties['maxWidth'] } |`-`|2.54.0|
 |checkedStrategy|Customize the return value<br/> parent:Only return the parent node when all child nodes are selected <br/> child: Return child nodes|'parent' \| 'child' |`child`|2.31.0|
 |expandTrigger|Set the way to display the next level menu. One of hover and click|'click' \| 'hover' |`click`|-|
 |mode|Set mode|'multiple' |`-`|-|

--- a/components/Cascader/README.zh-CN.md
+++ b/components/Cascader/README.zh-CN.md
@@ -29,6 +29,7 @@
 |unmountOnExit|是否在隐藏之后销毁DOM结构，默认为 `true`。如果是动态加载时，默认为`false`。|boolean |`-`|-|
 |inputValue|输入框的值|string |`-`|2.34.0|
 |placeholder|选择框默认文字。|string |`-`|-|
+|autoWidth|设置宽度自适应。minWidth 默认为 0，maxWidth 默认为 100%|\| boolean\| { minWidth?: CSSProperties['minWidth']; maxWidth?: CSSProperties['maxWidth'] } |`-`|2.54.0|
 |checkedStrategy|定制回填方式 <br/> parent: 子节点都被选中时候返回父节点 <br/> child: 返回子节点|'parent' \| 'child' |`child`|2.31.0|
 |expandTrigger|展开下一级方式|'click' \| 'hover' |`click`|-|
 |mode|是否开启多选|'multiple' |`-`|-|

--- a/components/Cascader/__test__/__snapshots__/demo.test.ts.snap
+++ b/components/Cascader/__test__/__snapshots__/demo.test.ts.snap
@@ -113,8 +113,9 @@ exports[`renders Cascader/demo/addon.md correctly 1`] = `
               >
                 <input
                   autocomplete="off"
-                  class="arco-input-tag-input arco-input-tag-input-size-default"
+                  class="arco-input-tag-input arco-input-tag-input-size-default arco-input-tag-input-autowidth"
                   placeholder="Hover to expand"
+                  style="min-width:100%"
                   value=""
                 />
                 <span
@@ -521,8 +522,9 @@ exports[`renders Cascader/demo/change_on_select.md correctly 1`] = `
             >
               <input
                 autocomplete="off"
-                class="arco-input-tag-input arco-input-tag-input-size-default"
+                class="arco-input-tag-input arco-input-tag-input-size-default arco-input-tag-input-autowidth"
                 placeholder="Please select ..."
+                style="min-width:100%"
                 value=""
               />
               <span
@@ -731,8 +733,9 @@ exports[`renders Cascader/demo/control.md correctly 1`] = `
             >
               <input
                 autocomplete="off"
-                class="arco-input-tag-input arco-input-tag-input-size-default"
+                class="arco-input-tag-input arco-input-tag-input-size-default arco-input-tag-input-autowidth"
                 placeholder="Please select ..."
+                style="min-width:100%"
                 value=""
               />
               <span
@@ -915,7 +918,7 @@ exports[`renders Cascader/demo/disabled.md correctly 1`] = `
               </div>
               <input
                 autocomplete="off"
-                class="arco-input-tag-input arco-input-tag-input-size-default"
+                class="arco-input-tag-input arco-input-tag-input-size-default arco-input-tag-input-autowidth"
                 placeholder=""
                 value=""
               />
@@ -1039,7 +1042,7 @@ exports[`renders Cascader/demo/draggable.md correctly 1`] = `
             >
               <input
                 autocomplete="off"
-                class="arco-input-tag-input arco-input-tag-input-size-default"
+                class="arco-input-tag-input arco-input-tag-input-size-default arco-input-tag-input-autowidth"
                 placeholder=""
                 value=""
               />
@@ -1281,7 +1284,7 @@ exports[`renders Cascader/demo/filedNames.md correctly 1`] = `
             </div>
             <input
               autocomplete="off"
-              class="arco-input-tag-input arco-input-tag-input-size-default"
+              class="arco-input-tag-input arco-input-tag-input-size-default arco-input-tag-input-autowidth"
               placeholder=""
               value=""
             />
@@ -1472,7 +1475,7 @@ exports[`renders Cascader/demo/filter_option.md correctly 1`] = `
               </div>
               <input
                 autocomplete="off"
-                class="arco-input-tag-input arco-input-tag-input-size-default"
+                class="arco-input-tag-input arco-input-tag-input-size-default arco-input-tag-input-autowidth"
                 placeholder=""
                 value=""
               />
@@ -1664,7 +1667,7 @@ exports[`renders Cascader/demo/footer.md correctly 1`] = `
               </div>
               <input
                 autocomplete="off"
-                class="arco-input-tag-input arco-input-tag-input-size-default"
+                class="arco-input-tag-input arco-input-tag-input-size-default arco-input-tag-input-autowidth"
                 placeholder=""
                 value=""
               />
@@ -1889,8 +1892,9 @@ exports[`renders Cascader/demo/loadmore.md correctly 1`] = `
             >
               <input
                 autocomplete="off"
-                class="arco-input-tag-input arco-input-tag-input-size-default"
+                class="arco-input-tag-input arco-input-tag-input-size-default arco-input-tag-input-autowidth"
                 placeholder="Please select ..."
+                style="min-width:100%"
                 value=""
               />
               <span
@@ -1991,7 +1995,7 @@ exports[`renders Cascader/demo/multiple.md correctly 1`] = `
               </div>
               <input
                 autocomplete="off"
-                class="arco-input-tag-input arco-input-tag-input-size-default"
+                class="arco-input-tag-input arco-input-tag-input-size-default arco-input-tag-input-autowidth"
                 placeholder=""
                 value=""
               />
@@ -2053,8 +2057,9 @@ exports[`renders Cascader/demo/multiple.md correctly 1`] = `
             >
               <input
                 autocomplete="off"
-                class="arco-input-tag-input arco-input-tag-input-size-default"
+                class="arco-input-tag-input arco-input-tag-input-size-default arco-input-tag-input-autowidth"
                 placeholder="Please select ..."
+                style="min-width:100%"
                 value=""
               />
               <span
@@ -2227,8 +2232,9 @@ exports[`renders Cascader/demo/onSearch.md correctly 1`] = `
               >
                 <input
                   autocomplete="off"
-                  class="arco-input-tag-input arco-input-tag-input-size-default"
+                  class="arco-input-tag-input arco-input-tag-input-size-default arco-input-tag-input-autowidth"
                   placeholder="Please enter ..."
+                  style="min-width:100%"
                   value=""
                 />
                 <span
@@ -2388,7 +2394,7 @@ exports[`renders Cascader/demo/render_option.md correctly 1`] = `
               </div>
               <input
                 autocomplete="off"
-                class="arco-input-tag-input arco-input-tag-input-size-default"
+                class="arco-input-tag-input arco-input-tag-input-size-default arco-input-tag-input-autowidth"
                 placeholder=""
                 value=""
               />
@@ -2563,7 +2569,7 @@ exports[`renders Cascader/demo/search.md correctly 1`] = `
               </div>
               <input
                 autocomplete="off"
-                class="arco-input-tag-input arco-input-tag-input-size-default"
+                class="arco-input-tag-input arco-input-tag-input-size-default arco-input-tag-input-autowidth"
                 placeholder=""
                 value=""
               />
@@ -2871,8 +2877,9 @@ exports[`renders Cascader/demo/size.md correctly 1`] = `
             >
               <input
                 autocomplete="off"
-                class="arco-input-tag-input arco-input-tag-input-size-default"
+                class="arco-input-tag-input arco-input-tag-input-size-default arco-input-tag-input-autowidth"
                 placeholder="Please select ..."
+                style="min-width:100%"
                 value=""
               />
               <span

--- a/components/DatePicker/__test__/__snapshots__/demo.test.ts.snap
+++ b/components/DatePicker/__test__/__snapshots__/demo.test.ts.snap
@@ -4885,7 +4885,7 @@ exports[`renders DatePicker/demo/utcOffset.md correctly 1`] = `
         >
           <div
             class="arco-select-view"
-            title="UTC "
+            title="UTC "
           >
             <span
               class="arco-select-view-selector"
@@ -4901,7 +4901,7 @@ exports[`renders DatePicker/demo/utcOffset.md correctly 1`] = `
               <span
                 class="arco-select-view-value"
               >
-                UTC 
+                UTC 
               </span>
             </span>
             <div

--- a/components/Form/__test__/__snapshots__/demo.test.ts.snap
+++ b/components/Form/__test__/__snapshots__/demo.test.ts.snap
@@ -869,7 +869,7 @@ exports[`renders Form/demo/control.md correctly 1`] = `
                         </div>
                         <input
                           autocomplete="off"
-                          class="arco-input-tag-input arco-input-tag-input-size-default"
+                          class="arco-input-tag-input arco-input-tag-input-size-default arco-input-tag-input-autowidth"
                           placeholder=""
                           value=""
                         />
@@ -2761,7 +2761,7 @@ exports[`renders Form/demo/disabled.md correctly 1`] = `
                         </div>
                         <input
                           autocomplete="off"
-                          class="arco-input-tag-input arco-input-tag-input-size-default arco-input-tag-input-disabled"
+                          class="arco-input-tag-input arco-input-tag-input-size-default arco-input-tag-input-disabled arco-input-tag-input-autowidth"
                           disabled=""
                           placeholder=""
                           value=""
@@ -7675,8 +7675,9 @@ exports[`renders Form/demo/size.md correctly 1`] = `
                       >
                         <input
                           autocomplete="off"
-                          class="arco-input-tag-input arco-input-tag-input-size-default"
+                          class="arco-input-tag-input arco-input-tag-input-size-default arco-input-tag-input-autowidth"
                           placeholder="please select"
+                          style="min-width:100%"
                           value=""
                         />
                         <span
@@ -9489,8 +9490,9 @@ exports[`renders Form/demo/validate-status.md correctly 1`] = `
                       >
                         <input
                           autocomplete="off"
-                          class="arco-input-tag-input arco-input-tag-input-size-default"
+                          class="arco-input-tag-input arco-input-tag-input-size-default arco-input-tag-input-autowidth"
                           placeholder="Select..."
+                          style="min-width:100%"
                           value=""
                         />
                         <span

--- a/components/Input/README.en-US.md
+++ b/components/Input/README.en-US.md
@@ -24,6 +24,7 @@ The basic form components have been expanded on the basis of native controls and
 |defaultValue|The initial input content|string |`-`|-|
 |placeholder|Input box prompt text|string |`-`|-|
 |value|The input content value|string |`-`|-|
+|autoWidth|auto width. minWidth defaults to 0, maxWidth defaults to 100%|\| boolean\| { minWidth?: CSSProperties['minWidth']; maxWidth?: CSSProperties['maxWidth'] } |`-`|2.54.0|
 |normalizeTrigger|Specify the timing of normalize execution|('onBlur' \| 'onPressEnter')[] |`['onBlur']`|2.50.0|
 |size|The size of the input box|'mini' \| 'small' \| 'default' \| 'large' |`default`|-|
 |status|Status|'error' \| 'warning' |`-`|2.45.0|

--- a/components/Input/README.zh-CN.md
+++ b/components/Input/README.zh-CN.md
@@ -24,6 +24,7 @@
 |defaultValue|默认值|string |`-`|-|
 |placeholder|输入框提示文字|string |`-`|-|
 |value|输入框的值，受控模式|string |`-`|-|
+|autoWidth|设置宽度自适应。minWidth 默认为 0，maxWidth 默认为 100%|\| boolean\| { minWidth?: CSSProperties['minWidth']; maxWidth?: CSSProperties['maxWidth'] } |`-`|2.54.0|
 |normalizeTrigger|指定 normalize 执行的时机|('onBlur' \| 'onPressEnter')[] |`['onBlur']`|2.50.0|
 |size|输入框的尺寸|'mini' \| 'small' \| 'default' \| 'large' |`default`|-|
 |status|状态|'error' \| 'warning' |`-`|2.45.0|

--- a/components/Input/__demo__/autoWidth.md
+++ b/components/Input/__demo__/autoWidth.md
@@ -1,0 +1,52 @@
+---
+order: 12
+title:
+  zh-CN: 宽度自适应
+  en-US: Auto Width
+---
+
+## zh-CN
+
+通过 `autoWidth` 属性可以设置 `Input` 的宽度跟随文字自适应
+
+## en-US
+
+Through the `autoWidth` attribute, you can set the width of `Input` to adapt to the text.
+
+```js
+import { Input, Divider, Space,Typography, Popover } from '@arco-design/web-react';
+
+const App = () => {
+  return (
+    <div>
+      <Divider>
+        <Typography.Text code>{JSON.stringify({minWidth: 0, maxWidth: 500})}</Typography.Text>
+      </Divider>
+
+      <Input
+        placeholder="Please Enter"
+        autoWidth={{ maxWidth: 500}}
+      />
+
+      <Divider>
+        <Typography.Text code>{JSON.stringify({minWidth: 300, maxWidth: 500})}</Typography.Text>
+      </Divider>
+
+      <Input autoWidth={{minWidth: 300, maxWidth: 500}}/>
+      <br/><br/>
+      <Input
+        prefix="Prefix"
+        autoWidth={{minWidth: 300, maxWidth: 500}}
+      />
+      <br/><br/>
+      <Input
+        addBefore="Before"
+        prefix="Prefix"
+        autoWidth={{minWidth: 300, maxWidth: 500}}
+      />
+      </div>
+  );
+};
+
+export default App;
+```

--- a/components/Input/__test__/__snapshots__/demo.test.ts.snap
+++ b/components/Input/__test__/__snapshots__/demo.test.ts.snap
@@ -199,6 +199,123 @@ exports[`renders Input/demo/addon.md correctly 1`] = `
 </div>
 `;
 
+exports[`renders Input/demo/autoWidth.md correctly 1`] = `
+<div>
+  <div
+    class="arco-divider arco-divider-horizontal arco-divider-with-text arco-divider-with-text-center"
+    role="separator"
+  >
+    <span
+      class="arco-divider-text arco-divider-text-center"
+    >
+      <span
+        class="arco-typography"
+      >
+        <code>
+          {"minWidth":0,"maxWidth":500}
+        </code>
+      </span>
+    </span>
+  </div>
+  <input
+    class="arco-input arco-input-size-default arco-input-autowidth"
+    placeholder="Please Enter"
+    style="min-width:0;max-width:500px;width:auto"
+    value=""
+  />
+  <span
+    class="arco-input-mirror"
+    style="min-width:0;max-width:500px;width:auto"
+  >
+    Please Enter
+  </span>
+  <div
+    class="arco-divider arco-divider-horizontal arco-divider-with-text arco-divider-with-text-center"
+    role="separator"
+  >
+    <span
+      class="arco-divider-text arco-divider-text-center"
+    >
+      <span
+        class="arco-typography"
+      >
+        <code>
+          {"minWidth":300,"maxWidth":500}
+        </code>
+      </span>
+    </span>
+  </div>
+  <input
+    class="arco-input arco-input-size-default arco-input-autowidth"
+    style="min-width:300px;max-width:500px;width:auto"
+    value=""
+  />
+  <span
+    class="arco-input-mirror"
+    style="min-width:300px;max-width:500px;width:auto"
+  />
+  <br />
+  <br />
+  <div
+    class="arco-input-group-wrapper arco-input-group-wrapper-default arco-input-group-wrapper-autowidth"
+    style="min-width:300px;max-width:500px;width:auto"
+  >
+    <span
+      class="arco-input-group"
+    >
+      <span
+        class="arco-input-inner-wrapper arco-input-inner-wrapper-has-prefix arco-input-inner-wrapper-default"
+      >
+        <span
+          class="arco-input-group-prefix"
+        >
+          Prefix
+        </span>
+        <input
+          class="arco-input arco-input-size-default arco-input-autowidth"
+          value=""
+        />
+        <span
+          class="arco-input-mirror"
+        />
+      </span>
+    </span>
+  </div>
+  <br />
+  <br />
+  <div
+    class="arco-input-group-wrapper arco-input-group-wrapper-default arco-input-group-wrapper-autowidth"
+    style="min-width:300px;max-width:500px;width:auto"
+  >
+    <span
+      class="arco-input-group"
+    >
+      <span
+        class="arco-input-group-addbefore"
+      >
+        Before
+      </span>
+      <span
+        class="arco-input-inner-wrapper arco-input-inner-wrapper-has-prefix arco-input-inner-wrapper-default"
+      >
+        <span
+          class="arco-input-group-prefix"
+        >
+          Prefix
+        </span>
+        <input
+          class="arco-input arco-input-size-default arco-input-autowidth"
+          value=""
+        />
+        <span
+          class="arco-input-mirror"
+        />
+      </span>
+    </span>
+  </div>
+</div>
+`;
+
 exports[`renders Input/demo/basic.md correctly 1`] = `
 <span
   class="arco-input-inner-wrapper arco-input-inner-wrapper-default arco-input-clear-wrapper"

--- a/components/Input/input.tsx
+++ b/components/Input/input.tsx
@@ -50,7 +50,7 @@ function Input(baseProps: InputProps, ref) {
   const props = useMergeProps<InputProps>(baseProps, {}, componentConfig?.Input);
   const {
     className,
-    style,
+    style: propsStyle,
     addBefore,
     addAfter,
     suffix,
@@ -62,7 +62,19 @@ function Input(baseProps: InputProps, ref) {
     maxLength,
     showWordLimit,
     allowClear,
+    autoWidth: propsAutoWidth,
   } = props;
+
+  const autoWidth = propsAutoWidth
+    ? { minWidth: 0, maxWidth: '100%', ...(isObject(propsAutoWidth) ? propsAutoWidth : {}) }
+    : null;
+
+  const style = {
+    minWidth: autoWidth?.minWidth,
+    maxWidth: autoWidth?.maxWidth,
+    width: autoWidth && 'auto',
+    ...propsStyle,
+  };
 
   const trueMaxLength = isObject(maxLength) ? maxLength.length : maxLength;
   const mergedMaxLength = isObject(maxLength) && maxLength.errorOnly ? undefined : trueMaxLength;
@@ -119,6 +131,7 @@ function Input(baseProps: InputProps, ref) {
       [`${prefixCls}-has-suffix`]: suffixElement,
       [`${prefixCls}-group-wrapper-disabled`]: disabled,
       [`${prefixCls}-group-wrapper-rtl`]: rtl,
+      [`${prefixCls}-group-wrapper-autowidth`]: autoWidth,
     },
     className
   );
@@ -128,6 +141,8 @@ function Input(baseProps: InputProps, ref) {
     <InputComponent
       ref={inputRef}
       {...props}
+      autoFitWidth={!!autoWidth}
+      style={style}
       status={status}
       onFocus={(e) => {
         setFocus(true);

--- a/components/Input/interface.tsx
+++ b/components/Input/interface.tsx
@@ -52,6 +52,14 @@ export interface InputProps
    */
   status?: 'error' | 'warning';
   /**
+   * @zh 设置宽度自适应。minWidth 默认为 0，maxWidth 默认为 100%
+   * @en auto width. minWidth defaults to 0, maxWidth defaults to 100%
+   * @version 2.54.0
+   */
+  autoWidth?:
+    | boolean
+    | { minWidth?: CSSProperties['minWidth']; maxWidth?: CSSProperties['maxWidth'] };
+  /**
   /**
    * @zh 输入时的回调
    * @en Callback when user input
@@ -306,7 +314,14 @@ export interface InputComponentProps extends InputProps {
   prefixCls?: string;
   hasParent?: boolean;
   // input 随输入文本的宽度变化
-  autoFitWidth?: boolean | { delay: number | ((width: number, prevWidth: number) => number) };
+  autoFitWidth?:
+    | boolean
+    | {
+        minWidth?: CSSProperties['minWidth'];
+        maxWidth?: CSSProperties['maxWidth'];
+        pure?: boolean; // 是否只测量内容宽度，排除 padding ，border 等因素
+        delay: number | ((width: number, prevWidth: number) => number);
+      };
 }
 
 export type RefInputType = {

--- a/components/Input/style/index.less
+++ b/components/Input/style/index.less
@@ -76,6 +76,11 @@
   line-height: @line-height-base;
   .input-style();
 
+  &-autowidth {
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
   // 禁用样式
   &-disabled {
     .disabled-style();
@@ -191,6 +196,33 @@
 
   &:not(&-focus) .@{input-prefix-cls}-clear-icon:hover::before {
     background-color: @input-color-icon-clear-bg_hover;
+  }
+}
+
+.@{input-prefix-cls}-group-wrapper-autowidth {
+  .@{input-prefix-cls}-group {
+    display: flex;
+    align-items: stretch;
+
+    &-addbefore,
+    &-after {
+      display: inline-flex;
+      height: unset;
+      flex-shrink: 0;
+      flex-grow: 0;
+      width: auto;
+      align-items: center;
+    }
+  }
+
+  .@{input-prefix-cls}-inner-wrapper {
+    overflow: hidden;
+  }
+
+  .@{input-prefix-cls} {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    flex: 1;
   }
 }
 

--- a/components/InputTag/__test__/__snapshots__/demo.test.ts.snap
+++ b/components/InputTag/__test__/__snapshots__/demo.test.ts.snap
@@ -22,8 +22,9 @@ exports[`renders InputTag/demo/basic.md correctly 1`] = `
           >
             <input
               autocomplete="off"
-              class="arco-input-tag-input arco-input-tag-input-size-default"
+              class="arco-input-tag-input arco-input-tag-input-size-default arco-input-tag-input-autowidth"
               placeholder="Input and press Enter"
+              style="min-width:100%"
               value=""
             />
             <span
@@ -50,9 +51,10 @@ exports[`renders InputTag/demo/basic.md correctly 1`] = `
           >
             <input
               autocomplete="off"
-              class="arco-input-tag-input arco-input-tag-input-size-default arco-input-tag-input-disabled"
+              class="arco-input-tag-input arco-input-tag-input-size-default arco-input-tag-input-disabled arco-input-tag-input-autowidth"
               disabled=""
               placeholder="Disabled"
+              style="min-width:100%"
               value=""
             />
             <span
@@ -85,9 +87,10 @@ exports[`renders InputTag/demo/basic.md correctly 1`] = `
           >
             <input
               autocomplete="off"
-              class="arco-input-tag-input arco-input-tag-input-size-default"
+              class="arco-input-tag-input arco-input-tag-input-size-default arco-input-tag-input-autowidth"
               placeholder="Readonly"
               readonly=""
+              style="min-width:100%"
               value=""
             />
             <span
@@ -114,8 +117,9 @@ exports[`renders InputTag/demo/basic.md correctly 1`] = `
           >
             <input
               autocomplete="off"
-              class="arco-input-tag-input arco-input-tag-input-size-default"
+              class="arco-input-tag-input arco-input-tag-input-size-default arco-input-tag-input-autowidth"
               placeholder="Error"
+              style="min-width:100%"
               value=""
             />
             <span
@@ -140,8 +144,9 @@ exports[`renders InputTag/demo/basic.md correctly 1`] = `
       >
         <input
           autocomplete="off"
-          class="arco-input-tag-input arco-input-tag-input-size-default"
+          class="arco-input-tag-input arco-input-tag-input-size-default arco-input-tag-input-autowidth"
           placeholder="Warning"
+          style="min-width:100%"
           value=""
         />
         <span
@@ -320,7 +325,7 @@ exports[`renders InputTag/demo/draggable.md correctly 1`] = `
         >
           <input
             autocomplete="off"
-            class="arco-input-tag-input arco-input-tag-input-size-default"
+            class="arco-input-tag-input arco-input-tag-input-size-default arco-input-tag-input-autowidth"
             placeholder=""
             value=""
           />
@@ -398,7 +403,7 @@ exports[`renders InputTag/demo/labelInValue.md correctly 1`] = `
       </div>
       <input
         autocomplete="off"
-        class="arco-input-tag-input arco-input-tag-input-size-default"
+        class="arco-input-tag-input arco-input-tag-input-size-default arco-input-tag-input-autowidth"
         placeholder=""
         value=""
       />
@@ -457,7 +462,8 @@ exports[`renders InputTag/demo/prefix.md correctly 1`] = `
           >
             <input
               autocomplete="off"
-              class="arco-input-tag-input arco-input-tag-input-size-default"
+              class="arco-input-tag-input arco-input-tag-input-size-default arco-input-tag-input-autowidth"
+              style="min-width:100%"
               value=""
             />
             <span
@@ -507,7 +513,8 @@ exports[`renders InputTag/demo/prefix.md correctly 1`] = `
             >
               <input
                 autocomplete="off"
-                class="arco-input-tag-input arco-input-tag-input-size-default"
+                class="arco-input-tag-input arco-input-tag-input-size-default arco-input-tag-input-autowidth"
+                style="min-width:100%"
                 value=""
               />
               <span
@@ -563,7 +570,8 @@ exports[`renders InputTag/demo/prefix.md correctly 1`] = `
             >
               <input
                 autocomplete="off"
-                class="arco-input-tag-input arco-input-tag-input-size-default"
+                class="arco-input-tag-input arco-input-tag-input-size-default arco-input-tag-input-autowidth"
+                style="min-width:100%"
                 value=""
               />
               <span
@@ -597,7 +605,8 @@ exports[`renders InputTag/demo/prefix.md correctly 1`] = `
             >
               <input
                 autocomplete="off"
-                class="arco-input-tag-input arco-input-tag-input-size-default"
+                class="arco-input-tag-input arco-input-tag-input-size-default arco-input-tag-input-autowidth"
+                style="min-width:100%"
                 value=""
               />
               <span
@@ -720,7 +729,7 @@ exports[`renders InputTag/demo/render-tag.md correctly 1`] = `
       </div>
       <input
         autocomplete="off"
-        class="arco-input-tag-input arco-input-tag-input-size-default"
+        class="arco-input-tag-input arco-input-tag-input-size-default arco-input-tag-input-autowidth"
         placeholder=""
         value=""
       />
@@ -766,8 +775,9 @@ exports[`renders InputTag/demo/save-on-blur.md correctly 1`] = `
     >
       <input
         autocomplete="off"
-        class="arco-input-tag-input arco-input-tag-input-size-default"
+        class="arco-input-tag-input arco-input-tag-input-size-default arco-input-tag-input-autowidth"
         placeholder="Input and blur directly"
+        style="min-width:100%"
         value=""
       />
       <span
@@ -918,7 +928,7 @@ exports[`renders InputTag/demo/size.md correctly 1`] = `
         </div>
         <input
           autocomplete="off"
-          class="arco-input-tag-input arco-input-tag-input-size-default"
+          class="arco-input-tag-input arco-input-tag-input-size-default arco-input-tag-input-autowidth"
           placeholder=""
           value=""
         />
@@ -991,8 +1001,9 @@ exports[`renders InputTag/demo/tokenSeparator.md correctly 1`] = `
       >
         <input
           autocomplete="off"
-          class="arco-input-tag-input arco-input-tag-input-size-default"
+          class="arco-input-tag-input arco-input-tag-input-size-default arco-input-tag-input-autowidth"
           placeholder="Paste text here"
+          style="min-width:100%"
           value=""
         />
         <span
@@ -1026,8 +1037,9 @@ exports[`renders InputTag/demo/validate.md correctly 1`] = `
         >
           <input
             autocomplete="off"
-            class="arco-input-tag-input arco-input-tag-input-size-default"
+            class="arco-input-tag-input arco-input-tag-input-size-default arco-input-tag-input-autowidth"
             placeholder="Please input"
+            style="min-width:100%"
             value=""
           />
           <span
@@ -1054,8 +1066,9 @@ exports[`renders InputTag/demo/validate.md correctly 1`] = `
         >
           <input
             autocomplete="off"
-            class="arco-input-tag-input arco-input-tag-input-size-default"
+            class="arco-input-tag-input arco-input-tag-input-size-default arco-input-tag-input-autowidth"
             placeholder="Format user input"
+            style="min-width:100%"
             value=""
           />
           <span

--- a/components/InputTag/__test__/__snapshots__/index.test.tsx.snap
+++ b/components/InputTag/__test__/__snapshots__/index.test.tsx.snap
@@ -12,7 +12,8 @@ exports[`ConfigProvider componentConfig.InputTag default 1`] = `
     >
       <input
         autocomplete="off"
-        class="arco-input-tag-input arco-input-tag-input-size-default"
+        class="arco-input-tag-input arco-input-tag-input-size-default arco-input-tag-input-autowidth"
+        style="min-width:100%"
         value=""
       />
       <span
@@ -35,7 +36,8 @@ exports[`ConfigProvider componentConfig.InputTag set className globally 1`] = `
     >
       <input
         autocomplete="off"
-        class="arco-input-tag-input arco-input-tag-input-size-default"
+        class="arco-input-tag-input arco-input-tag-input-size-default arco-input-tag-input-autowidth"
+        style="min-width:100%"
         value=""
       />
       <span
@@ -58,7 +60,8 @@ exports[`ConfigProvider componentConfig.InputTag set className globally and comp
     >
       <input
         autocomplete="off"
-        class="arco-input-tag-input arco-input-tag-input-size-default"
+        class="arco-input-tag-input arco-input-tag-input-size-default arco-input-tag-input-autowidth"
+        style="min-width:100%"
         value=""
       />
       <span
@@ -82,7 +85,8 @@ exports[`ConfigProvider componentConfig.InputTag set data-* property 1`] = `
     >
       <input
         autocomplete="off"
-        class="arco-input-tag-input arco-input-tag-input-size-default"
+        class="arco-input-tag-input arco-input-tag-input-size-default arco-input-tag-input-autowidth"
+        style="min-width:100%"
         value=""
       />
       <span

--- a/components/InputTag/input-tag.tsx
+++ b/components/InputTag/input-tag.tsx
@@ -360,6 +360,8 @@ function InputTag(baseProps: InputTagProps<string | ObjectValueType>, ref) {
           prefixCls={`${prefixCls}-input`}
           autoFitWidth={{
             delay: () => refDelay.current,
+            pure: true,
+            minWidth: value.length ? undefined : '100%',
           }}
           onPressEnter={async (e) => {
             inputValue && e.preventDefault();

--- a/components/InputTag/style/index.less
+++ b/components/InputTag/style/index.less
@@ -100,7 +100,7 @@
     }
 
     .@{prefix}-tag + &[disabled] {
-      width: 0 !important;
+      width: 0;
     }
 
     &-mirror {

--- a/components/Select/README.en-US.md
+++ b/components/Select/README.en-US.md
@@ -29,6 +29,7 @@ When users need to select one or more from a group of similar data, they can use
 |unmountOnExit|Whether to destroy the DOM when hiding|boolean |`true`|-|
 |inputValue|To set input value|string |`-`|-|
 |placeholder|Placeholder of element|string |`-`|-|
+|autoWidth|auto width. minWidth defaults to 0, maxWidth defaults to 100%|\| boolean\| { minWidth?: CSSProperties['minWidth']; maxWidth?: CSSProperties['maxWidth'] } |`-`|2.54.0|
 |mode|Set mode of Select(**`tags` recommends using `mode: multiple; allowCreate: true` instead, this mode will be removed in the next major version**)|'multiple' \| 'tags' |`-`|-|
 |size|Height of element, `24px` `28px` `32px` `36px`|'mini' \| 'small' \| 'default' \| 'large' |`-`|-|
 |status|Status|'error' \| 'warning' |`-`|2.45.0|

--- a/components/Select/README.zh-CN.md
+++ b/components/Select/README.zh-CN.md
@@ -29,6 +29,7 @@
 |unmountOnExit|是否在隐藏的时候销毁 DOM 结构|boolean |`true`|-|
 |inputValue|输入框的值（受控模式）|string |`-`|-|
 |placeholder|选择框默认文字。|string |`-`|-|
+|autoWidth|设置宽度自适应。minWidth 默认为 0，maxWidth 默认为 100%|\| boolean\| { minWidth?: CSSProperties['minWidth']; maxWidth?: CSSProperties['maxWidth'] } |`-`|2.54.0|
 |mode|是否开启多选模式或标签模式 (**`tags` 推荐使用 `mode: multiple; allowCreate: true` 替代，下一大版本将移除此模式**)|'multiple' \| 'tags' |`-`|-|
 |size|分别不同尺寸的选择器。对应 `24px`, `28px`, `32px`, `36px`|'mini' \| 'small' \| 'default' \| 'large' |`-`|-|
 |status|状态|'error' \| 'warning' |`-`|2.45.0|

--- a/components/Select/__demo__/autoWidth.md
+++ b/components/Select/__demo__/autoWidth.md
@@ -1,0 +1,101 @@
+---
+order: 21
+title:
+  zh-CN: 宽度自适应
+  en-US: Auto Width
+---
+## zh-CN
+
+通过 `autoWidth` 属性可以设置 `Select` 的宽度自适应
+
+## en-US
+
+The width adaptation of `Select` can be set through the `autoWidth` property
+
+
+```js
+import { Select, Typography, Space, Divider } from '@arco-design/web-react';
+const Option = Select.Option;
+const options = ['AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA', 'BBBBBBBBBBBBBBBBBBBB', 'CCCCCCCCCCCC', 'DDDD', 'EEE', 'FF'];
+
+const App = () => {
+  return (
+    <div >
+      <div style={{marginBottom: 32}}>
+        <Divider orientation="center">
+          <Typography.Text code>{JSON.stringify({minWidth: 200, maxWidth: 500})}</Typography.Text>
+        </Divider>
+        <Select
+          autoWidth={{minWidth: 200, maxWidth: 500}}
+          options={options}
+          allowClear
+          showSearch
+        >
+        </Select>
+        <br/><br/>
+        <Select
+          autoWidth={{minWidth: 200, maxWidth: 500}}
+          options={options}
+          allowClear
+          showSearch
+          addBefore="Select"
+        >
+        </Select>
+      </div>
+
+      <div style={{marginBottom: 32}}>
+        <Divider orientation="center">
+          <Typography.Text code>{JSON.stringify({minWidth: 0, maxWidth: 500})}</Typography.Text>
+        </Divider>
+        <Select
+          autoWidth={{ maxWidth: 500}}
+          placeholder="Please select"
+          options={options}
+          allowClear
+          showSearch
+        >
+        </Select>
+        <br/><br/>
+        <Select
+          autoWidth={{ maxWidth: 500}}
+          placeholder="Please select"
+          options={options}
+          allowClear
+          showSearch
+          addBefore="Select"
+        >
+        </Select>
+      </div>
+
+      <div style={{marginBottom: 32}}>
+      <Divider orientation="center">
+          <Typography.Text code>{JSON.stringify({minWidth: 300, maxWidth: "100%"})}</Typography.Text>
+        </Divider>
+        <Select
+          autoWidth={{ minWidth: 300 }}
+          placeholder="Please select"
+          options={options}
+          allowClear
+          mode="multiple"
+          allowCreate
+        >
+        </Select>
+        <br/>
+        <br/>
+        <Select
+          addBefore="Select"
+          autoWidth={{ minWidth: 300 }}
+          placeholder="Please select"
+          options={options}
+          allowClear
+          mode="multiple"
+          allowCreate
+        >
+        </Select>
+      </div>
+    </div>
+  );
+};
+
+export default App;
+```

--- a/components/Select/__test__/__snapshots__/demo.test.ts.snap
+++ b/components/Select/__test__/__snapshots__/demo.test.ts.snap
@@ -113,7 +113,8 @@ exports[`renders Select/demo/addbefore.md correctly 1`] = `
               >
                 <input
                   autocomplete="off"
-                  class="arco-input-tag-input arco-input-tag-input-size-default"
+                  class="arco-input-tag-input arco-input-tag-input-size-default arco-input-tag-input-autowidth"
+                  style="min-width:100%"
                   value=""
                 />
                 <span
@@ -286,7 +287,7 @@ exports[`renders Select/demo/allow-create.md correctly 1`] = `
               </div>
               <input
                 autocomplete="off"
-                class="arco-input-tag-input arco-input-tag-input-size-default"
+                class="arco-input-tag-input arco-input-tag-input-size-default arco-input-tag-input-autowidth"
                 placeholder=""
                 value=""
               />
@@ -366,8 +367,9 @@ exports[`renders Select/demo/async-data.md correctly 1`] = `
         >
           <input
             autocomplete="off"
-            class="arco-input-tag-input arco-input-tag-input-size-default"
+            class="arco-input-tag-input arco-input-tag-input-size-default arco-input-tag-input-autowidth"
             placeholder="Search by name"
+            style="min-width:100%"
             value=""
           />
           <span
@@ -398,6 +400,452 @@ exports[`renders Select/demo/async-data.md correctly 1`] = `
             d="M39.6 17.443 24.043 33 8.487 17.443"
           />
         </svg>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`renders Select/demo/autoWidth.md correctly 1`] = `
+<div>
+  <div
+    style="margin-bottom:32px"
+  >
+    <div
+      class="arco-divider arco-divider-horizontal arco-divider-with-text arco-divider-with-text-center"
+      role="separator"
+    >
+      <span
+        class="arco-divider-text arco-divider-text-center"
+      >
+        <span
+          class="arco-typography"
+        >
+          <code>
+            {"minWidth":200,"maxWidth":500}
+          </code>
+        </span>
+      </span>
+    </div>
+    <div
+      aria-autocomplete="list"
+      aria-expanded="false"
+      aria-haspopup="listbox"
+      class="arco-select arco-select-single arco-select-show-search arco-select-size-default"
+      role="combobox"
+      style="min-width:200px;max-width:500px;width:auto"
+      tabindex="0"
+    >
+      <div
+        class="arco-select-view"
+        title=""
+      >
+        <span
+          class="arco-select-view-selector"
+        >
+          <input
+            autocomplete="off"
+            class="arco-select-view-input"
+            style="width:100%"
+            value=""
+          />
+          <span
+            class="arco-select-view-value-mirror"
+          />
+          <span
+            class="arco-select-view-value"
+            style="display:none"
+          />
+        </span>
+        <div
+          aria-hidden="true"
+          class="arco-select-suffix"
+        >
+          <div
+            class="arco-select-arrow-icon"
+          >
+            <svg
+              aria-hidden="true"
+              class="arco-icon arco-icon-down"
+              fill="none"
+              focusable="false"
+              stroke="currentColor"
+              stroke-width="4"
+              viewBox="0 0 48 48"
+            >
+              <path
+                d="M39.6 17.443 24.043 33 8.487 17.443"
+              />
+            </svg>
+          </div>
+        </div>
+      </div>
+    </div>
+    <br />
+    <br />
+    <div
+      class="arco-select-wrapper"
+      style="min-width:200px;max-width:500px;width:auto"
+    >
+      <div
+        class="arco-select-addbefore"
+      >
+        Select
+      </div>
+      <div
+        aria-autocomplete="list"
+        aria-expanded="false"
+        aria-haspopup="listbox"
+        class="arco-select arco-select-single arco-select-show-search arco-select-size-default"
+        role="combobox"
+        tabindex="0"
+      >
+        <div
+          class="arco-select-view"
+          title=""
+        >
+          <span
+            class="arco-select-view-selector"
+          >
+            <input
+              autocomplete="off"
+              class="arco-select-view-input"
+              style="width:100%"
+              value=""
+            />
+            <span
+              class="arco-select-view-value-mirror"
+            />
+            <span
+              class="arco-select-view-value"
+              style="display:none"
+            />
+          </span>
+          <div
+            aria-hidden="true"
+            class="arco-select-suffix"
+          >
+            <div
+              class="arco-select-arrow-icon"
+            >
+              <svg
+                aria-hidden="true"
+                class="arco-icon arco-icon-down"
+                fill="none"
+                focusable="false"
+                stroke="currentColor"
+                stroke-width="4"
+                viewBox="0 0 48 48"
+              >
+                <path
+                  d="M39.6 17.443 24.043 33 8.487 17.443"
+                />
+              </svg>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    style="margin-bottom:32px"
+  >
+    <div
+      class="arco-divider arco-divider-horizontal arco-divider-with-text arco-divider-with-text-center"
+      role="separator"
+    >
+      <span
+        class="arco-divider-text arco-divider-text-center"
+      >
+        <span
+          class="arco-typography"
+        >
+          <code>
+            {"minWidth":0,"maxWidth":500}
+          </code>
+        </span>
+      </span>
+    </div>
+    <div
+      aria-autocomplete="list"
+      aria-expanded="false"
+      aria-haspopup="listbox"
+      class="arco-select arco-select-single arco-select-show-search arco-select-size-default"
+      role="combobox"
+      style="min-width:0;max-width:500px;width:auto"
+      tabindex="0"
+    >
+      <div
+        class="arco-select-view"
+        title=""
+      >
+        <span
+          class="arco-select-view-selector"
+        >
+          <input
+            autocomplete="off"
+            class="arco-select-view-input"
+            placeholder="Please select"
+            style="width:100%"
+            value=""
+          />
+          <span
+            class="arco-select-view-value-mirror"
+          >
+            Please select
+          </span>
+          <span
+            class="arco-select-view-value"
+            style="display:none"
+          >
+            Please select
+          </span>
+        </span>
+        <div
+          aria-hidden="true"
+          class="arco-select-suffix"
+        >
+          <div
+            class="arco-select-arrow-icon"
+          >
+            <svg
+              aria-hidden="true"
+              class="arco-icon arco-icon-down"
+              fill="none"
+              focusable="false"
+              stroke="currentColor"
+              stroke-width="4"
+              viewBox="0 0 48 48"
+            >
+              <path
+                d="M39.6 17.443 24.043 33 8.487 17.443"
+              />
+            </svg>
+          </div>
+        </div>
+      </div>
+    </div>
+    <br />
+    <br />
+    <div
+      class="arco-select-wrapper"
+      style="min-width:0;max-width:500px;width:auto"
+    >
+      <div
+        class="arco-select-addbefore"
+      >
+        Select
+      </div>
+      <div
+        aria-autocomplete="list"
+        aria-expanded="false"
+        aria-haspopup="listbox"
+        class="arco-select arco-select-single arco-select-show-search arco-select-size-default"
+        role="combobox"
+        tabindex="0"
+      >
+        <div
+          class="arco-select-view"
+          title=""
+        >
+          <span
+            class="arco-select-view-selector"
+          >
+            <input
+              autocomplete="off"
+              class="arco-select-view-input"
+              placeholder="Please select"
+              style="width:100%"
+              value=""
+            />
+            <span
+              class="arco-select-view-value-mirror"
+            >
+              Please select
+            </span>
+            <span
+              class="arco-select-view-value"
+              style="display:none"
+            >
+              Please select
+            </span>
+          </span>
+          <div
+            aria-hidden="true"
+            class="arco-select-suffix"
+          >
+            <div
+              class="arco-select-arrow-icon"
+            >
+              <svg
+                aria-hidden="true"
+                class="arco-icon arco-icon-down"
+                fill="none"
+                focusable="false"
+                stroke="currentColor"
+                stroke-width="4"
+                viewBox="0 0 48 48"
+              >
+                <path
+                  d="M39.6 17.443 24.043 33 8.487 17.443"
+                />
+              </svg>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    style="margin-bottom:32px"
+  >
+    <div
+      class="arco-divider arco-divider-horizontal arco-divider-with-text arco-divider-with-text-center"
+      role="separator"
+    >
+      <span
+        class="arco-divider-text arco-divider-text-center"
+      >
+        <span
+          class="arco-typography"
+        >
+          <code>
+            {"minWidth":300,"maxWidth":"100%"}
+          </code>
+        </span>
+      </span>
+    </div>
+    <div
+      aria-autocomplete="list"
+      aria-expanded="false"
+      aria-haspopup="listbox"
+      class="arco-select arco-select-multiple arco-select-show-search arco-select-size-default"
+      role="combobox"
+      style="min-width:300px;max-width:100%;width:auto"
+      tabindex="0"
+    >
+      <div
+        class="arco-select-view"
+        title=""
+      >
+        <div
+          class="arco-input-tag arco-input-tag-size-default arco-input-tag-has-placeholder"
+        >
+          <div
+            class="arco-input-tag-view"
+          >
+            <div
+              class="arco-input-tag-inner"
+            >
+              <input
+                autocomplete="off"
+                class="arco-input-tag-input arco-input-tag-input-size-default arco-input-tag-input-autowidth"
+                placeholder="Please select"
+                style="min-width:100%"
+                value=""
+              />
+              <span
+                class="arco-input-tag-input-mirror"
+              >
+                Please select
+              </span>
+            </div>
+          </div>
+        </div>
+        <div
+          aria-hidden="true"
+          class="arco-select-suffix"
+        >
+          <div
+            class="arco-select-arrow-icon"
+          >
+            <svg
+              aria-hidden="true"
+              class="arco-icon arco-icon-down"
+              fill="none"
+              focusable="false"
+              stroke="currentColor"
+              stroke-width="4"
+              viewBox="0 0 48 48"
+            >
+              <path
+                d="M39.6 17.443 24.043 33 8.487 17.443"
+              />
+            </svg>
+          </div>
+        </div>
+      </div>
+    </div>
+    <br />
+    <br />
+    <div
+      class="arco-select-wrapper"
+      style="min-width:300px;max-width:100%;width:auto"
+    >
+      <div
+        class="arco-select-addbefore"
+      >
+        Select
+      </div>
+      <div
+        aria-autocomplete="list"
+        aria-expanded="false"
+        aria-haspopup="listbox"
+        class="arco-select arco-select-multiple arco-select-show-search arco-select-size-default"
+        role="combobox"
+        tabindex="0"
+      >
+        <div
+          class="arco-select-view"
+          title=""
+        >
+          <div
+            class="arco-input-tag arco-input-tag-size-default arco-input-tag-has-placeholder"
+          >
+            <div
+              class="arco-input-tag-view"
+            >
+              <div
+                class="arco-input-tag-inner"
+              >
+                <input
+                  autocomplete="off"
+                  class="arco-input-tag-input arco-input-tag-input-size-default arco-input-tag-input-autowidth"
+                  placeholder="Please select"
+                  style="min-width:100%"
+                  value=""
+                />
+                <span
+                  class="arco-input-tag-input-mirror"
+                >
+                  Please select
+                </span>
+              </div>
+            </div>
+          </div>
+          <div
+            aria-hidden="true"
+            class="arco-select-suffix"
+          >
+            <div
+              class="arco-select-arrow-icon"
+            >
+              <svg
+                aria-hidden="true"
+                class="arco-icon arco-icon-down"
+                fill="none"
+                focusable="false"
+                stroke="currentColor"
+                stroke-width="4"
+                viewBox="0 0 48 48"
+              >
+                <path
+                  d="M39.6 17.443 24.043 33 8.487 17.443"
+                />
+              </svg>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   </div>
@@ -1026,7 +1474,7 @@ exports[`renders Select/demo/darggable.md correctly 1`] = `
             >
               <input
                 autocomplete="off"
-                class="arco-input-tag-input arco-input-tag-input-size-default"
+                class="arco-input-tag-input arco-input-tag-input-size-default arco-input-tag-input-autowidth"
                 placeholder=""
                 value=""
               />
@@ -1216,8 +1664,9 @@ exports[`renders Select/demo/hide-selected-option.md correctly 1`] = `
         >
           <input
             autocomplete="off"
-            class="arco-input-tag-input arco-input-tag-input-size-default"
+            class="arco-input-tag-input arco-input-tag-input-size-default arco-input-tag-input-autowidth"
             placeholder="Please select"
+            style="min-width:100%"
             value=""
           />
           <span
@@ -1346,7 +1795,7 @@ exports[`renders Select/demo/multiple.md correctly 1`] = `
               </div>
               <input
                 autocomplete="off"
-                class="arco-input-tag-input arco-input-tag-input-size-default"
+                class="arco-input-tag-input arco-input-tag-input-size-default arco-input-tag-input-autowidth"
                 placeholder=""
                 value=""
               />
@@ -1496,7 +1945,7 @@ exports[`renders Select/demo/multiple.md correctly 1`] = `
               </div>
               <input
                 autocomplete="off"
-                class="arco-input-tag-input arco-input-tag-input-size-default"
+                class="arco-input-tag-input arco-input-tag-input-size-default arco-input-tag-input-autowidth"
                 placeholder=""
                 value=""
               />
@@ -1646,7 +2095,7 @@ exports[`renders Select/demo/multiple.md correctly 1`] = `
               </div>
               <input
                 autocomplete="off"
-                class="arco-input-tag-input arco-input-tag-input-size-default"
+                class="arco-input-tag-input arco-input-tag-input-size-default arco-input-tag-input-autowidth"
                 placeholder=""
                 value=""
               />
@@ -1730,7 +2179,7 @@ exports[`renders Select/demo/multiple.md correctly 1`] = `
               </span>
               <input
                 autocomplete="off"
-                class="arco-input-tag-input arco-input-tag-input-size-default"
+                class="arco-input-tag-input arco-input-tag-input-size-default arco-input-tag-input-autowidth"
                 placeholder=""
                 value=""
               />
@@ -1943,8 +2392,9 @@ exports[`renders Select/demo/on-popup-scroll.md correctly 1`] = `
         >
           <input
             autocomplete="off"
-            class="arco-input-tag-input arco-input-tag-input-size-default"
+            class="arco-input-tag-input arco-input-tag-input-size-default arco-input-tag-input-autowidth"
             placeholder="Search by name"
+            style="min-width:100%"
             value=""
           />
           <span
@@ -2132,7 +2582,7 @@ exports[`renders Select/demo/options.md correctly 1`] = `
               </div>
               <input
                 autocomplete="off"
-                class="arco-input-tag-input arco-input-tag-input-size-default"
+                class="arco-input-tag-input arco-input-tag-input-size-default arco-input-tag-input-autowidth"
                 placeholder=""
                 value=""
               />
@@ -2480,7 +2930,7 @@ exports[`renders Select/demo/render-format.md correctly 1`] = `
               </div>
               <input
                 autocomplete="off"
-                class="arco-input-tag-input arco-input-tag-input-size-default"
+                class="arco-input-tag-input arco-input-tag-input-size-default arco-input-tag-input-autowidth"
                 placeholder=""
                 value=""
               />
@@ -2607,7 +3057,7 @@ exports[`renders Select/demo/render-tag.md correctly 1`] = `
               </div>
               <input
                 autocomplete="off"
-                class="arco-input-tag-input arco-input-tag-input-size-default"
+                class="arco-input-tag-input arco-input-tag-input-size-default arco-input-tag-input-autowidth"
                 placeholder=""
                 value=""
               />
@@ -3010,8 +3460,9 @@ exports[`renders Select/demo/size.md correctly 1`] = `
             >
               <input
                 autocomplete="off"
-                class="arco-input-tag-input arco-input-tag-input-size-default"
+                class="arco-input-tag-input arco-input-tag-input-size-default arco-input-tag-input-autowidth"
                 placeholder="Please select"
+                style="min-width:100%"
                 value=""
               />
               <span
@@ -3075,8 +3526,9 @@ exports[`renders Select/demo/token-separators.md correctly 1`] = `
         >
           <input
             autocomplete="off"
-            class="arco-input-tag-input arco-input-tag-input-size-default"
+            class="arco-input-tag-input arco-input-tag-input-size-default arco-input-tag-input-autowidth"
             placeholder="Please select"
+            style="min-width:100%"
             value=""
           />
           <span
@@ -3144,8 +3596,9 @@ Array [
           >
             <input
               autocomplete="off"
-              class="arco-input-tag-input arco-input-tag-input-size-default"
+              class="arco-input-tag-input arco-input-tag-input-size-default arco-input-tag-input-autowidth"
               placeholder="Select a tag"
+              style="min-width:100%"
               value=""
             />
             <span

--- a/components/TimePicker/__test__/__snapshots__/demo.test.ts.snap
+++ b/components/TimePicker/__test__/__snapshots__/demo.test.ts.snap
@@ -1533,7 +1533,7 @@ exports[`renders TimePicker/demo/utcOffset.md correctly 1`] = `
         >
           <div
             class="arco-select-view"
-            title="UTC "
+            title="UTC "
           >
             <span
               class="arco-select-view-selector"
@@ -1549,7 +1549,7 @@ exports[`renders TimePicker/demo/utcOffset.md correctly 1`] = `
               <span
                 class="arco-select-view-value"
               >
-                UTC 
+                UTC 
               </span>
             </span>
             <div

--- a/components/Tree/__test__/__snapshots__/demo.test.ts.snap
+++ b/components/Tree/__test__/__snapshots__/demo.test.ts.snap
@@ -6224,7 +6224,7 @@ exports[`renders Tree/demo/search.md correctly 1`] = `
 <div>
   <div
     class="arco-input-group-wrapper arco-input-group-wrapper-default arco-input-has-suffix arco-input-search"
-    style="margin-bottom:8px;max-width:240px"
+    style="max-width:240px;margin-bottom:8px"
   >
     <span
       class="arco-input-group"

--- a/components/TreeSelect/README.en-US.md
+++ b/components/TreeSelect/README.en-US.md
@@ -29,6 +29,7 @@ Can choose tree structure data.Only Single choice is supports.
 |unmountOnExit|Whether to destroy the DOM after hiding|boolean |`-`|-|
 |inputValue|To set input search value|string |`-`|2.39.0|
 |placeholder|Placeholder of element|string |`-`|-|
+|autoWidth|auto width. minWidth defaults to 0, maxWidth defaults to 100%|\| boolean\| { minWidth?: CSSProperties['minWidth']; maxWidth?: CSSProperties['maxWidth'] } |`-`|2.54.0|
 |fieldNames|Custom field name for key, title, isLeaf, disabled and children|[TreeProps](tree#tree)['fieldNames'] |`DefaultFieldNames`|2.11.0|
 |size|Height of element, `24px` `28px` `32px` `36px`|'mini' \| 'small' \| 'default' \| 'large' |`-`|-|
 |status|Status|'error' \| 'warning' |`-`|2.45.0|

--- a/components/TreeSelect/README.zh-CN.md
+++ b/components/TreeSelect/README.zh-CN.md
@@ -29,6 +29,7 @@
 |unmountOnExit|是否在隐藏之后销毁 DOM 结构|boolean |`-`|-|
 |inputValue|输入框搜索文本的受控值|string |`-`|2.39.0|
 |placeholder|选择框默认文字。|string |`-`|-|
+|autoWidth|设置宽度自适应。minWidth 默认为 0，maxWidth 默认为 100%|\| boolean\| { minWidth?: CSSProperties['minWidth']; maxWidth?: CSSProperties['maxWidth'] } |`-`|2.54.0|
 |fieldNames|指定 key，title，isLeaf，disabled，children 对应的字段|[TreeProps](tree#tree)['fieldNames'] |`DefaultFieldNames`|2.11.0|
 |size|分别不同尺寸的选择器。对应 `24px`, `28px`, `32px`, `36px`|'mini' \| 'small' \| 'default' \| 'large' |`-`|-|
 |status|状态|'error' \| 'warning' |`-`|2.45.0|

--- a/components/TreeSelect/__test__/__snapshots__/demo.test.ts.snap
+++ b/components/TreeSelect/__test__/__snapshots__/demo.test.ts.snap
@@ -108,7 +108,8 @@ exports[`renders TreeSelect/demo/addon.md correctly 1`] = `
               >
                 <input
                   autocomplete="off"
-                  class="arco-input-tag-input arco-input-tag-input-size-default"
+                  class="arco-input-tag-input arco-input-tag-input-size-default arco-input-tag-input-autowidth"
+                  style="min-width:100%"
                   value=""
                 />
                 <span
@@ -314,7 +315,7 @@ exports[`renders TreeSelect/demo/checkable.md correctly 1`] = `
             </div>
             <input
               autocomplete="off"
-              class="arco-input-tag-input arco-input-tag-input-size-default"
+              class="arco-input-tag-input arco-input-tag-input-size-default arco-input-tag-input-autowidth"
               placeholder=""
               value=""
             />
@@ -503,7 +504,7 @@ exports[`renders TreeSelect/demo/checkedStrategy.md correctly 1`] = `
             </div>
             <input
               autocomplete="off"
-              class="arco-input-tag-input arco-input-tag-input-size-default"
+              class="arco-input-tag-input arco-input-tag-input-size-default arco-input-tag-input-autowidth"
               placeholder=""
               value=""
             />
@@ -647,8 +648,9 @@ exports[`renders TreeSelect/demo/draggable.md correctly 1`] = `
             >
               <input
                 autocomplete="off"
-                class="arco-input-tag-input arco-input-tag-input-size-default"
+                class="arco-input-tag-input arco-input-tag-input-size-default arco-input-tag-input-autowidth"
                 placeholder="请选择..."
+                style="min-width:100%"
                 value=""
               />
               <span
@@ -969,8 +971,9 @@ exports[`renders TreeSelect/demo/multiple.md correctly 1`] = `
             >
               <input
                 autocomplete="off"
-                class="arco-input-tag-input arco-input-tag-input-size-default"
+                class="arco-input-tag-input arco-input-tag-input-size-default arco-input-tag-input-autowidth"
                 placeholder="Please select ..."
+                style="min-width:100%"
                 value=""
               />
               <span
@@ -1033,8 +1036,9 @@ exports[`renders TreeSelect/demo/multiple.md correctly 1`] = `
             >
               <input
                 autocomplete="off"
-                class="arco-input-tag-input arco-input-tag-input-size-default"
+                class="arco-input-tag-input arco-input-tag-input-size-default arco-input-tag-input-autowidth"
                 placeholder="Max display 2 tags"
+                style="min-width:100%"
                 value=""
               />
               <span
@@ -1098,8 +1102,9 @@ exports[`renders TreeSelect/demo/onSearch.md correctly 1`] = `
         >
           <input
             autocomplete="off"
-            class="arco-input-tag-input arco-input-tag-input-size-default"
+            class="arco-input-tag-input arco-input-tag-input-size-default arco-input-tag-input-autowidth"
             placeholder="please select..."
+            style="min-width:100%"
             value=""
           />
           <span

--- a/components/Trigger/__test__/__snapshots__/demo.test.ts.snap
+++ b/components/Trigger/__test__/__snapshots__/demo.test.ts.snap
@@ -65,7 +65,7 @@ exports[`renders Trigger/demo/alignPoint.md correctly 1`] = `
               </div>
               <input
                 autocomplete="off"
-                class="arco-input-tag-input arco-input-tag-input-size-default"
+                class="arco-input-tag-input arco-input-tag-input-size-default arco-input-tag-input-autowidth"
                 placeholder=""
                 value=""
               />

--- a/components/_class/select-view.tsx
+++ b/components/_class/select-view.tsx
@@ -130,6 +130,14 @@ export interface SelectViewCommonProps
    */
   clearIcon?: ReactNode;
   /**
+   * @zh 设置宽度自适应。minWidth 默认为 0，maxWidth 默认为 100%
+   * @en auto width. minWidth defaults to 0, maxWidth defaults to 100%
+   * @version 2.54.0
+   */
+  autoWidth?:
+    | boolean
+    | { minWidth?: CSSProperties['minWidth']; maxWidth?: CSSProperties['maxWidth'] };
+  /**
    * @zh 选择框前添加元素
    * @en The label text displayed before (on the left side of) the select field
    * @version 2.41.0
@@ -623,7 +631,21 @@ const CoreSelectView = React.forwardRef(
 );
 
 const SelectView = (props: SelectViewProps, ref) => {
-  const { prefixCls, id, style, className, addBefore, rtl, renderView, ...rest } = props;
+  const {
+    prefixCls,
+    id,
+    style,
+    className,
+    addBefore,
+    rtl,
+    renderView,
+    autoWidth: propsAutoWidth,
+    ...rest
+  } = props;
+
+  const autoWidth = propsAutoWidth
+    ? { minWidth: 0, maxWidth: '100%', ...(isObject(propsAutoWidth) ? propsAutoWidth : {}) }
+    : null;
 
   const refCoreSelectView = useRef<SelectViewHandle>(null);
 
@@ -631,7 +653,11 @@ const SelectView = (props: SelectViewProps, ref) => {
   // const needAddAfter = addAfter !== null && addAfter !== undefined;
   const needAddAfter = false;
   const needWrapper = needAddBefore || needAddAfter;
-  const propsAppliedToRoot = { id, style, className };
+  const propsAppliedToRoot = {
+    id,
+    style: { ...autoWidth, width: autoWidth ? 'auto' : undefined, ...style },
+    className,
+  };
   const htmlDataAttributes = pickDataAttributes(rest);
 
   useImperativeHandle<any, SelectViewHandle>(ref, () => refCoreSelectView.current);

--- a/components/_util/fillNBSP.ts
+++ b/components/_util/fillNBSP.ts
@@ -1,4 +1,6 @@
 // Replace empty string to &nbsp;
 export default function (str: any) {
-  return typeof str === 'string' ? str.replace(/\s{2,}/g, ($0) => '\u00A0'.repeat($0.length)) : str;
+  return typeof str === 'string'
+    ? str.replace(/(\s{2,})|(\s{1,}$)/g, ($0) => '\u00A0'.repeat($0.length))
+    : str;
 }


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [x] New feature
- [ ] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context

<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

## Solution

<!-- Describe how the problem is fixed in detail -->

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|   Select        |     `Select` 组件支持通过 `autoWidth` 属性设置宽度自适应。          |     The `Select` component supports setting width adaptation through the `autoWidth` property.          |     close #2249            |
|   Cascader        |     `Cascader` 组件支持通过 `autoWidth` 属性设置宽度自适应。          |     The `Cascader` component supports setting width adaptation through the `autoWidth` property.          |     close #2249            |
|   TreeSelect        |     `TreeSelect` 组件支持通过 `autoWidth` 属性设置宽度自适应。          |     The `TreeSelect` component supports setting width adaptation through the `autoWidth` property.          |     close #2249            |
|   Input        |     `Input` 组件支持通过 `autoWidth` 属性设置宽度自适应。          |     The `Input` component supports setting width adaptation through the `autoWidth` property.          |     close #2249            |


<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->
## Checklist:

- [ ] Test suite passes (`npm run test`)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
