### PR TITLE
fix(Spin): render child when it is 0/NaN

### DIFF
--- a/components/Spin/__test__/index.test.tsx
+++ b/components/Spin/__test__/index.test.tsx
@@ -60,4 +60,9 @@ describe('Spin', () => {
 
     expect(wrapper.find('.arco-spin-block').length).toBe(1);
   });
+
+  it('render children while it is 0/NaN', () => {
+    const wrapper0 = render(<Spin>{0}</Spin>);
+    expect(wrapper0.find('div')[0]).toHaveTextContent('0');
+  });
 });

--- a/components/Spin/index.tsx
+++ b/components/Spin/index.tsx
@@ -6,6 +6,7 @@ import { ConfigContext } from '../ConfigProvider';
 import DotLoading from './dot-loading';
 import { SpinProps } from './interface';
 import useMergeProps from '../_util/hooks/useMergeProps';
+import { isEmptyReactNode } from '../_util/is';
 
 function Spin(baseProps: SpinProps, ref) {
   const { getPrefixCls, componentConfig } = useContext(ConfigContext);
@@ -67,7 +68,12 @@ function Spin(baseProps: SpinProps, ref) {
       style={style}
       {...rest}
     >
-      {children ? (
+      {isEmptyReactNode(children) ? (
+        <>
+          {loadingIcon}
+          {tip ? <div className={`${prefixCls}-tip`}>{tip}</div> : null}
+        </>
+      ) : (
         <>
           <div className={`${prefixCls}-children`}>{children}</div>
           {_usedLoading && (
@@ -78,11 +84,6 @@ function Spin(baseProps: SpinProps, ref) {
               </span>
             </div>
           )}
-        </>
-      ) : (
-        <>
-          {loadingIcon}
-          {tip ? <div className={`${prefixCls}-tip`}>{tip}</div> : null}
         </>
       )}
     </div>

--- a/components/_util/is.ts
+++ b/components/_util/is.ts
@@ -64,6 +64,10 @@ export function isEmptyObject(obj: any): boolean {
   return isObject(obj) && Object.keys(obj).length === 0;
 }
 
+export function isEmptyReactNode(node: any): boolean {
+  return !node && (node === null || node === undefined || node === '' || node === false);
+}
+
 export function isExist(obj: any): boolean {
   return obj || obj === 0;
 }


### PR DESCRIPTION
## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 


## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|  Spin   |   修复 `Spin` 组件传入 Children 为 `0` 时，其子节点未渲染的问题。  |  Fixed the issue that the child node of `Spin` is not rendered when the child passed in was `0`.  |                |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->
## Checklist:

- [ ] Test suite passes (`npm run test`)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
