### PR TITLE
style(Input): vertical jitter in Safari when clear text content of input-box

### DIFF
--- a/components/Input/style/index.less
+++ b/components/Input/style/index.less
@@ -230,6 +230,8 @@
   display: table;
   width: 100%;
   height: 100%;
+  // fix issue: https://github.com/arco-design/arco-design/issues/2310
+  line-height: 0;
 
   > .@{input-prefix-cls}-inner-wrapper,
   > .@{input-prefix-cls} {


### PR DESCRIPTION

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [ ] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [x] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
| Input   |  修复 `Input` 组件具有前后缀时在 Safari 中清空文本导致垂直方向高度抖动的问题。  |   Fixed the issue that clear text of `Input` with prefix/suffix in Safari caused vertical jitter.  |     Close #2310    |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->
## Checklist:

- [ ] Test suite passes (`npm run test`)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
