### PR TITLE
fix(InputTag): word separate will be triggered twice if onChange takes a long time

### DIFF
--- a/components/Select/select.tsx
+++ b/components/Select/select.tsx
@@ -45,10 +45,6 @@ import useMergeProps from '../_util/hooks/useMergeProps';
 import { SelectOptionProps } from '../index';
 import useId from '../_util/hooks/useId';
 
-// 输入框粘贴会先触发 onPaste 后触发 onChange，但 onChange 的 value 中不包含换行符
-// 如果刚刚因为粘贴触发过分词，则 onChange 不再进行分词尝试
-const THRESHOLD_TOKEN_SEPARATOR_TRIGGER = 100;
-
 const defaultProps: SelectProps = {
   trigger: 'click',
   bordered: true,
@@ -636,12 +632,18 @@ function Select(baseProps: SelectProps, ref) {
     );
   };
 
-  const handleTokenSeparators = (str): boolean => {
-    let hasSeparator = false;
+  const handleTokenSeparators = (str: string): boolean => {
+    // clear the timestamp, and then we can judge whether tokenSeparators has been triggered
+    // according to timestamp value
+    refTSLastSeparateTriggered.current = null;
+
     if (isMultipleMode && isArray(tokenSeparators) && tokenSeparators.length) {
       const rawValues = str.split(new RegExp(`[${tokenSeparators.join('')}]`));
       // 输入了分隔符的情况
       if (rawValues.length > 1) {
+        // record the timestamp of tokenSeparators triggered
+        refTSLastSeparateTriggered.current = Date.now();
+
         const splitValues = rawValues.filter((v, index) => v && rawValues.indexOf(v) === index);
         const newValue = (value as any[]).slice(0);
         let needUpdate = false;
@@ -656,11 +658,10 @@ function Select(baseProps: SelectProps, ref) {
         if (needUpdate) {
           tryUpdateSelectValue(newValue);
         }
-
-        hasSeparator = true;
       }
     }
-    return hasSeparator;
+
+    return !!refTSLastSeparateTriggered.current;
   };
 
   // SelectView组件事件处理
@@ -680,7 +681,6 @@ function Select(baseProps: SelectProps, ref) {
         if (isEnter || isTab) {
           const suffix = isEnter ? '\n' : isTab ? '\t' : '';
           if (handleTokenSeparators(event.target.value + suffix)) {
-            refTSLastSeparateTriggered.current = Date.now();
             // 回车后不会触发 onChangeInputValue 回调，所以在这里直接清空输入框
             tryUpdateInputValue('', 'tokenSeparator');
           }
@@ -692,12 +692,13 @@ function Select(baseProps: SelectProps, ref) {
       onKeyDown?.(event);
     },
 
-    onChangeInputValue: (value, { nativeEvent: { inputType } }) => {
-      if (
-        (inputType === 'insertFromPaste' &&
-          Date.now() - refTSLastSeparateTriggered.current < THRESHOLD_TOKEN_SEPARATOR_TRIGGER) ||
-        handleTokenSeparators(value)
-      ) {
+    onChangeInputValue: (value: string, { nativeEvent: { inputType } }) => {
+      // Pasting in the input box will trigger onPaste first and then onChange, but the value of onChange does not contain a newline character.
+      // If word segmentation has just been triggered due to pasting, onChange will no longer attempt word segmentation.
+      // Do NOT use await, need to update input value right away
+      inputType !== 'insertFromPaste' && handleTokenSeparators(value);
+
+      if (refTSLastSeparateTriggered.current) {
         tryUpdateInputValue('', 'tokenSeparator');
       } else {
         tryUpdateInputValue(value, 'manual');
@@ -709,9 +710,7 @@ function Select(baseProps: SelectProps, ref) {
     },
 
     onPaste: (e) => {
-      if (handleTokenSeparators(e.clipboardData.getData('text'))) {
-        refTSLastSeparateTriggered.current = Date.now();
-      }
+      handleTokenSeparators(e.clipboardData.getData('text'));
       onPaste?.(e);
     },
 


### PR DESCRIPTION

<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|  InputTag  |  修复 `InputTag` 组件 `onChange` 回调用时较长时自动分词将会连续触发两次的问题。 |    Fixed the bug that automatic word segmentation would be triggered twice in a row when the `onChange` callback of the `InputTag` took a long time.   |     Close #2376    |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->
## Checklist:

- [x] Test suite passes (`npm run test`)
- [x] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [x] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
