### PR TITLE
fix(Layout): sider can not resize if resizeBoxProps is given

### DIFF
--- a/components/Layout/sider.tsx
+++ b/components/Layout/sider.tsx
@@ -11,7 +11,7 @@ import cs from '../_util/classNames';
 import IconLeft from '../../icon/react-icon/IconLeft';
 import IconRight from '../../icon/react-icon/IconRight';
 import { ConfigContext } from '../ConfigProvider';
-import ResizeBox from '../ResizeBox';
+import ResizeBox, { ResizeBoxProps } from '../ResizeBox';
 import { isArray, isNumber } from '../_util/is';
 import ResponsiveObserve, { responsiveMap } from '../_util/responsiveObserve';
 import useMergeValue from '../_util/hooks/useMergeValue';
@@ -151,16 +151,17 @@ function Sider(props: SiderProps, ref) {
     ) : null;
   };
 
-  const resizeProps = useMemo(() => {
+  const resizeProps = useMemo<ResizeBoxProps>(() => {
     if (resizable) {
       return {
         component: 'aside',
-        onMoving: (_, { width: currentWidth }) => {
-          setSiderWidth(currentWidth);
-        },
         ...resizeBoxProps,
         width: siderWidth,
         directions: resizeDirections,
+        onMoving: (event, size) => {
+          setSiderWidth(`${size.width}px`);
+          resizeBoxProps?.onMoving?.(event, size);
+        },
       };
     }
     return {};


### PR DESCRIPTION

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context

<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

## Solution

<!-- Describe how the problem is fixed in detail -->

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|    Layout    |  修复 `Layout.Sider` 在传入 `resizeBoxProps.onMoving` 时无法拖拽改变尺寸的问题。  |   Fix the problem that `Layout.Sider` cannot be dragged to change the size when `resizeBoxProps.onMoving` is passed in.  |        |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->
## Checklist:

- [ ] Test suite passes (`npm run test`)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
