### PR TITLE
feat(Menu): new property onEllipsisChange for horizontal-menu ellipsis status change

### DIFF
--- a/components/Menu/README.en-US.md
+++ b/components/Menu/README.en-US.md
@@ -37,6 +37,7 @@ A component to organize, arrange, and display a list of options.
 |onClickMenuItem|Click menu item callback|(key: string, event, keyPath: string[]) => any |`-`|`event` in 2.15.0, `keyPath` in 2.19.0|
 |onClickSubMenu|Callback when click sub menu|(key: string, openKeys: string[], keyPath: string[]) => void |`-`|`keyPath` in 2.19.0|
 |onCollapseChange|Callback when menu collapse status changed|(collapse: boolean) => void |`-`|-|
+|onEllipsisChange|Callback when horizontal-menu ellipsis status changed|(lastVisibleIndex: number, ellipsisChildren: ReactNode[]) => void |`-`|2.57.0|
 
 ### Menu.SubMenu
 

--- a/components/Menu/README.zh-CN.md
+++ b/components/Menu/README.zh-CN.md
@@ -37,6 +37,7 @@
 |onClickMenuItem|点击菜单项的回调|(key: string, event, keyPath: string[]) => any |`-`|`event` in 2.15.0, `keyPath` in 2.19.0|
 |onClickSubMenu|点击子菜单标题的回调|(key: string, openKeys: string[], keyPath: string[]) => void |`-`|`keyPath` in 2.19.0|
 |onCollapseChange|折叠状态改变时的回调|(collapse: boolean) => void |`-`|-|
+|onEllipsisChange|水平菜单自动超出省略发生变化时的回调|(lastVisibleIndex: number, ellipsisChildren: ReactNode[]) => void |`-`|2.57.0|
 
 ### Menu.SubMenu
 

--- a/components/Menu/index.tsx
+++ b/components/Menu/index.tsx
@@ -57,6 +57,7 @@ function Menu(baseProps: MenuProps, ref) {
     onClickSubMenu,
     onClickMenuItem,
     onCollapseChange,
+    onEllipsisChange,
     ...rest
   } = props;
 
@@ -124,7 +125,10 @@ function Menu(baseProps: MenuProps, ref) {
       <>
         <div className={`${prefixCls}-inner`}>
           {mode === 'horizontal' && ellipsis !== false ? (
-            <OverflowWrap ellipsisText={isObject(ellipsis) ? ellipsis.text : '···'}>
+            <OverflowWrap
+              ellipsisText={isObject(ellipsis) ? ellipsis.text : '···'}
+              onEllipsisChange={onEllipsisChange}
+            >
               {childrenList}
             </OverflowWrap>
           ) : (

--- a/components/Menu/interface.tsx
+++ b/components/Menu/interface.tsx
@@ -121,6 +121,12 @@ export interface MenuProps extends Omit<HTMLAttributes<HTMLDivElement>, 'classNa
    * @en Callback when menu collapse status changed
    */
   onCollapseChange?: (collapse: boolean) => void;
+  /**
+   * @zh 水平菜单自动超出省略发生变化时的回调
+   * @en Callback when horizontal-menu ellipsis status changed
+   * @version 2.57.0
+   */
+  onEllipsisChange?: (status: { lastVisibleIndex: number; overflowNodes: ReactNode[] }) => void;
 
   /**
    * @zh


### PR DESCRIPTION

<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [x] New feature
- [ ] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 


## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|  Menu  |  `Menu` 组件新增 `onEllipsisChange` 回调以通知水平菜单内容自动省略状态发生改变。   |  `Menu` component adds a `onEllipsisChange` callback to notify the horizontal menu ellipsis status changed. |   Close #2411      |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->
## Checklist:

- [ ] Test suite passes (`npm run test`)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
