### PR TITLE
fix(select): 最后一个选项被清除时,高度会闪现2行的高度直到标签完全消失 (#2451)

### DIFF
--- a/components/InputTag/input-tag.tsx
+++ b/components/InputTag/input-tag.tsx
@@ -349,7 +349,6 @@ function InputTag(baseProps: InputTagProps<string | ObjectValueType>, ref) {
           autoFitWidth={{
             delay: () => refDelay.current,
             pure: true,
-            minWidth: value.length ? undefined : '100%',
           }}
           onPressEnter={async (e) => {
             inputValue && e.preventDefault();


### PR DESCRIPTION
## Types of changes

- [ ] New feature
- [ ] Bug fix
- [x] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context

[#2451](https://github.com/arco-design/arco-design/issues/2451)

## Solution

删除 `minWidth: "100%"` 的设置

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|  InputTag   |   优化 `InputTag` 清除所有标签时高度抖动的问题。   |    Optimize the issue of vertical jitter when clearing all tags in `InputTag`.     |   Close #2451  |

