### PR TITLE
fix: initializing ColorPicker trigger onChange

### DIFF
--- a/components/ColorPicker/hooks/useColorPicker.ts
+++ b/components/ColorPicker/hooks/useColorPicker.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { HSV } from '../interface';
 import { formatInputToHSVA, hsvToRgb, rgbaToHex, rgbToHex } from '../../_util/color';
 import useMergeValue from '../../_util/hooks/useMergeValue';
+import useIsFirstRender from '../../_util/hooks/useIsFirstRender';
 
 interface UseColorPickerProps {
   value?: string;
@@ -15,7 +16,7 @@ interface UseColorPickerProps {
 
 export const useColorPicker = (props: UseColorPickerProps) => {
   const { format, onChange } = props;
-
+  const isFirstRender = useIsFirstRender();
   const [value, setValue] = useMergeValue('', props);
 
   const formatInput = useMemo(() => {
@@ -59,7 +60,7 @@ export const useColorPicker = (props: UseColorPickerProps) => {
 
   useEffect(() => {
     setValue(formatValue);
-    onChange?.(formatValue);
+    !isFirstRender && onChange?.(formatValue);
   }, [formatValue]);
 
   const onVisibleChange = useCallback(


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context

<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

The onChange event of the ColorPicker component fires even when initializing.

## Solution

<!-- Describe how the problem is fixed in detail -->

Determine whether it is the first render.

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

Just add onChange={console.log} in `components/ColorPicker/__demo__/basic.md` and observe it

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|    ColorPicker      |     修复 `ColorPicker` 初始化时触发`onChange` 的 bug         |       Fix the bug that triggers `onChange` when `ColorPicker` is initialized    |                |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->
## Checklist:

- [x] Test suite passes (`npm run test`)
- [x] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [x] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
