### PR TITLE
Enhance inputvalue

### DIFF
--- a/components/DatePicker/picker-range.tsx
+++ b/components/DatePicker/picker-range.tsx
@@ -414,7 +414,6 @@ const Picker = (baseProps: RangePickerProps) => {
   }
 
   function changeFocusedInputIndex(index: number, silent?: boolean) {
-    setInputValue(undefined);
     setFocusedInputIndex(index);
     if (panelValue && panelValue.length && !silent) {
       const newPageShowDates = getShowDatesFromFocused(panelValue, index);
@@ -454,6 +453,12 @@ const Picker = (baseProps: RangePickerProps) => {
       newValueShow[focusedInputIndex] = getDayjsValue(niv, format) as Dayjs;
       setValueShow(newValueShow);
       setFixedPageShowDates(newValueShow);
+      setInputValue(undefined);
+    }
+  }
+
+  function onBlurInput() {
+    if (inputValue) {
       setInputValue(undefined);
     }
   }
@@ -891,6 +896,7 @@ const Picker = (baseProps: RangePickerProps) => {
               focusedInputIndex={focusedInputIndex}
               isPlaceholder={!!hoverPlaceholderValue}
               separator={separator}
+              onBlur={onBlurInput}
             />
           )}
         </Trigger>

--- a/components/_class/picker/input-range.tsx
+++ b/components/_class/picker/input-range.tsx
@@ -40,6 +40,7 @@ export interface DateInputRangeProps {
   isPlaceholder?: boolean;
   prefix?: ReactNode;
   inputProps?: React.InputHTMLAttributes<HTMLInputElement>[];
+  onBlur?: (e) => void;
 }
 
 type DateInputHandle = {
@@ -73,6 +74,7 @@ function DateInput(
     isPlaceholder,
     prefix,
     inputProps = [],
+    onBlur,
     ...rest
   }: DateInputRangeProps,
   ref
@@ -124,6 +126,11 @@ function DateInput(
     onChange && onChange(e);
   }
 
+  function onBlurInput(e, index) {
+    onBlur?.(e);
+    inputProps?.[index]?.onBlur(e);
+  }
+
   const prefixCls = getPrefixCls('picker');
   const size = propSize || ctxSize;
 
@@ -172,6 +179,7 @@ function DateInput(
           onChange={onChangeInput}
           onKeyDown={onKeyDown}
           onClick={() => changeFocusedInput(0)}
+          onBlur={(e) => onBlurInput(e, 0)}
           {...readOnlyProps}
         />
       </div>
@@ -186,6 +194,7 @@ function DateInput(
           onChange={onChangeInput}
           onKeyDown={onKeyDown}
           onClick={() => changeFocusedInput(1)}
+          onBlur={(e) => onBlurInput(e, 1)}
           {...readOnlyProps}
         />
       </div>


### PR DESCRIPTION
优化RangePicker input 框重置值的逻辑。
之前：
焦点切换才会重置输入的值。但是有些场景，用户自定义面板后，可能有点击面板的场景，这时候也需要对值进行清空。
之后：
输入框blur之后，就会进行值的清空。