### PR TITLE
Fix(ColorPicker): Implement disabledAlpha (reported missing in #2528)

### DIFF
--- a/CONTRIBUTING.zh-CN.md
+++ b/CONTRIBUTING.zh-CN.md
@@ -31,7 +31,7 @@
 - 认领 issue： 在 github 建立 issue 并认领（或直接认领已有 issue），告知大家自己正在修复，避免重复工作。
 - 项目开发：在完成开发前准备后，进行 bug 修复或功能开发。
 - 添加单测：针对代码变动添加单元测试，执行 yarn test -- ./components/xxx/，确认测试用例通过，尽量保证一定的测试覆盖率。
-- 更新快照：如果涉及到组件 dom 层级变动，类名增删或新增/删除了 Demo，快照可能需要重新生成一下。执行 yarn build:cjs && yarn test:client -u
+- 更新快照：如果涉及到组件 dom 层级变动，类名增删或新增/删除了 Demo，快照可能需要重新生成一下。执行 yarn build:cjs && yarn test:client -u ./components/xxx
 - 文档生成：组件 API 存在调整时针对当前组件 yarn docgen ./components/xxx重新生成文档。
 - 提交 PR
 

--- a/components/ColorPicker/__demo__/disabled.md
+++ b/components/ColorPicker/__demo__/disabled.md
@@ -7,11 +7,11 @@ title:
 
 ## zh-CN
 
-设置 `disabled` 禁用选择器。
+设置 `disabled` 禁用整个选择器。
 
 ## en-US
 
-Set `disabled` to disable the selector.
+Set `disabled` to disable the selector. 
 
 ```js
 import { ColorPicker, Radio } from '@arco-design/web-react';

--- a/components/ColorPicker/__demo__/disabledAlpha.md
+++ b/components/ColorPicker/__demo__/disabledAlpha.md
@@ -7,11 +7,15 @@ title:
 
 ## zh-CN
 
-设置 `disabledAlpha` 以隐藏 Alpha 值滑条和数值显示。 
+设置 `disabledAlpha` 以隐藏 Alpha 值滑条和数值显示。
+
+如果 `defaultValue` 传入的初始色值包含 Alpha，那么初次显示时，色块会保留传入的 Alpha。当用户在取色版上取色时，Alpha 将被重置并锁定为100。
 
 ## en-US
 
-Set `disabledAlpha` to disable the Alpha slider and lock Alpha value.
+Set `disabledAlpha` to hide the slider and value for Alpha. 
+
+If the `defaultValue` has alpha (like `#165DFF80`), then the alpha value is retained for the intial render. The alpha value is reset and locked to 100 once the user clicks on the palette. 
 
 ```js
 import { ColorPicker } from '@arco-design/web-react';
@@ -21,6 +25,8 @@ const App = () => {
   return (
     <div>
       <ColorPicker defaultValue={'#165DFF'} disabledAlpha />
+      <br />
+      <ColorPicker defaultValue={'#165DFF80'} disabledAlpha />
     </div>
   ) ;
 };

--- a/components/ColorPicker/__demo__/disabledAlpha.md
+++ b/components/ColorPicker/__demo__/disabledAlpha.md
@@ -1,0 +1,29 @@
+---
+order: 3
+title:
+  zh-CN: 禁用透明通道
+  en-US: DisabledAlpha
+---
+
+## zh-CN
+
+设置 `disabledAlpha` 以隐藏 Alpha 值滑条和数值显示。 
+
+## en-US
+
+Set `disabledAlpha` to disable the Alpha slider and lock Alpha value.
+
+```js
+import { ColorPicker } from '@arco-design/web-react';
+
+
+const App = () => {
+  return (
+    <div>
+      <ColorPicker defaultValue={'#165DFF'} disabledAlpha />
+    </div>
+  ) ;
+};
+
+export default App;
+```

--- a/components/ColorPicker/__test__/__snapshots__/demo.test.ts.snap
+++ b/components/ColorPicker/__test__/__snapshots__/demo.test.ts.snap
@@ -189,6 +189,20 @@ exports[`renders ColorPicker/demo/disabledAlpha.md correctly 1`] = `
       value="#165DFF"
     />
   </div>
+  <br />
+  <div
+    class="arco-color-picker arco-color-picker-size-default"
+  >
+    <div
+      class="arco-color-picker-preview"
+      style="background-color:#165DFF80"
+    />
+    <input
+      class="arco-color-picker-input"
+      readonly=""
+      value="#165DFF80"
+    />
+  </div>
 </div>
 `;
 

--- a/components/ColorPicker/__test__/__snapshots__/demo.test.ts.snap
+++ b/components/ColorPicker/__test__/__snapshots__/demo.test.ts.snap
@@ -174,6 +174,24 @@ exports[`renders ColorPicker/demo/disabled.md correctly 1`] = `
 </div>
 `;
 
+exports[`renders ColorPicker/demo/disabledAlpha.md correctly 1`] = `
+<div>
+  <div
+    class="arco-color-picker arco-color-picker-size-default"
+  >
+    <div
+      class="arco-color-picker-preview"
+      style="background-color:#165DFF"
+    />
+    <input
+      class="arco-color-picker-input"
+      readonly=""
+      value="#165DFF"
+    />
+  </div>
+</div>
+`;
+
 exports[`renders ColorPicker/demo/format.md correctly 1`] = `
 <div>
   <div

--- a/components/ColorPicker/control-bar.tsx
+++ b/components/ColorPicker/control-bar.tsx
@@ -7,7 +7,6 @@ import { Color } from './interface';
 interface ControlBarProps {
   x: number;
   type?: 'hue' | 'alpha';
-
   colorString: string;
   // for alpha bar use
   color?: Color;

--- a/components/ColorPicker/hooks/useColorPicker.ts
+++ b/components/ColorPicker/hooks/useColorPicker.ts
@@ -7,6 +7,7 @@ interface UseColorPickerProps {
   value?: string;
   defaultValue?: string;
   defaultPopupVisible?: boolean;
+  disabledAlpha?: boolean;
   popupVisible?: boolean;
   format?: 'hex' | 'rgb';
   onChange?: (value: string) => void;
@@ -14,7 +15,7 @@ interface UseColorPickerProps {
 }
 
 export const useColorPicker = (props: UseColorPickerProps) => {
-  const { format, onChange } = props;
+  const { format, onChange, disabledAlpha } = props;
 
   const [value, setValue] = useMergeValue('', props);
 
@@ -82,6 +83,9 @@ export const useColorPicker = (props: UseColorPickerProps) => {
 
   const onHsvChange = (_value: HSV) => {
     setHsv(_value);
+    if (disabledAlpha && alpha !== 100) {
+      setAlpha(100);
+    }
   };
 
   const onAlphaChange = (_value: number) => {

--- a/components/ColorPicker/index.tsx
+++ b/components/ColorPicker/index.tsx
@@ -25,6 +25,7 @@ function ColorPicker(baseProps: ColorPickerProps, ref) {
     className,
     size,
     disabled,
+    disabledAlpha = false,
     triggerProps = {},
     unmountOnExit,
     showText,
@@ -76,6 +77,7 @@ function ColorPicker(baseProps: ColorPickerProps, ref) {
         showPreset={showPreset}
         onHsvChange={onHsvChange}
         onAlphaChange={onAlphaChange}
+        disabledAlpha={disabledAlpha}
       />
     );
   };

--- a/components/ColorPicker/input-alpha.tsx
+++ b/components/ColorPicker/input-alpha.tsx
@@ -5,9 +5,10 @@ import { ConfigContext } from '../ConfigProvider';
 interface InputAlphaProps {
   value: number;
   onChange: (value: number) => void;
+  disabled?: boolean;
 }
 
-export const InputAlpha: React.FC<InputAlphaProps> = ({ value, onChange }) => {
+export const InputAlpha: React.FC<InputAlphaProps> = ({ value, onChange, disabled }) => {
   const { getPrefixCls } = useContext(ConfigContext);
   const prefixCls = getPrefixCls('color-picker');
 
@@ -20,6 +21,7 @@ export const InputAlpha: React.FC<InputAlphaProps> = ({ value, onChange }) => {
       value={Math.round(value * 100)}
       suffix="%"
       onChange={(a) => onChange(a / 100)}
+      disabled={disabled}
     />
   );
 };

--- a/components/ColorPicker/input-alpha.tsx
+++ b/components/ColorPicker/input-alpha.tsx
@@ -5,10 +5,9 @@ import { ConfigContext } from '../ConfigProvider';
 interface InputAlphaProps {
   value: number;
   onChange: (value: number) => void;
-  disabled?: boolean;
 }
 
-export const InputAlpha: React.FC<InputAlphaProps> = ({ value, onChange, disabled }) => {
+export const InputAlpha: React.FC<InputAlphaProps> = ({ value, onChange }) => {
   const { getPrefixCls } = useContext(ConfigContext);
   const prefixCls = getPrefixCls('color-picker');
 
@@ -21,7 +20,6 @@ export const InputAlpha: React.FC<InputAlphaProps> = ({ value, onChange, disable
       value={Math.round(value * 100)}
       suffix="%"
       onChange={(a) => onChange(a / 100)}
-      disabled={disabled}
     />
   );
 };

--- a/components/ColorPicker/input-hex.tsx
+++ b/components/ColorPicker/input-hex.tsx
@@ -10,9 +10,16 @@ interface InputHexProps {
   alpha: number;
   onHsvChange: (value: HSV) => void;
   onAlphaChange: (value: number) => void;
+  disabledAlpha?: boolean;
 }
 
-export const InputHex: React.FC<InputHexProps> = ({ color, alpha, onHsvChange, onAlphaChange }) => {
+export const InputHex: React.FC<InputHexProps> = ({
+  color,
+  alpha,
+  onHsvChange,
+  onAlphaChange,
+  disabledAlpha,
+}) => {
   const { getPrefixCls } = useContext(ConfigContext);
   const prefixCls = getPrefixCls('color-picker');
   const [hex, setHex] = useState(color.hex);
@@ -62,7 +69,9 @@ export const InputHex: React.FC<InputHexProps> = ({ color, alpha, onHsvChange, o
         onPressEnter={onBlur}
         onPaste={onPaste as any}
       />
-      <InputAlpha value={alpha} onChange={onAlphaChange} />
+      {!disabledAlpha && (
+        <InputAlpha value={alpha} onChange={onAlphaChange} disabled={disabledAlpha} />
+      )}
     </Input.Group>
   );
 };

--- a/components/ColorPicker/input-hex.tsx
+++ b/components/ColorPicker/input-hex.tsx
@@ -69,9 +69,7 @@ export const InputHex: React.FC<InputHexProps> = ({
         onPressEnter={onBlur}
         onPaste={onPaste as any}
       />
-      {!disabledAlpha && (
-        <InputAlpha value={alpha} onChange={onAlphaChange} disabled={disabledAlpha} />
-      )}
+      {!disabledAlpha && <InputAlpha value={alpha} onChange={onAlphaChange} />}
     </Input.Group>
   );
 };

--- a/components/ColorPicker/input-rgb.tsx
+++ b/components/ColorPicker/input-rgb.tsx
@@ -11,9 +11,16 @@ interface InputRgbProps {
   alpha: number;
   onHsvChange: (value: HSV) => void;
   onAlphaChange: (value: number) => void;
+  disabledAlpha?: boolean;
 }
 
-export const InputRgb = ({ color, alpha, onHsvChange, onAlphaChange }: InputRgbProps) => {
+export const InputRgb = ({
+  color,
+  alpha,
+  onHsvChange,
+  onAlphaChange,
+  disabledAlpha,
+}: InputRgbProps) => {
   const { getPrefixCls } = useContext(ConfigContext);
   const prefixCls = getPrefixCls('color-picker');
 
@@ -50,7 +57,7 @@ export const InputRgb = ({ color, alpha, onHsvChange, onAlphaChange }: InputRgbP
         value={b}
         onChange={(b) => onInputChange({ r, g, b })}
       />
-      <InputAlpha value={alpha} onChange={onAlphaChange} />
+      {!disabledAlpha && <InputAlpha value={alpha} onChange={onAlphaChange} />}
     </Input.Group>
   );
 };

--- a/components/ColorPicker/panel.tsx
+++ b/components/ColorPicker/panel.tsx
@@ -11,6 +11,7 @@ import { hexToRgb, rgbToHsv } from '../_util/color';
 interface PanelProps {
   color: Color;
   alpha: number;
+  disabledAlpha: boolean;
   colorString: string;
   showHistory?: boolean;
   historyColors?: string[];
@@ -26,6 +27,7 @@ interface PanelProps {
 export const Panel: React.FC<PanelProps> = ({
   color,
   alpha,
+  disabledAlpha,
   colorString,
   historyColors,
   presetColors,
@@ -64,6 +66,7 @@ export const Panel: React.FC<PanelProps> = ({
           alpha={alpha}
           onHsvChange={onHsvChange}
           onAlphaChange={onAlphaChange}
+          disabledAlpha={disabledAlpha}
         />
       );
     }
@@ -73,6 +76,7 @@ export const Panel: React.FC<PanelProps> = ({
         alpha={alpha}
         onHsvChange={onHsvChange}
         onAlphaChange={onAlphaChange}
+        disabledAlpha={disabledAlpha}
       />
     );
   };
@@ -157,13 +161,15 @@ export const Panel: React.FC<PanelProps> = ({
               colorString={colorString}
               onChange={(h) => onHsvChange({ h, s, v })}
             />
-            <ControlBar
-              type="alpha"
-              x={alpha}
-              color={color}
-              colorString={colorString}
-              onChange={onAlphaChange}
-            />
+            {!disabledAlpha && (
+              <ControlBar
+                type="alpha"
+                x={alpha}
+                color={color}
+                colorString={colorString}
+                onChange={onAlphaChange}
+              />
+            )}
           </div>
           <div className={`${prefixCls}-preview`} style={{ backgroundColor: colorString }} />
         </div>

--- a/components/ColorPicker/style/index.less
+++ b/components/ColorPicker/style/index.less
@@ -135,6 +135,7 @@
 
     .@{color-picker-prefix-cls}-control-wrapper {
       display: flex;
+      align-items: center;
 
       .@{color-picker-prefix-cls}-preview {
         margin-left: auto;

--- a/stories/ColorPicker.story.tsx
+++ b/stories/ColorPicker.story.tsx
@@ -8,11 +8,13 @@ export default {
 export const Demo = () => (
   <div style={{ marginTop: 150 }}>
     <ColorPicker size={'mini'} />
-    <br/>
+    <br />
     <ColorPicker size={'small'} />
-    <br/>
+    <br />
     <ColorPicker size={'default'} showPreset showHistory />
-    <br/>
+    <br />
     <ColorPicker size={'large'} />
+    <br />
+    <ColorPicker size={'large'} disabledAlpha />
   </div>
 );


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context

As reported in #2528,  disabledAlpha is in the API doc but not implemented

## Solution

Implement disabledAlpha
<img width="491" alt="Screenshot 2024-02-19 at 8 42 39 PM" src="https://github.com/arco-design/arco-design/assets/8275280/36a56d36-0dd1-47f3-a572-452fda2e0ae4">

<img width="451" alt="Screenshot 2024-02-19 at 8 42 24 PM" src="https://github.com/arco-design/arco-design/assets/8275280/838f1a86-6e1f-4fbc-bb61-42684bc8e94f">

## How is the change tested?

看了下这个组件本身没单元测试，所以就只是更新了快照。

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|ColorPicker| 支持 disabledAlpha | Add support for disabledAlpha  |  #2528  |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->
## Checklist:

- [x] Test suite passes (`npm run test`)
- [x] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [x] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information
