### PR TITLE
fix(image): when src change，set loading

### DIFF
--- a/components/Image/image.tsx
+++ b/components/Image/image.tsx
@@ -84,6 +84,7 @@ function Image(baseProps: ImagePropsType, ref: LegacyRef<HTMLDivElement>) {
   const previewSrc = previewProps.src || src;
   const [showFooter] = useShowFooter({ title, description, actions });
   const { isLoading, isError, isLoaded, isBeforeLoad, setStatus } = useImageStatus('beforeLoad');
+  const loaded = useRef(false);
   const [previewVisible, setPreviewVisible] = useMergeValue(false, {
     defaultValue: previewProps.defaultVisible,
     value: previewProps.visible,
@@ -114,11 +115,13 @@ function Image(baseProps: ImagePropsType, ref: LegacyRef<HTMLDivElement>) {
   const refImg = useRef<HTMLImageElement>();
 
   function onImgLoaded(e) {
+    loaded.current = true;
     setStatus('loaded');
     onLoad && onLoad(e);
   }
 
   function onImgLoadError(e) {
+    loaded.current = true;
     setStatus('error');
     onError && onError(e);
   }
@@ -145,11 +148,17 @@ function Image(baseProps: ImagePropsType, ref: LegacyRef<HTMLDivElement>) {
   });
 
   useEffect(() => {
+    loaded.current = false;
+  }, [src]);
+
+  useEffect(() => {
     if (refImg.current) {
       if (inView) {
         // avoid set img.src to undefined when its doesn't have [src] attribute
         if ((refImg.current.src || src) && refImg.current.src !== src) {
           refImg.current.src = src;
+        }
+        if (!loaded.current) {
           setStatus('loading');
         }
       } else {


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context

<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

## Solution

<!-- Describe how the problem is fixed in detail -->

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|  Image  |   修复 `Image` 组件 `loading` 状态展示的问题   |    Fix the problem of `loading` status display of `Image` component  |   Close #2541    |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->
## Checklist:

- [ ] Test suite passes (`npm run test`)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
