### PR TITLE
enhance(Table): support expanedRows and treeData while Table is virtualized

### DIFF
--- a/components/Table/__demo__/virtualized.md
+++ b/components/Table/__demo__/virtualized.md
@@ -9,15 +9,11 @@ title:
 
 内置虚拟滚动逻辑，设置 `virtualized=true` 开启。
 
-目前虚拟滚动表格受限比较多，开启虚拟滚动后会自动禁用掉展开行、树形数据等逻辑，我们会逐步进行改善。
-
 **注意：** 开启虚拟滚动之后，不要给每一列都设置宽度，要保证有一列自适应，不然可能出现表头表身对不齐的情况。
 
 ## en-US
 
 Built-in virtual scrolling logic, set `virtualized=true` to enable.
-
-At present, the virtual scrolling table is more limited. After the virtual scrolling is turned on, the logic of expanding rows, tree data, etc. will be automatically disabled. We will gradually improve.
 
 **Note:** After enabling virtual scrolling, do not set the width for each column. Make sure that one column is adaptive, otherwise there may be misalignment between the header and the body.
 

--- a/components/Table/style/index.less
+++ b/components/Table/style/index.less
@@ -330,6 +330,11 @@
     }
   }
 
+  // make sure expanded-icon is horizontal-center while using div as td
+  div&-expand-icon-cell {
+    justify-content: center;
+  }
+
   &-cell-expand-icon {
     // https://github.com/arco-design/arco-design/issues/298
     float: left;

--- a/components/Table/tbody/tr.tsx
+++ b/components/Table/tbody/tr.tsx
@@ -95,7 +95,7 @@ function Tr<T>(props: TrType<T>, ref) {
 
   const shouldRenderExpandRow = shouldRowExpand(record, index);
   const recordHaveChildren = isChildrenNotEmpty(record);
-  const haveTreeData = !virtualized && isDataHaveChildren() && !expandedRowRender;
+  const haveTreeData = isDataHaveChildren() && !expandedRowRender;
   const shouldRenderTreeDataExpandRow = haveTreeData && recordHaveChildren;
 
   const expandRowByClick = expandProps.expandRowByClick;


### PR DESCRIPTION


<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [ ] Bug fix
- [x] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|  Table  |  `Table` 组件虚拟滚动开启时支持展开行和树形数据。  |   `Table` component supports expanding rows and tree data when virtual scrolling is turned on.   |   Close #2543  |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->
## Checklist:

- [x] Test suite passes (`npm run test`)
- [x] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [x] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
