### PR TITLE
feat(VirtualList): add parameter for onScroll to notify current list-item index

### DIFF
--- a/components/_class/VirtualList/index.tsx
+++ b/components/_class/VirtualList/index.tsx
@@ -6,6 +6,7 @@ import React, {
   useState,
   ReactNode,
   CSSProperties,
+  UIEvent,
 } from 'react';
 import {
   Key,
@@ -39,7 +40,8 @@ export type RenderFunc<T> = (
 
 type Status = 'NONE' | 'MEASURE_START' | 'MEASURE_DONE';
 
-export interface VirtualListProps<T> extends Omit<React.HTMLAttributes<any>, 'children'> {
+export interface VirtualListProps<T>
+  extends Omit<React.HTMLAttributes<any>, 'children' | 'onScroll'> {
   children: RenderFunc<T>;
   data: T[];
   /* Viewable area height (`2.11.0` starts support `string` type such as `80%`) */
@@ -62,7 +64,7 @@ export interface VirtualListProps<T> extends Omit<React.HTMLAttributes<any>, 'ch
   /** Custom filler outer style */
   outerStyle?: CSSProperties;
   innerStyle?: CSSProperties;
-  onScroll?: React.UIEventHandler<HTMLElement>;
+  onScroll?: (event: UIEvent<HTMLElement>, info: { index: number }) => void;
   wrapperChild?: string | React.FC<any> | React.ComponentClass<any>;
 }
 
@@ -358,7 +360,7 @@ const VirtualList: React.ForwardRefExoticComponent<
       itemOffsetPtg: offsetPtg,
     });
 
-    event && onScroll && onScroll(event);
+    event && onScroll?.(event, { index });
   };
 
   // Modify the state and recalculate the position in the next render
@@ -396,7 +398,7 @@ const VirtualList: React.ForwardRefExoticComponent<
       status: 'MEASURE_START',
     });
 
-    event && onScroll && onScroll(event);
+    event && onScroll?.(event, { index: itemIndex });
   };
 
   useEffect(() => {


### PR DESCRIPTION
## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [x] New feature
- [ ] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|  Common  |  `VirtualListProps.onScroll` 回调新增第二个参数以通知当前视图区域内首个元素的索引。  |  The `VirtualListProps.onScroll` callback adds a second parameter to inform the index of the first element in the current view area.
    |                |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->
## Checklist:

- [ ] Test suite passes (`npm run test`)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
