### PR TITLE
docs: add some descriptions for Form.Item API

### DIFF
--- a/components/Form/README.en-US.md
+++ b/components/Form/README.en-US.md
@@ -54,6 +54,7 @@ A form with data collection, verification and submission functions, including ch
 |extra|Additional hint content.|ReactNode |`-`|-|
 |help|Custom help text|ReactNode |`-`|-|
 |label|Label text|ReactNode |`-`|-|
+|children|`ReactNode` type and Fuction type children|React.ReactNode \| [FormItemChildrenFn](#formitemchildrenfn)&lt;FormData, FieldValue, FieldKey&gt; |`-`|-|
 |className|Additional css class|string \| string[] |`-`|-|
 |dependencies|the dependency fields. When the value of the dependent field changes, trigger its own validation.If you want to dynamically render a form control/form area, use shouldUpdate|string[] |`-`|2.40.0|
 |field|Unique identification of controlled components|FieldKey |`-`|-|
@@ -168,6 +169,19 @@ export type FieldError<FieldValue = any> = {
   type?: string;
   requiredError?: boolean;
 };
+```
+
+### FormItemChildrenFn
+
+```js
+export type FormItemChildrenFn<
+  FormData = any,
+  FieldValue = FormData[keyof FormData],
+  FieldKey extends KeyType = keyof FormData
+> = (
+  formData: any,
+  form: FormInstance<FormData, FieldValue, FieldKey>
+) => React.ReactNode;
 ```
 
 ### Rules

--- a/components/Form/README.en-US.md
+++ b/components/Form/README.en-US.md
@@ -44,6 +44,7 @@ A form with data collection, verification and submission functions, including ch
 |disabled|Whether the FormItem is disabled. Priority is higher than the `disabled` prop of `Form`|boolean |`-`|-|
 |hasFeedback|Whether to show the verification icon, configure `validateStatus` to use.|boolean |`-`|-|
 |hidden|hide the form item|boolean |`-`|2.29.0|
+|isFormList|Whether the FormItem is `Form.List`|boolean |`-`|-|
 |required|Whether The FormItem is Required, Will display an red symbol in front of the `label` label.If it is not set here, it will look for `required` from the rules|boolean |`-`|-|
 |trigger|When to take over and collecting the child nodes.|string |`onChange`|-|
 |triggerPropName|The attribute name of the child node being taken over, default is `value`, ex, `<Checkbox>` is `checked`.|string |`value`|-|

--- a/components/Form/README.en-US.md
+++ b/components/Form/README.en-US.md
@@ -49,6 +49,7 @@ A form with data collection, verification and submission functions, including ch
 |trigger|When to take over and collecting the child nodes.|string |`onChange`|-|
 |triggerPropName|The attribute name of the child node being taken over, default is `value`, ex, `<Checkbox>` is `checked`.|string |`value`|-|
 |labelAlign|Text alignment of `label`|'left' \| 'right' |`right`|-|
+|layout|The layout|'horizontal' \| 'vertical' \| 'inline' |`-`|-|
 |requiredSymbol|Whether show red symbol when item is required，Set position props, you can choose to place the symbol before/after the label|boolean \| { position: 'start' \| 'end' } |`true`|`position` in 2.24.0|
 |validateStatus|Validate status|'success' \| 'warning' \| 'error' \| 'validating' |`-`|-|
 |colon|Whether show colon after `label`. Priority is lower than `colon` in `Form.Item`.(`ReactNode` in `v2.41.0`)|boolean \| ReactNode |`-`|-|

--- a/components/Form/README.en-US.md
+++ b/components/Form/README.en-US.md
@@ -44,7 +44,6 @@ A form with data collection, verification and submission functions, including ch
 |disabled|Whether the FormItem is disabled. Priority is higher than the `disabled` prop of `Form`|boolean |`-`|-|
 |hasFeedback|Whether to show the verification icon, configure `validateStatus` to use.|boolean |`-`|-|
 |hidden|hide the form item|boolean |`-`|2.29.0|
-|isFormList|Whether the FormItem is `Form.List`|boolean |`-`|-|
 |required|Whether the FormItem is Required, Will display an red symbol in front of the `label` label.If it is not set here, it will look for `required` from the rules|boolean |`-`|-|
 |trigger|When to take over and collecting the child nodes.|string |`onChange`|-|
 |triggerPropName|The attribute name of the child node being taken over, default is `value`, ex, `<Checkbox>` is `checked`.|string |`value`|-|

--- a/components/Form/README.en-US.md
+++ b/components/Form/README.en-US.md
@@ -45,7 +45,7 @@ A form with data collection, verification and submission functions, including ch
 |hasFeedback|Whether to show the verification icon, configure `validateStatus` to use.|boolean |`-`|-|
 |hidden|hide the form item|boolean |`-`|2.29.0|
 |isFormList|Whether the FormItem is `Form.List`|boolean |`-`|-|
-|required|Whether The FormItem is Required, Will display an red symbol in front of the `label` label.If it is not set here, it will look for `required` from the rules|boolean |`-`|-|
+|required|Whether the FormItem is Required, Will display an red symbol in front of the `label` label.If it is not set here, it will look for `required` from the rules|boolean |`-`|-|
 |trigger|When to take over and collecting the child nodes.|string |`onChange`|-|
 |triggerPropName|The attribute name of the child node being taken over, default is `value`, ex, `<Checkbox>` is `checked`.|string |`value`|-|
 |labelAlign|Text alignment of `label`|'left' \| 'right' |`right`|-|

--- a/components/Form/README.zh-CN.md
+++ b/components/Form/README.zh-CN.md
@@ -44,6 +44,7 @@
 |disabled|是否禁用，优先级高于 `Form` 的 `disabled` 属性|boolean |`-`|-|
 |hasFeedback|是否显示校验图标，配置 validateStatus 使用。|boolean |`-`|-|
 |hidden|隐藏表单项. 表单字段值仍然会被获取|boolean |`-`|2.29.0|
+|isFormList|是否为 `FormList`|boolean |`-`|-|
 |required|是否必选，会在 `label` 标签前显示加重红色符号，如果这里不设置，会从 rules 中寻找是否是 required|boolean |`-`|-|
 |trigger|接管子节点，搜集子节点值的时机。|string |`onChange`|-|
 |triggerPropName|子节点被接管的值的属性名，默认是 `value`,比如 `<Checkbox>` 为 `checked`。|string |`value`|-|

--- a/components/Form/README.zh-CN.md
+++ b/components/Form/README.zh-CN.md
@@ -49,6 +49,7 @@
 |trigger|接管子节点，搜集子节点值的时机。|string |`onChange`|-|
 |triggerPropName|子节点被接管的值的属性名，默认是 `value`,比如 `<Checkbox>` 为 `checked`。|string |`value`|-|
 |labelAlign|标签的文本对齐方式，优先级高于 `Form`|'left' \| 'right' |`right`|-|
+|layout|布局|'horizontal' \| 'vertical' \| 'inline' |`-`|-|
 |requiredSymbol|是否在 required 的时候显示加重的红色星号，设置 position 可选择将星号置于 label 前/后|boolean \| { position: 'start' \| 'end' } |`true`|`position` in 2.24.0|
 |validateStatus|校验状态|'success' \| 'warning' \| 'error' \| 'validating' |`-`|-|
 |colon|是否显示标签后的一个冒号，优先级小于 `Form.Item` 中 `colon` 的优先级。(`ReactNode` in `v2.41.0`)|boolean \| ReactNode |`-`|-|

--- a/components/Form/README.zh-CN.md
+++ b/components/Form/README.zh-CN.md
@@ -44,7 +44,6 @@
 |disabled|是否禁用，优先级高于 `Form` 的 `disabled` 属性|boolean |`-`|-|
 |hasFeedback|是否显示校验图标，配置 validateStatus 使用。|boolean |`-`|-|
 |hidden|隐藏表单项. 表单字段值仍然会被获取|boolean |`-`|2.29.0|
-|isFormList|是否为 `FormList`|boolean |`-`|-|
 |required|是否必选，会在 `label` 标签前显示加重红色符号，如果这里不设置，会从 rules 中寻找是否是 required|boolean |`-`|-|
 |trigger|接管子节点，搜集子节点值的时机。|string |`onChange`|-|
 |triggerPropName|子节点被接管的值的属性名，默认是 `value`,比如 `<Checkbox>` 为 `checked`。|string |`value`|-|

--- a/components/Form/README.zh-CN.md
+++ b/components/Form/README.zh-CN.md
@@ -54,6 +54,7 @@
 |extra|额外的提示内容。|ReactNode |`-`|-|
 |help|自定义校验文案|ReactNode |`-`|-|
 |label|标签的文本|ReactNode |`-`|-|
+|children|`ReactNode` 类型与函数类型的 children|React.ReactNode \| [FormItemChildrenFn](#formitemchildrenfn)&lt;FormData, FieldValue, FieldKey&gt; |`-`|-|
 |className|节点类名|string \| string[] |`-`|-|
 |dependencies|设置依赖字段。当依赖的字段值改变时，触发自身的校验。如果是想动态渲染某个表单控件/表单区域，使用 shouldUpdate|string[] |`-`|2.40.0|
 |field|受控组件的唯一标示|FieldKey |`-`|-|
@@ -168,6 +169,19 @@ export type FieldError<FieldValue = any> = {
   type?: string;
   requiredError?: boolean;
 };
+```
+
+### FormItemChildrenFn
+
+```js
+export type FormItemChildrenFn<
+  FormData = any,
+  FieldValue = FormData[keyof FormData],
+  FieldKey extends KeyType = keyof FormData
+> = (
+  formData: any,
+  form: FormInstance<FormData, FieldValue, FieldKey>
+) => React.ReactNode;
 ```
 
 ### Rules

--- a/components/Form/interface.tsx
+++ b/components/Form/interface.tsx
@@ -393,8 +393,7 @@ export interface FormItemProps<
    */
   requiredSymbol?: boolean | { position: 'start' | 'end' };
   /**
-   * @zh 是否为 `FormList`
-   * @en Whether the FormItem is `Form.List`
+   * 内部使用属性，无需在文档上体现
    */
   isFormList?: boolean;
   /**

--- a/components/Form/interface.tsx
+++ b/components/Form/interface.tsx
@@ -308,7 +308,7 @@ export interface FormItemProps<
    * @zh
    * 是否必选，会在 `label` 标签前显示加重红色符号，如果这里不设置，会从 rules 中寻找是否是 required
    * @en
-   * Whether The FormItem is Required, Will display an red symbol in front of the `label` label.
+   * Whether the FormItem is Required, Will display an red symbol in front of the `label` label.
    * If it is not set here, it will look for `required` from the rules
    */
   required?: boolean;

--- a/components/Form/interface.tsx
+++ b/components/Form/interface.tsx
@@ -388,6 +388,10 @@ export interface FormItemProps<
    * @version `position` in 2.24.0
    */
   requiredSymbol?: boolean | { position: 'start' | 'end' };
+  /**
+   * @zh 是否为 `FormList`
+   * @en Whether the FormItem is `Form.List`
+   */
   isFormList?: boolean;
   /**
    * @zh `ReactNode` 类型与函数类型的 children

--- a/components/Form/interface.tsx
+++ b/components/Form/interface.tsx
@@ -389,6 +389,10 @@ export interface FormItemProps<
    */
   requiredSymbol?: boolean | { position: 'start' | 'end' };
   isFormList?: boolean;
+  /**
+   * @zh `ReactNode` 类型与函数类型的 children
+   * @en `ReactNode` type and Fuction type children
+   */
   children?: React.ReactNode | FormItemChildrenFn<FormData, FieldValue, FieldKey>;
 }
 

--- a/components/Form/interface.tsx
+++ b/components/Form/interface.tsx
@@ -380,6 +380,10 @@ export interface FormItemProps<
    * @defaultValue right
    */
   labelAlign?: 'left' | 'right';
+  /**
+   * @zh 布局
+   * @en The layout
+   */
   layout?: 'horizontal' | 'vertical' | 'inline';
   /**
    * @zh 是否在 required 的时候显示加重的红色星号，设置 position 可选择将星号置于 label 前/后

--- a/components/Modal/README.en-US.md
+++ b/components/Modal/README.en-US.md
@@ -17,7 +17,7 @@ Open a floating layer on the current page to carry related operations.
 |alignCenter|Modal is centered vertically and horizontally|boolean |`true`|-|
 |autoFocus|Whether to focus the first focusable element|boolean |`true`|-|
 |closable|Whether to show the close button in TitleBar|boolean |`-`|-|
-|confirmLoading|Whether The `ok` button is loading|boolean |`-`|-|
+|confirmLoading|Whether the `ok` button is loading|boolean |`-`|-|
 |escToExit|Whether enable press `ESC` to close Modal|boolean |`true`|-|
 |focusLock|Whether to lock the focus in the Modal|boolean |`true`|-|
 |mask|Whether show mask|boolean |`true`|-|

--- a/components/Modal/interface.ts
+++ b/components/Modal/interface.ts
@@ -116,7 +116,7 @@ export interface ModalProps {
   afterClose?: () => void;
   /**
    * @zh 确认按钮加载中
-   * @en Whether The `ok` button is loading
+   * @en Whether the `ok` button is loading
    */
   confirmLoading?: boolean;
   /**


### PR DESCRIPTION
## Types of changes

- [ ] New feature
- [ ] Bug fix
- [ ] Enhancement
- [x] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context

Some of the `Form.Item` API docs are missing

## Solution

### 1. Add missing docs
Add children description for Form.Item API
Add isFormList description for Form.Item API
Add layout description for Form.Item API

|Property|Description|Type|DefaultValue|Version|
|---|---|---|---|---|
|children|`React.ReactNode` type and Fuction type children| React.ReactNode \| (formData: any, form: FormInstance<FormData, FieldValue, FieldKey>) => React.ReactNode |`-`|-|
|layout|布局|'horizontal' \| 'vertical' \| 'inline' |`-`|-|

### 2. Fix two typos from `Whether The` to `Whether the`

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|           |               |               |                |

## Checklist:

- [x] Test suite passes (`npm run test`)
- [x] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [x] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)