### PR TITLE
fix: Images stuck in loading state when triggered by memory cache for…

### DIFF
--- a/components/Image/image.tsx
+++ b/components/Image/image.tsx
@@ -158,7 +158,7 @@ function Image(baseProps: ImagePropsType, ref: LegacyRef<HTMLDivElement>) {
         if ((refImg.current.src || src) && refImg.current.src !== src) {
           refImg.current.src = src;
         }
-        if (!loaded.current) {
+        if (!loaded.current && !refImg.current.complete) {
           setStatus('loading');
         }
       } else {


### PR DESCRIPTION
… image links

<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [x] Bug fix

## Background and context
当我使用云存储图片链接时，浏览器第二次加载会使用内存存储，这时Image组件不显示任何东西（我没有开启lazyload），打开元素审查发现他应用了loading的状态类
<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

## Solution
我看到运行时img标签的onload事件会先于设置loading状态的执行，所以导致设置loading状态后并不会再执行onload使组件回到正确的状态，所以我在设置loading状态的判断条件里加入了当前实例的complete属性的判断。
<!-- Describe how the problem is fixed in detail -->

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|        Image   |      修复了图片链接触发内存缓存时图片一直处于loading状态的问题         |     Fixed the issue where images stuck in loading state when triggered by memory cache for image links          |         #2586       |
