### PR TITLE
style:  fix input width overflow in Transfer&ColorPicker

### DIFF
--- a/components/ColorPicker/style/index.less
+++ b/components/ColorPicker/style/index.less
@@ -158,7 +158,7 @@
       .@{color-picker-prefix-cls}-group-wrapper {
         margin-left: @color-panel-input-group-margin-left;
         display: flex;
-        flex: 1;
+        width: calc(100% - @color-panel-input-group-margin-left - @color-panel-format-select-width);
       }
 
       .@{prefix}-select-view,

--- a/components/Transfer/style/index.less
+++ b/components/Transfer/style/index.less
@@ -19,6 +19,9 @@
     &-search {
       padding: @transfer-search-padding-top @transfer-search-padding-right
         @transfer-search-padding-bottom @transfer-search-padding-left;
+      .@{prefix}-input-group-wrapper {
+        max-width: 100%;
+      }
     }
 
     &-list {


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [x] Bug fix

## Background and context

<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->
问题：
分析 [issues #2627](https://github.com/arco-design/arco-design/issues/2627)，并排查所有组件发现：

- Transfer、ColorPicker 都会被 ConfigProvider 中设置了 Input 的宽度影响样式
- 其他内部依赖 Input 组件的不会被影响，包括：Cascader、Slider、VerificationCode、AutoComplete、Select、InputTag、InputNumber、Mentions

<img width="1172" alt="image" src="https://github.com/arco-design/arco-design/assets/20812315/194670c8-3b39-4028-80af-26479a4df659">


## Solution

<!-- Describe how the problem is fixed in detail -->
- 修改 Transfer、ColorPicker 中的宽度限制

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|     Transfer      |       修复  Transfer 组件因为 ConfigProvider 组件中设置了 Input 的宽度造成样式错乱问题      |       Fix the styling issue in the Transfer component caused by the width setting of Input in the ConfigProvider component        |    [#2627](https://github.com/arco-design/arco-design/issues/2627)         | 
|     ColorPicker       |      修复   ColorPicker  组件因为 ConfigProvider 组件中设置了 Input 的宽度造成样式错乱问题         |   Fix the styling issue in the ColorPicker component caused by the width setting of Input in the ConfigProvider component                |    |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->
## Checklist:

- [x] Test suite passes (`npm run test`)
- [x] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [x] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
