### PR TITLE
fix: change tab behavior for RangePicker and reuse focused style while focused

### DIFF
--- a/components/_class/picker/input.tsx
+++ b/components/_class/picker/input.tsx
@@ -5,6 +5,7 @@ import React, {
   useContext,
   CSSProperties,
   ReactNode,
+  useState,
 } from 'react';
 import { Dayjs } from 'dayjs';
 import omit from '../../_util/omit';
@@ -73,6 +74,7 @@ function DateInput(
 ) {
   const { getPrefixCls, size: ctxSize, locale, rtl } = useContext(ConfigContext);
   const input = useRef<HTMLInputElement>(null);
+  const [focused, setFocused] = useState(false);
   const size = propSize || ctxSize;
 
   useImperativeHandle<any, DateInputHandle>(ref, () => ({
@@ -114,11 +116,12 @@ function DateInput(
   const prefixCls = propPrefixCls || getPrefixCls('picker');
 
   const inputStatus = status || (error ? 'error' : undefined);
+  const mergedFocused = focused || popupVisible;
   const classNames = cs(
     prefixCls,
     `${prefixCls}-size-${size}`,
     {
-      [`${prefixCls}-focused`]: !!popupVisible,
+      [`${prefixCls}-focused`]: mergedFocused,
       [`${prefixCls}-disabled`]: disabled,
       [`${prefixCls}-has-prefix`]: prefix,
       [`${prefixCls}-${inputStatus}`]: inputStatus,
@@ -143,6 +146,14 @@ function DateInput(
           onKeyDown={onKeyDown}
           onChange={onChangeInput}
           {...readOnlyProps}
+          onFocus={() => {
+            if (!disabled && editable) {
+              setFocused(true);
+            }
+          }}
+          onBlur={() => {
+            setFocused(false);
+          }}
         />
       </div>
       <div className={`${prefixCls}-suffix`}>


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context

当前组件存在两个问题：

1. DatePicker 和 RangePicker 缺少 `onFocus` 事件的样式，导致在使用 Tab 键和 `ref.current.focus()` 方法的时候没有正确显示聚焦样式
2.  RangePicker 组件使用 Tab 键切换焦点的时候，无法在组件的两个 `<input />` 之间切换，也无法通过Tab将焦点切换到其他组件上

Two issues of current components:
1. DatePicker and RangePicker lack the style of `onFocus` event, causing the focused style to not be displayed correctly when using Tab and `ref.current.focus()` method.
2. When using Tab to move the focus point inside RangePicker, the focusing point cannot be moved from one `<input />` components to the other, and the focus point cannot be moved away from RangePicker by using Tab.

| 现有效果 Current Behavior with Tab | 期待效果 Expected Behavior with Tab | 
| --------- | ------------- |
| 一旦进入RangePicker，则焦点不能切走 Once focused on RangePicker, the focus point cannot be moved away | 聚焦时正确显示样式，并且可以使用 Tab 切换焦点 Styles can be displayed correctly when get focused, and focus point can be moved with Tab |
| ![current-tab-behavior](https://github.com/arco-design/arco-design/assets/29125211/dfaf09df-2639-446c-945e-98c2d9cca751) | ![expected-tab-behavior](https://github.com/arco-design/arco-design/assets/29125211/64d154a8-7cd5-4ab6-8115-c749fec394a2) | 

## Solution

<!-- Describe how the problem is fixed in detail -->

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
| DatePicker, DatePicker.MonthPicker, DatePicker.YearPicker, DatePicker.WeekPicker, DatePicker.QuarterPicker, DatePicker.RangePicker | DatePicker等组件单纯focus（非点击）的时候，也显示focused的样式 | Components such as Date Picker also display the focused style when they are purely focused (not by click) | |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->
## Checklist:

- [ ] Test suite passes (`npm run test`)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
