### PR TITLE
chore: fix typo in text forceUpdate

### DIFF
--- a/components/Cascader/hook/useRefCurrent.ts
+++ b/components/Cascader/hook/useRefCurrent.ts
@@ -4,7 +4,7 @@ import useUpdate from '../../_util/hooks/useUpdate';
 
 function useCurrentRef<T>(initFunc: () => T, deps: DependencyList): T {
   const ref = useRef<T>(null);
-  const forceUdpate = useForceUpdate();
+  const forceUpdate = useForceUpdate();
 
   if (!ref.current) {
     ref.current = initFunc();
@@ -12,7 +12,7 @@ function useCurrentRef<T>(initFunc: () => T, deps: DependencyList): T {
 
   useUpdate(() => {
     ref.current = initFunc();
-    forceUdpate();
+    forceUpdate();
   }, [...deps]);
 
   return ref.current;


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [ ] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [x] Others 

## Background and context

Fixed a small typo in text `forceUdpate`, it should be `forceUpdate`.

## Solution

<!-- Describe how the problem is fixed in detail -->

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|              |               |               |                |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->
## Checklist:

- [ ] Test suite passes (`npm run test`)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
