### PR TITLE
fix: Trigger component content will not pop up

### DIFF
--- a/components/Trigger/index.tsx
+++ b/components/Trigger/index.tsx
@@ -879,6 +879,10 @@ class Trigger extends PureComponent<TriggerProps, TriggerState> {
   };
 
   getContainer = () => {
+    if (!this.isDidMount) {
+      return null;
+    }
+
     const popupContainer = document.createElement('div');
 
     popupContainer.style.width = '100%';


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context

<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

## Solution

<!-- Describe how the problem is fixed in detail -->

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
| Trigger | 修复某些情况下 Trigger 组件 popupVisible 属性默认为 True 时内容没有弹出的问题  |  Fix the issue that the content is not popped up when the Trigger component popupVisible property is defaulted to True in some cases.  | https://github.com/arco-design/arco-design/issues/2811 |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->
## Checklist:

- [ ] Test suite passes (`npm run test`)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
In some cases, Portal getContainer may be called before the componentDidMount of the index file
https://github.com/arco-design/arco-design/blob/8593792df73de56e18990eba01d8e3265f4be8a0/components/Trigger/portal.tsx#L20

At this time, since this.isDidMount is false, it will cause the container not to be added to the rootElement
https://github.com/arco-design/arco-design/blob/8593792df73de56e18990eba01d8e3265f4be8a0/components/Trigger/index.tsx#L859-L893

And because getContainer returns an element that has not been added to the rootElement, it will cause getContainer not to be called again.
https://github.com/arco-design/arco-design/blob/8593792df73de56e18990eba01d8e3265f4be8a0/components/Trigger/portal.tsx#L15-L21

This will lead to the content not being able to pop up, so it is necessary to add an isDidMount check in getContainer.




