### PR TITLE
fix: 解决当Drawer内部组件获取到焦点后escToExit失效

### DIFF
--- a/components/Drawer/index.tsx
+++ b/components/Drawer/index.tsx
@@ -212,7 +212,7 @@ function Drawer(baseProps: DrawerProps, ref) {
       <div
         {...omit(rest, ['onCancel', 'onOk'])}
         ref={drawerWrapperRef}
-        onKeyDown={(e) => {
+        onKeyUp={(e) => {
           const keyCode = e.keyCode || e.which;
           if (keyCode === Esc.code) {
             if (escToExit && visible) {


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context
Drawer开启escToExit后，内部使用Select组件，当Select获取焦点后，Drawer的ESC关闭失效。

<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

## Solution
Drawer内部其他组件获取焦点后，不会触发onKeyDown，需要替换成onKeyUp事件。
这里我建议不主动在组件内部调用 e.stopPropagation();来防止Drawer嵌套Drawer组件时，按ESC关闭会导致所有的Drawer关闭。因为按下ESC默认关闭所有的Drawer可能某些场景下需要。

<!-- Describe how the problem is fixed in detail -->

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|   Drawer        |  解决Drawer内部其他组件获取焦点后，不会触发onKeyDown             |    onKeyDown is not triggered when the focus is obtained by other components inside the Drawer.           |       https://github.com/arco-design/arco-design/pull/2812         |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->
## Checklist:

- [x] Test suite passes (`npm run test`)
- [x] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [x] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information
运行npm run test测试用例报错，这个错误应该不是我修改的代码造成的。
<img width="791" alt="image" src="https://github.com/user-attachments/assets/f469fce0-cb6c-4d4d-968a-527f5b7756b6">


<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
