### PR TITLE
fix:InputNumber autoFocus 导致value被清空

### DIFF
--- a/components/InputNumber/index.tsx
+++ b/components/InputNumber/index.tsx
@@ -239,9 +239,12 @@ function InputNumber(baseProps: InputNumberProps, ref) {
     },
     onFocus: (e) => {
       // Both tab and button click trigger focus event. This can be used to determine whether user has taken operations
-      refHasOperateSincePropValueChanged.current = true;
-      setInputValue(refInput.current?.dom?.value);
-      onFocus?.(e);
+      const timeoutId = setTimeout(() => {
+        refHasOperateSincePropValueChanged.current = true;
+        setInputValue(refInput.current?.dom?.value);
+        onFocus?.(e);
+        clearTimeout(timeoutId);
+      }, 0);
     },
     onBlur: (e) => {
       setValue(getLegalValue(value), 'outOfRange');


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context
InputNumber设置autoFocus后，使用Switch来回切换，输入字母导致value被清空。

<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

## Solution
InputNumber 设置autoFocus后，使用Switch来回切换InputNumber在执行onFocus还原上一次值的时候setInputValue(refInput.current?.dom?.value); refInput.current可能会为空，onFocus事件早于ref的赋值。当再次输入字母时候并不会触发setValue，但是会触发displayedInputValue的重新计算，但是这个时候inputValue为空字符串，进而导致input的value值为空字符串。触发onFocus使用setTimeout来保证refInput.current不会为空。
输入数字正常是因为正常触发了setValue，但是输入字母不会触发setValue导致inputValue还是初始值空字符串。
 
<!-- Describe how the problem is fixed in detail -->

## How is the change tested?
来回切换Switch上一次值不会被清空。

<img width="1018" alt="image" src="https://github.com/user-attachments/assets/f3405f37-0a67-4e30-b5d6-6c8ec34abb17">



<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|    InputNumber       |     InputNumber设置autoFocus后，使用Switch来回切，输入字母导致value被清空 。         |   InputNumber After autoFocus is set, Switch is used to cut back and forth. When a letter is entered, the value is cleared            |       https://github.com/arco-design/arco-design/issues/2818         |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->
## Checklist:

- [x] Test suite passes (`npm run test`)
- [x] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [x] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
