### PR TITLE
fix(ColorPicker): use the size form ConfigProvider when there is no size property

### DIFF
--- a/components/ColorPicker/index.tsx
+++ b/components/ColorPicker/index.tsx
@@ -15,7 +15,7 @@ const defaultProps: ColorPickerProps = {
 };
 
 function ColorPicker(baseProps: React.PropsWithChildren<ColorPickerProps>, ref) {
-  const { getPrefixCls, componentConfig } = useContext(ConfigContext);
+  const { getPrefixCls, componentConfig, size: ctxSize } = useContext(ConfigContext);
   const props = useMergeProps<ColorPickerProps>(
     baseProps,
     defaultProps,
@@ -59,10 +59,12 @@ function ColorPicker(baseProps: React.PropsWithChildren<ColorPickerProps>, ref) 
       return customTriggerElement;
     }
 
+    const actualSize = size || ctxSize;
+
     return (
       <div
         className={cs(prefixCls, className, {
-          [`${prefixCls}-size-${size}`]: size,
+          [`${prefixCls}-size-${actualSize}`]: actualSize,
           [`${prefixCls}-disabled`]: disabled,
         })}
         style={style}

--- a/components/ColorPicker/index.tsx
+++ b/components/ColorPicker/index.tsx
@@ -18,7 +18,7 @@ function ColorPicker(baseProps: React.PropsWithChildren<ColorPickerProps>, ref) 
   const { getPrefixCls, componentConfig, size: ctxSize } = useContext(ConfigContext);
   const props = useMergeProps<ColorPickerProps>(
     baseProps,
-    defaultProps,
+    { ...defaultProps, size: ctxSize || defaultProps.size },
     componentConfig?.ColorPicker
   );
   const {
@@ -59,12 +59,10 @@ function ColorPicker(baseProps: React.PropsWithChildren<ColorPickerProps>, ref) 
       return customTriggerElement;
     }
 
-    const actualSize = size || ctxSize;
-
     return (
       <div
         className={cs(prefixCls, className, {
-          [`${prefixCls}-size-${actualSize}`]: actualSize,
+          [`${prefixCls}-size-${size}`]: size,
           [`${prefixCls}-disabled`]: disabled,
         })}
         style={style}

--- a/stories/ColorPicker.story.tsx
+++ b/stories/ColorPicker.story.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ColorPicker } from '@self';
+import { ColorPicker, ConfigProvider } from '@self';
 
 export default {
   title: 'ColorPicker',
@@ -7,6 +7,26 @@ export default {
 
 export const Demo = () => (
   <div style={{ marginTop: 150 }}>
+    {/* 使用 ConfigProvider 的组件默认配置。这里取值 mini */}
+    <ConfigProvider componentConfig={{ ColorPicker: { size: 'mini' } }}>
+      <ColorPicker />
+    </ConfigProvider>
+    <br />
+    {/* 使用 ConfigProvider 的 size 配置。这里取值 small */}
+    <ConfigProvider size="small">
+      <ColorPicker />
+    </ConfigProvider>
+    <br />
+    {/* ConfigPrivider 的组件默认值优先于ConfigPrivider 的 size。这里取值 default */}
+    <ConfigProvider componentConfig={{ ColorPicker: { size: 'default' } }} size="small">
+      <ColorPicker />
+    </ConfigProvider>
+    <br />
+    {/* 组件的优先级最高，这里取值 large */}
+    <ConfigProvider componentConfig={{ ColorPicker: { size: 'default' } }} size="small">
+      <ColorPicker size="large" />
+    </ConfigProvider>
+    <br />
     <ColorPicker size={'mini'} />
     <br />
     <ColorPicker size={'small'} />


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context

<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

fix #2821 

## Solution

<!-- Describe how the problem is fixed in detail -->

仿照Button组件方式，使用 ConfigContext 的 size

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|      ColorPicker     |      修复 `ConfigProvider` 对 `ColorPicker` 提供的 size 属性不生效 bug。         |   Fixed the bug that the size attribute provided by `ConfigProvider` for `ColorPicker` does not take effect.       |   close    #2821          |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->
## Checklist:

- [x] Test suite passes (`npm run test`)
- [x] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [x] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
