### PR TITLE
fix: InputNumber受控情况下onchange里直接设置受控的value值，并不会直接变化，失去焦点才会变化

### DIFF
--- a/components/InputNumber/index.tsx
+++ b/components/InputNumber/index.tsx
@@ -194,9 +194,7 @@ function InputNumber(baseProps: InputNumberProps, ref) {
   const displayedInputValue = useMemo<string>(() => {
     let _value: string;
 
-    if (isUserTyping) {
-      _value = parser ? `${parser(inputValue)}` : inputValue;
-    } else if (isNumber(mergedPrecision)) {
+    if (isNumber(mergedPrecision)) {
       _value = value.toString({ safe: true, precision: mergedPrecision });
     } else if (value.isInvalid) {
       _value = '';
@@ -205,7 +203,7 @@ function InputNumber(baseProps: InputNumberProps, ref) {
     }
 
     return formatter ? formatter(_value, { userTyping: isUserTyping, input: inputValue }) : _value;
-  }, [value, inputValue, isUserTyping, mergedPrecision, parser, formatter]);
+  }, [value, inputValue, isUserTyping, mergedPrecision, formatter]);
 
   const updateSelectionRangePosition = useSelectionRange({
     inputElement: refInput.current?.dom,


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context
InputNumber受控情况下onchange里直接设置受控的value值，并不会直接变化，失去焦点才会变化

<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

## Solution
InputNumber中displayedInputValue是传给Input组件的value值，在计算displayedInputValue时候，当isUserTyping为true（用户正在输入），计算_value使用的是inputValue而不是value，value是通过props.value和innerValue计算得到，<br/>
``` javascript
const value = useMemo<Decimal>(() => {
    return 'value' in props ? getDecimal(props.value) : innerValue;
  }, [props.value, innerValue]);
```
所以应该使用value来计算displayedInputValue。
原来的：
``` javascript
const displayedInputValue = useMemo<string>(() => {
    let _value: string;
    if (isUserTyping) {
      _value = parser ? `${parser(inputValue)}` : inputValue;
    } else if (isNumber(mergedPrecision)) {
      _value = value.toString({ safe: true, precision: mergedPrecision });
    } else if (value.isInvalid) {
      _value = '';
    } else {
      _value = value.toString();
    }

    return formatter ? formatter(_value, { userTyping: isUserTyping, input: inputValue }) : _value;
  }, [value, inputValue, isUserTyping, mergedPrecision, parser, formatter]);
```
修改后：
``` javascript
  const displayedInputValue = useMemo<string>(() => {
    let _value: string;
   if (isNumber(mergedPrecision)) {
      _value = value.toString({ safe: true, precision: mergedPrecision });
    } else if (value.isInvalid) {
      _value = '';
    } else {
      _value = value.toString();
    }

    return formatter ? formatter(_value, { userTyping: isUserTyping, input: inputValue }) : _value;
  }, [value, inputValue, isUserTyping, mergedPrecision, formatter]);
```

```javascript
_value = parser ? `${parser(inputValue)}` : inputValue;
```
这行可以删除，直接使用value就行，用户如果没有传"value"属性，那么value=innerValue，而innerValue就是通过parser处理过的也就是innerValue=parser(inputValue)，如果用户传入"value"属性，那么直接使用用户传进来的value值。
```javascript
formatter(_value, { userTyping: isUserTyping, input: inputValue })
```
formatter函数里依然是input: inputValue，没有修改是因为formatter第一个参数已经是value值（也就是外部传进来的值或者经过parser处理过后的innerValue）， input: inputValue是告诉外部使用者，用户实际的输入值，如果某些情况下二者不同，是开发者自己处理的结果，比如开发者主动传入"value"属性。

<!-- Describe how the problem is fixed in detail -->

## How is the change tested?

<img width="1357" alt="image" src="https://github.com/user-attachments/assets/7b81aa8e-3b1c-46ba-8cd5-5faa486ec67b">


<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|    InputNumber       |    InputNumber受控情况下onchange里直接设置受控的value值，并不会直接变化，失去焦点才会变化           |         InputNumber Under controlled conditions, the controlled value is directly set in onchange and does not change directly. When the focus is lost, the value changes      |       https://github.com/arco-design/arco-design/issues/2751         |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->
## Checklist:

- [x] Test suite passes (`npm run test`)
- [x] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [x] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information
运行npm run test 会出现很多错误，项目中的测试单元代码错误造成的，下面
<InputNumber defaultValue={8} min={0} max={15} />
最大值是15，输入123输出15是没有问题的。

<img width="849" alt="image" src="https://github.com/user-attachments/assets/3ae95c4a-ae26-445f-816c-c1dc0476aab2">



<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
