### PR TITLE
仅当表格可见时，修改表格尺寸

### DIFF
--- a/components/Table/table.tsx
+++ b/components/Table/table.tsx
@@ -540,8 +540,10 @@ function Table<T extends unknown>(baseProps: TableProps<T>, ref: React.Ref<Table
       const ele =
         root.querySelector(`.${prefixCls}-body`) ||
         root.querySelector(`.${prefixCls}-content-inner`);
-      const tableViewWidth = ele.getBoundingClientRect().width;
-      setTableViewWidth(tableViewWidth);
+      if(checkIsVisible(ele){
+        const tableViewWidth = ele.getBoundingClientRect().width;
+        setTableViewWidth(tableViewWidth);
+      }
     }
   }
 

--- a/components/Table/table.tsx
+++ b/components/Table/table.tsx
@@ -540,7 +540,7 @@ function Table<T extends unknown>(baseProps: TableProps<T>, ref: React.Ref<Table
       const ele =
         root.querySelector(`.${prefixCls}-body`) ||
         root.querySelector(`.${prefixCls}-content-inner`);
-      if(checkIsVisible(ele){
+      if(ele&&ele.offsetParent){
         const tableViewWidth = ele.getBoundingClientRect().width;
         setTableViewWidth(tableViewWidth);
       }


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context

<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

## Solution

<!-- Describe how the problem is fixed in detail -->

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|           |               |               |                |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->
## Checklist:

- [ ] Test suite passes (`npm run test`)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
