### PR TITLE
fix: type error

### DIFF
--- a/components/Table/interface.tsx
+++ b/components/Table/interface.tsx
@@ -549,7 +549,6 @@ export interface ColumnProps<T = any> {
   components?: ComponentsProps;
   columnFixedStyle?: CSSProperties;
   column?: any;
-  [key: string]: any;
 }
 
 // private use


### PR DESCRIPTION
Try the following code and observe the type of Foo before and after modification.
```ts
type Foo = Omit<ColumnProps, 'className'>
```