### PR TITLE
feat: max tag bugfix & feature

### DIFF
--- a/components/InputTag/__changelog__/index.en-US.md
+++ b/components/InputTag/__changelog__/index.en-US.md
@@ -22,6 +22,10 @@
 
 - `InputTag` supports responsive Tag number([#2656](https://github.com/arco-design/arco-design/pull/2656))
 
+### 🐛 BugFix
+
+- Fixed the bug that `maxTagCount` of `InputTag` component does not take effect when setting `renderTag`.
+
 ## 2.59.0
 
 2024-01-19

--- a/components/InputTag/__changelog__/index.zh-CN.md
+++ b/components/InputTag/__changelog__/index.zh-CN.md
@@ -22,6 +22,11 @@
 
 - `InputTag` 支持响应式 Tag 数([#2656](https://github.com/arco-design/arco-design/pull/2656))
 
+
+### 🐛 问题修复
+
+- 修复 `InputTag` 组件在设置 `renderTag` 时 `maxTagCount` 不生效的 bug。
+
 ## 2.59.0
 
 2024-01-19

--- a/components/InputTag/input-tag.tsx
+++ b/components/InputTag/input-tag.tsx
@@ -30,8 +30,6 @@ import fillNBSP from '../_util/fillNBSP';
 import OverflowEllipsis from '../_class/OverflowEllipsis';
 import ArcoCSSTransition from '../_util/CSSTransition';
 
-const MAX_TAG_COUNT_VALUE_PLACEHOLDER = '__arco_value_tag_placeholder';
-
 const CSS_TRANSITION_DURATION = 300;
 const MAX_TAG_RESPONSIVE = 'responsive';
 const REACT_KEY_FOR_INPUT = `__input_${Math.random().toFixed(10).slice(2)}`;
@@ -235,11 +233,12 @@ function InputTag(baseProps: InputTagProps<string | ObjectValueType>, ref) {
     index: number,
     inTooltip = false
   ): { valueKey: string | number; dom: ReactNode } => {
-    let { value: itemValue, label } = item;
+    const itemValue = item.value;
+    let label = item.label;
     let closable = !readOnly && !disabled && item.closable !== false;
 
     // 当前 Tag 的key
-    let valueKey = typeof itemValue === 'object' ? index : itemValue;
+    const valueKey = typeof itemValue === 'object' ? index : itemValue;
 
     const onClose = (event) => {
       tagCloseHandler(item, index, event);
@@ -247,18 +246,11 @@ function InputTag(baseProps: InputTagProps<string | ObjectValueType>, ref) {
 
     if (!inTooltip && typeof maxTagCountValue === 'number' && index >= maxTagCountValue) {
       if (index === value.length - 1) {
-        // 为什么这里要重新赋值呢？ 因为select里之前 maxTagCount 会执行 renderTag 逻辑
-        // https://github.com/arco-design/arco-design/blob/main/components/_class/select-view.tsx#L462
         label = renderEllipsisNode(value.length - Number(maxTagCountValue));
-        itemValue = MAX_TAG_COUNT_VALUE_PLACEHOLDER;
         closable = false;
-        valueKey = MAX_TAG_COUNT_VALUE_PLACEHOLDER;
-        if (!renderTag) {
-          return { valueKey, dom: label };
-        }
-      } else {
-        return { valueKey, dom: null };
+        return { valueKey, dom: label };
       }
+      return { valueKey, dom: null };
     }
 
     if (renderTag) {
@@ -276,7 +268,6 @@ function InputTag(baseProps: InputTagProps<string | ObjectValueType>, ref) {
         ),
       };
     }
-
     const tagProps: Partial<TagProps> = {
       closable,
       onClose,
@@ -291,7 +282,6 @@ function InputTag(baseProps: InputTagProps<string | ObjectValueType>, ref) {
       }),
       title: typeof label === 'string' ? label : undefined,
     };
-
     return { valueKey, dom: <Tag key={`${valueKey}-tag`} {...tagProps} /> };
   };
 
@@ -301,10 +291,10 @@ function InputTag(baseProps: InputTagProps<string | ObjectValueType>, ref) {
         ? maxTagCount.render
         : () => <span className={`${prefixCls}-tag-ellipsis`}>+{invisibleTagCount}</span>;
 
+    const popoverProps = isObject(maxTagCount) && maxTagCount.popoverProps;
+
     return (
       <Popover
-        {...(isObject(maxTagCount) ? maxTagCount.popoverProps : {})}
-        children={renderEllipsisLabel(invisibleTagCount, value)}
         content={
           <>
             {value
@@ -313,6 +303,8 @@ function InputTag(baseProps: InputTagProps<string | ObjectValueType>, ref) {
               .map(({ tagValue, tagIndex }) => mergedRenderTag(tagValue, tagIndex, true)?.dom)}
           </>
         }
+        {...(popoverProps || {})}
+        children={renderEllipsisLabel(invisibleTagCount, value)}
       />
     );
   }

--- a/components/Select/__demo__/maxTag.md
+++ b/components/Select/__demo__/maxTag.md
@@ -50,10 +50,24 @@ const App = () => {
           allowCreate
         ></Select>
       </div>
+
+      <div>
+        <Divider orientation="left"> 最多显示三个 Tag，隐藏节点以 Popover 展示 </Divider>
+        <Select
+          defaultValue={options.slice(0, 4)}
+          maxTagCount={{ count: 3, showPopover: true,  }}
+          style={{ width: 350 }}
+          placeholder="Select an item"
+          options={options}
+          allowClear
+          mode="multiple"
+          allowCreate
+        ></Select>
+      </div>
       <div>
         <Divider orientation="left"> 根据 select 宽度自适应渲染 Tag 个数 </Divider>
         <Select
-          defaultValue={options.slice(0, 4)}
+          defaultValue={options.slice(0, 5)}
           maxTagCount="responsive"
           style={{ width: 350 }}
           placeholder="Select an item"

--- a/components/Select/__test__/__snapshots__/demo.test.ts.snap
+++ b/components/Select/__test__/__snapshots__/demo.test.ts.snap
@@ -1844,6 +1844,7 @@ exports[`renders Select/demo/maxTag.md correctly 1`] = `
                 </div>
                 <div
                   class="arco-tag arco-tag-checked arco-tag-size-default arco-input-tag-tag arco-select-tag"
+                  title="+1..."
                 >
                   <span
                     class="arco-tag-content"
@@ -2035,11 +2036,205 @@ exports[`renders Select/demo/maxTag.md correctly 1`] = `
                 </div>
                 <div
                   class="arco-tag arco-tag-checked arco-tag-size-default arco-input-tag-tag arco-select-tag"
+                  title="+1"
                 >
                   <span
                     class="arco-tag-content"
                   >
                     +1
+                  </span>
+                </div>
+                <input
+                  autocomplete="off"
+                  class="arco-input-tag-input arco-input-tag-input-size-default arco-input-tag-input-autowidth"
+                  placeholder=""
+                  value=""
+                />
+                <span
+                  class="arco-input-tag-input-mirror"
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            aria-hidden="true"
+            class="arco-select-suffix"
+          >
+            <span
+              class="arco-icon-hover arco-select-clear-icon"
+            >
+              <svg
+                aria-hidden="true"
+                class="arco-icon arco-icon-close"
+                fill="none"
+                focusable="false"
+                stroke="currentColor"
+                stroke-width="4"
+                viewBox="0 0 48 48"
+              >
+                <path
+                  d="M9.857 9.858 24 24m0 0 14.142 14.142M24 24 38.142 9.858M24 24 9.857 38.142"
+                />
+              </svg>
+            </span>
+            <div
+              class="arco-select-arrow-icon"
+            >
+              <svg
+                aria-hidden="true"
+                class="arco-icon arco-icon-down"
+                fill="none"
+                focusable="false"
+                stroke="currentColor"
+                stroke-width="4"
+                viewBox="0 0 48 48"
+              >
+                <path
+                  d="M39.6 17.443 24.043 33 8.487 17.443"
+                />
+              </svg>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="arco-space-item"
+    style="margin-bottom:24px"
+  >
+    <div>
+      <div
+        class="arco-divider arco-divider-horizontal arco-divider-with-text arco-divider-with-text-left"
+        role="separator"
+      >
+        <span
+          class="arco-divider-text arco-divider-text-left"
+        >
+           最多显示三个 Tag，隐藏节点以 Popover 展示 
+        </span>
+      </div>
+      <div
+        aria-autocomplete="list"
+        aria-expanded="false"
+        aria-haspopup="listbox"
+        class="arco-select arco-select-multiple arco-select-show-search arco-select-size-default"
+        role="combobox"
+        style="width:350px"
+        tabindex="0"
+      >
+        <div
+          class="arco-select-view"
+          title=""
+        >
+          <div
+            class="arco-input-tag arco-input-tag-size-default"
+          >
+            <div
+              class="arco-input-tag-view"
+            >
+              <div
+                class="arco-input-tag-inner"
+              >
+                <div
+                  class="arco-tag arco-tag-checked arco-tag-size-default arco-input-tag-tag arco-select-tag"
+                  title="label 0"
+                >
+                  <span
+                    class="arco-tag-content"
+                  >
+                    label 0
+                  </span>
+                  <span
+                    aria-label="Close"
+                    class="arco-icon-hover arco-tag-icon-hover arco-tag-close-btn"
+                    role="button"
+                    tabindex="0"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="arco-icon arco-icon-close"
+                      fill="none"
+                      focusable="false"
+                      stroke="currentColor"
+                      stroke-width="4"
+                      viewBox="0 0 48 48"
+                    >
+                      <path
+                        d="M9.857 9.858 24 24m0 0 14.142 14.142M24 24 38.142 9.858M24 24 9.857 38.142"
+                      />
+                    </svg>
+                  </span>
+                </div>
+                <div
+                  class="arco-tag arco-tag-checked arco-tag-size-default arco-input-tag-tag arco-select-tag"
+                  title="label 1"
+                >
+                  <span
+                    class="arco-tag-content"
+                  >
+                    label 1
+                  </span>
+                  <span
+                    aria-label="Close"
+                    class="arco-icon-hover arco-tag-icon-hover arco-tag-close-btn"
+                    role="button"
+                    tabindex="0"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="arco-icon arco-icon-close"
+                      fill="none"
+                      focusable="false"
+                      stroke="currentColor"
+                      stroke-width="4"
+                      viewBox="0 0 48 48"
+                    >
+                      <path
+                        d="M9.857 9.858 24 24m0 0 14.142 14.142M24 24 38.142 9.858M24 24 9.857 38.142"
+                      />
+                    </svg>
+                  </span>
+                </div>
+                <div
+                  class="arco-tag arco-tag-checked arco-tag-size-default arco-input-tag-tag arco-select-tag"
+                  title="label 2"
+                >
+                  <span
+                    class="arco-tag-content"
+                  >
+                    label 2
+                  </span>
+                  <span
+                    aria-label="Close"
+                    class="arco-icon-hover arco-tag-icon-hover arco-tag-close-btn"
+                    role="button"
+                    tabindex="0"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="arco-icon arco-icon-close"
+                      fill="none"
+                      focusable="false"
+                      stroke="currentColor"
+                      stroke-width="4"
+                      viewBox="0 0 48 48"
+                    >
+                      <path
+                        d="M9.857 9.858 24 24m0 0 14.142 14.142M24 24 38.142 9.858M24 24 9.857 38.142"
+                      />
+                    </svg>
+                  </span>
+                </div>
+                <div
+                  class="arco-tag arco-tag-checked arco-tag-size-default arco-input-tag-tag arco-select-tag"
+                >
+                  <span
+                    class="arco-tag-content"
+                  >
+                    <span>
+                      +1...
+                    </span>
                   </span>
                 </div>
                 <input
@@ -2249,6 +2444,40 @@ exports[`renders Select/demo/maxTag.md correctly 1`] = `
                         class="arco-tag-content"
                       >
                         label 3
+                      </span>
+                      <span
+                        aria-label="Close"
+                        class="arco-icon-hover arco-tag-icon-hover arco-tag-close-btn"
+                        role="button"
+                        tabindex="0"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="arco-icon arco-icon-close"
+                          fill="none"
+                          focusable="false"
+                          stroke="currentColor"
+                          stroke-width="4"
+                          viewBox="0 0 48 48"
+                        >
+                          <path
+                            d="M9.857 9.858 24 24m0 0 14.142 14.142M24 24 38.142 9.858M24 24 9.857 38.142"
+                          />
+                        </svg>
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="arco-overflow-item"
+                  >
+                    <div
+                      class="arco-tag arco-tag-checked arco-tag-size-default arco-input-tag-tag arco-select-tag"
+                      title="label 4"
+                    >
+                      <span
+                        class="arco-tag-content"
+                      >
+                        label 4
                       </span>
                       <span
                         aria-label="Close"
@@ -2567,6 +2796,7 @@ exports[`renders Select/demo/multiple.md correctly 1`] = `
               </div>
               <div
                 class="arco-tag arco-tag-checked arco-tag-size-default arco-input-tag-tag arco-select-tag"
+                title="+1..."
               >
                 <span
                   class="arco-tag-content"
@@ -2716,6 +2946,7 @@ exports[`renders Select/demo/multiple.md correctly 1`] = `
               </div>
               <div
                 class="arco-tag arco-tag-checked arco-tag-size-default arco-input-tag-tag arco-select-tag"
+                title="+1 more"
               >
                 <span
                   class="arco-tag-content"

--- a/site/docs/version_v2.en-US.md
+++ b/site/docs/version_v2.en-US.md
@@ -108,6 +108,7 @@ changelog: true
 - Fixed the issue where entering a minus sign in the Slider component triggered an onChange value of NaN.([#2660](https://github.com/arco-design/arco-design/pull/2660))
 - Fixed the issue where the ref reference in the Tabs component could be null.([#2660](https://github.com/arco-design/arco-design/pull/2660))
 - Fixed the issue where the `disabled` configuration of the internal Radio is invalid after `Radio.Group` is set to disabled.([#2653](https://github.com/arco-design/arco-design/pull/2653))
+- Fixed the bug that `maxTagCount` of `InputTag` component does not take effect when setting `renderTag`.
 
 ## 2.61.3
 

--- a/site/docs/version_v2.zh-CN.md
+++ b/site/docs/version_v2.zh-CN.md
@@ -108,6 +108,7 @@ changelog: true
 - 修复`Slider`组件输入负号触发`onChange`的值为`NaN`的问题。([#2660](https://github.com/arco-design/arco-design/pull/2660))
 - 修复`Tabs`组件的`ref`引用可能为`null`的问题。([#2660](https://github.com/arco-design/arco-design/pull/2660))
 - 修复 `Radio.Group` 设置 disabled 后，内部 Radio 的 `disabled` 配置无效的问题 。([#2653](https://github.com/arco-design/arco-design/pull/2653))
+- 修复 `InputTag` 组件在设置 `renderTag` 时 `maxTagCount` 不生效的 bug。
 
 ## 2.61.3
 


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context

<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

## Solution

<!-- Describe how the problem is fixed in detail -->

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog





| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|   InputTag        |     修复 `InputTag` 组件 `renderTag` 会针对 `+x...` 标签执行的 bug。（`2.62.0` 引入）          |Fixed the bug that `renderTag` of `InputTag` component will execute for `+x...` tag. (Introduced in `2.62.0`)|                |
|   Select        |     修复 `Select` / `Cascader` / `TreeSelect` 组件设置 `maxTagCount` 后，拖拽排序导致部分已选中值取消选中的 bug。（2.62.0 引入）          |       Fixed the bug that after `maxTagCount` is set for `Select` / `Cascader` / `TreeSelect` components, drag and sort will cause some selected values ​​to be unselected. (Introduced in` 2.62.0`)        |                |
|   Select        |    `Select` / `Cascader` / `TreeSelect` 组件支持通过 `maxTagCount.showPopover` 设置以 `Popover` 形式展示隐藏 tag          |     `Select` / `Cascader` / `TreeSelect` components support displaying hidden tags in `Popover` form through `maxTagCount.showPopover` property          |      close #2870          |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->
## Checklist:

- [ ] Test suite passes (`npm run test`)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
