### PR TITLE
fix: datepicker warning key

### DIFF
--- a/components/DatePicker/panels/header.tsx
+++ b/components/DatePicker/panels/header.tsx
@@ -56,13 +56,21 @@ function Header(props: HeaderProps) {
 
     if (mode === 'date' || mode === 'week') {
       const yearNode = (
-        <span className={`${prefixCls}-header-label`} onClick={() => onChangePanel('year')}>
+        <span
+          key="year-header-label"
+          className={`${prefixCls}-header-label`}
+          onClick={() => onChangePanel('year')}
+        >
           {value.format(yearFormat || 'YYYY')}
         </span>
       );
 
       const monthNode = (
-        <span className={`${prefixCls}-header-label`} onClick={() => onChangePanel('month')}>
+        <span
+          key="month-header-label"
+          className={`${prefixCls}-header-label`}
+          onClick={() => onChangePanel('month')}
+        >
           {value.format(monthFormat || 'MM')}
         </span>
       );

--- a/components/DatePicker/picker.tsx
+++ b/components/DatePicker/picker.tsx
@@ -214,7 +214,7 @@ const Picker = (baseProps: InnerPickerProps, ref) => {
   const timeValue = panelValue || defaultTimeValue;
 
   function focusInput() {
-    refInput.current && refInput.current.blur && refInput.current.focus();
+    refInput.current && refInput.current.focus?.();
   }
 
   function blurInput() {


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [x] Bug fix
- [] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context

<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

## Solution

<!-- Describe how the problem is fixed in detail -->

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|     DatePicker      |    修复 `DatePicker` 组件          |         Fixed the bug that some nodes of the `DatePicker` component lacked `key`, causing the console `warning`      |    #2854   close #2856          |


<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->
## Checklist:

- [ ] Test suite passes (`npm run test`)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
