### PR TITLE
fix(form/use-watch): strong typing for Form.useWatch without breaking changes

### DIFF
--- a/components/Form/hooks/useWatch.ts
+++ b/components/Form/hooks/useWatch.ts
@@ -13,9 +13,7 @@ const useWatch = <
 >(
   field: Field,
   form?: FormInstance<FormData, FieldValue, FieldKey>
-): Field extends Array<any>
-  ? Pick<FormData, Extract<Field[number], keyof FormData>>
-  : FormData[Extract<Field, keyof FormData>] => {
+): Field extends Array<any> ? Partial<FormData> : FormData[Extract<Field, keyof FormData>] => {
   const formCtx = useContext(FormContext);
 
   const formInstance =

--- a/components/Form/hooks/useWatch.ts
+++ b/components/Form/hooks/useWatch.ts
@@ -1,14 +1,25 @@
 import { useState, useContext, useEffect, useRef } from 'react';
 import get from 'lodash/get';
-import { isArray, isString } from '../../_util/is';
-import { FormInstance } from '../interface';
+import { isString } from '../../_util/is';
+import { FormInstance, KeyType } from '../interface';
 import { FormContext } from '../context';
 import warn from '../../_util/warning';
 
-const useWatch = (field: string | string[], form?: FormInstance) => {
+const useWatch = <
+  FormData = any,
+  FieldValue = FormData[keyof FormData],
+  FieldKey extends KeyType = keyof FormData,
+  Field extends FieldKey | FieldKey[] = FieldKey | FieldKey[]
+>(
+  field: Field,
+  form?: FormInstance<FormData, FieldValue, FieldKey>
+): Field extends Array<any>
+  ? Pick<FormData, Extract<Field[number], keyof FormData>>
+  : FormData[Extract<Field, keyof FormData>] => {
   const formCtx = useContext(FormContext);
 
-  const formInstance = form || formCtx.store;
+  const formInstance =
+    form || (formCtx.store as FormInstance<FormData, FieldValue, FieldKey> | undefined);
 
   const [value, setValue] = useState(() => {
     const fieldValues = formInstance?.getFieldsValue([].concat(field));
@@ -35,7 +46,7 @@ const useWatch = (field: string | string[], form?: FormInstance) => {
       const field = fieldRef.current;
       const formValues = formInstance.getFieldsValue([].concat(field));
       let newValue = formValues;
-      if (!isArray(field)) {
+      if (isString(field)) {
         newValue = get(formValues, field);
       }
       const newValueString = JSON.stringify(newValue);

--- a/stories/Form.story.tsx
+++ b/stories/Form.story.tsx
@@ -44,6 +44,11 @@ export const Demo = () => {
   // 监听多个字段
   const multipleFields = Form.useWatch(['name', 'age'], form);
 
+  const [anyForm] = Form.useForm();
+  const expectedAny1 = Form.useWatch('aaa');
+  const expectedAny2 = Form.useWatch('aaa', anyForm);
+  const expectedAny3 = Form.useWatch(['AAA'], anyForm);
+
   // 初始化表单数据
   useEffect(() => {
     form.setFieldsValue({

--- a/stories/Form.story.tsx
+++ b/stories/Form.story.tsx
@@ -1,23 +1,164 @@
-import React, { useEffect } from 'react';
+import React, { useState, useEffect } from 'react';
+import { Form, Input, Button, Card, Typography, Space, Divider } from '@self';
 
-import { Form, Input } from '@self';
+// 定义表单数据类型
+interface FormType {
+  name: {
+    firstName: string;
+    lastName: string;
+  };
+  desc: string;
+  age: number;
+  hobbies: string[];
+}
 
-const CustomInput = (props) => {
-  useEffect(() => {
-    props.onChange('asd');
-  }, [props.onChange]);
-  return <Input onChange={props.onChange} value={props.value} />;
+// 类型推断演示组件
+const TypeDemo = ({ value, label }: { value: any; label: string }) => {
+  return (
+    <div style={{ marginBottom: '10px' }}>
+      <Typography.Text style={{ display: 'block', fontWeight: 'bold' }}>{label}</Typography.Text>
+      <Card style={{ marginTop: '4px', background: '#f5f5f5' }}>
+        <pre style={{ margin: 0 }}>
+          {typeof value === 'object' ? JSON.stringify(value, null, 2) : String(value)}
+        </pre>
+        <Typography.Text type="secondary" style={{ display: 'block', marginTop: '4px' }}>
+          类型: {Array.isArray(value) ? 'array' : typeof value}
+        </Typography.Text>
+      </Card>
+    </div>
+  );
 };
 
 export const Demo = () => {
-  const [form] = Form.useForm();
+  // 使用泛型指定表单数据类型
+  const [form] = Form.useForm<FormType>();
+  const [formData, setFormData] = useState<Partial<FormType>>({});
+
+  // 使用 useWatch 监听不同字段
+  const name = Form.useWatch('name', form);
+  // @ts-expect-error 预期报错，与form.getFieldsValue()行为保持一致
+  const firstName = Form.useWatch('name.firstName', form); // 注意：这里的类型推断有限制
+  const age = Form.useWatch('age', form);
+  const hobbies = Form.useWatch('hobbies', form);
+
+  // 监听多个字段
+  const multipleFields = Form.useWatch(['name', 'age'], form);
+
+  // 初始化表单数据
+  useEffect(() => {
+    form.setFieldsValue({
+      name: {
+        firstName: 'John',
+        lastName: 'Doe',
+      },
+      desc: 'Frontend Developer',
+      age: 30,
+      hobbies: ['Coding', 'Reading'],
+    });
+  }, [form]);
+
+  // 提交表单
+  const handleSubmit = () => {
+    form
+      .validate()
+      .then((values) => {
+        setFormData(values);
+      })
+      .catch((e) => {
+        console.error('Validation failed', e);
+      });
+  };
+
+  // 重置表单
+  const handleReset = () => {
+    form.resetFields();
+    setFormData({});
+  };
+
   return (
-    <div>
-      <Form form={form}>
-        <Form.Item field="a">
-          <CustomInput />
-        </Form.Item>
-      </Form>
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '20px' }}>
+      <Typography.Title heading={4}>useWatch 类型安全演示</Typography.Title>
+
+      <div style={{ display: 'flex', gap: '20px' }}>
+        {/* 表单部分 */}
+        <Card title="表单" style={{ width: '50%' }}>
+          <Form form={form} autoComplete="off" style={{ width: '100%' }}>
+            <Form.Item label="First Name" field="name.firstName" rules={[{ required: true }]}>
+              <Input placeholder="请输入名字" />
+            </Form.Item>
+
+            <Form.Item label="Last Name" field="name.lastName" rules={[{ required: true }]}>
+              <Input placeholder="请输入姓氏" />
+            </Form.Item>
+
+            <Form.Item label="Description" field="desc">
+              <Input placeholder="请输入描述" />
+            </Form.Item>
+
+            <Form.Item label="Age" field="age" rules={[{ required: true, type: 'number' }]}>
+              <Input type="number" placeholder="请输入年龄" />
+            </Form.Item>
+
+            <Form.Item label="Hobbies" field="hobbies">
+              <Input
+                placeholder="请输入爱好，用逗号分隔"
+                onChange={(value) => {
+                  const hobbies = value
+                    .split(',')
+                    .map((item) => item.trim())
+                    .filter(Boolean);
+                  form.setFieldValue('hobbies', hobbies);
+                }}
+              />
+            </Form.Item>
+
+            <Form.Item>
+              <Space>
+                <Button type="primary" onClick={handleSubmit}>
+                  提交
+                </Button>
+                <Button onClick={handleReset}>重置</Button>
+              </Space>
+            </Form.Item>
+          </Form>
+        </Card>
+
+        {/* 类型演示部分 */}
+        <Card title="useWatch 返回值类型" style={{ width: '50%' }}>
+          <Typography.Text type="secondary" style={{ display: 'block', marginBottom: '16px' }}>
+            useWatch
+            根据传入的字段类型返回不同的类型：单个字段返回该字段的值类型，字段数组返回对象类型
+          </Typography.Text>
+
+          <TypeDemo label="name = useWatch('name', form)" value={name} />
+
+          <TypeDemo label="firstName = useWatch('name.firstName', form)" value={firstName} />
+          <Typography.Text type="warning" style={{ display: 'block', marginBottom: '16px' }}>
+            注意：对于嵌套路径 name.firstName，类型系统无法正确推断出它是 string 类型
+          </Typography.Text>
+
+          <TypeDemo label="age = useWatch('age', form)" value={age} />
+
+          <TypeDemo label="hobbies = useWatch('hobbies', form)" value={hobbies} />
+
+          <Divider />
+
+          <TypeDemo
+            label="multipleFields = useWatch(['name', 'age'], form)"
+            value={multipleFields}
+          />
+          <Typography.Text type="secondary" style={{ display: 'block', marginBottom: '16px' }}>
+            当传入字段数组时，返回包含这些字段的对象类型
+          </Typography.Text>
+        </Card>
+      </div>
+
+      {/* 提交的表单数据 */}
+      {Object.keys(formData).length > 0 && (
+        <Card title="提交的表单数据">
+          <pre>{JSON.stringify(formData, null, 2)}</pre>
+        </Card>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [ ] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [x] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context

<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

Types definition of `Form.useWatch` does not accept generic types as `Form.useForm`, which causes when passing a typed FormInstance (such as `FormInstance<T>`) to `Form.useWatch` as a second parameter will cause unexpected types error.

Related Posts:

- https://github.com/arco-design/arco-design/pull/2779 This PR is not accepted because it introduced a breaking change - a generic type parameter without default value.
- https://github.com/arco-design/arco-design/issues/1895

## Solution

<!-- Describe how the problem is fixed in detail -->

1. Strong types support for `useWatch` using type inference and generic.
2. Provide a fallback type `any` for not making break changes.

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

Since I didn't change any runtime behavior, I simply edit the `form.story.tsx` to test the added types of `Form.useWatch`.

## Changelog

| Component | Changelog(CN)                                                | Changelog(EN)                                                | Related issues                                         |
| --------- | ------------------------------------------------------------ | ------------------------------------------------------------ | ------------------------------------------------------ |
| Form      |  新增支持 `Form.useWatch` 强类型，从传入的 FormInstance 自动推断，类型行为与 `form.getFieldsValue`一致并兜底为any  |  Added support for strong typing of `Form.useWatch`, which is automatically inferred from the passed FormInstance. The type behavior is consistent with `form.getFieldsValue` and falls back to any | close https://github.com/arco-design/arco-design/issues/1895 |
<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->
## Checklist:

- [x] Test suite passes (`npm run test`)
- [x] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [x ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
