### PR TITLE
fix: #2970 TreeSelect Maximum update depth exceeded

### DIFF
--- a/components/Tree/index.tsx
+++ b/components/Tree/index.tsx
@@ -160,7 +160,7 @@ class Tree extends Component<TreeProps, TreeState> {
       const newState: Partial<TreeState> = {};
       if (
         this.needUpdateTreeData(
-          { prevMergedProps, ...prevProps },
+          { ...prevMergedProps, ...prevProps },
           { ...mergedProps, ...this.props }
         )
       ) {
@@ -261,7 +261,7 @@ class Tree extends Component<TreeProps, TreeState> {
     return (
       prevProps.treeData !== props.treeData ||
       prevProps.children !== props.children ||
-      keys.some((key) => isEqualWith(prevProps[key], props[key]))
+      keys.some((key) => !isEqualWith(prevProps[key], props[key]))
     );
   };
 


### PR DESCRIPTION
## Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context

#2970 TreeSelect 组件在React19下报错：Maximum update depth exceeded
在 React 19中只要向 TreeSelect 传入 treedata ，展开下拉框就会导致死循环

## Solution

经排查为 Tree 组件 needUpdateTreeData 入参解构错误并且 `keys.some((key) => isEqualWith(prevProps[key], props[key]))` 的判断逻辑明显错误

之前没有问题可能由于 prevMergedProps 一直未被正确传入 needUpdateTreeData 导致 prevProps[key] 和 props[key] 始终是不等的，但是判断逻辑又正好写反了，负负得正了属于是

## How is the change tested?

已验证在 React19 下渲染正常。

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|Tree|更新 needUpdateTreeData 判断逻辑|Update needUpdateTreeData Judgement Logic|#2970|


## Checklist:

- [x] Test suite passes (`npm run test`)
- [x] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [x] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

