### PR TITLE
fix(Select): allow 0 as valid placeholder value

### DIFF
--- a/components/_class/select-view.tsx
+++ b/components/_class/select-view.tsx
@@ -386,7 +386,10 @@ const CoreSelectView = React.forwardRef(
         value: needShowInput && typeof _inputValue !== 'object' ? _inputValue : '',
         // Allow placeholder to display the selected value first when searching
         placeholder:
-          canFocusInput && renderedValue && typeof renderedValue !== 'object'
+          canFocusInput &&
+          // 0 can also be used as a placeholder, because when options is number[], the selected value may be 0
+          (!!renderedValue || renderedValue === 0) &&
+          typeof renderedValue !== 'object'
             ? renderedValue
             : placeholder,
       };


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context

<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

When options is number[], the selected value may be 0, so we need to explicitly check for 0 as a valid placeholder condition.

More specifically:

- Consider:

```tsx
export function Demo() {
  const [value, setValue] = useState<number>();
  const options = [0, 1, 2];

  return (
    <Select style={{ width: 256 }} showSearch value={value} options={options} onChange={setValue} />
  );
}
```

- When we select `1` first and then click to focus on the Select component, its behavior is as shown below:

<img width="264" height="162" alt="image" src="https://github.com/user-attachments/assets/6af04bda-b617-4462-ae12-e1456e71f2e1" />

- When we select `0` first and then focus again, its behavior is as shown below:

<img width="264" height="162" alt="image" src="https://github.com/user-attachments/assets/90ad3f83-8de4-4ec0-a0cc-f61e441bc7ba" />

- The original value `0` is missing!

## Solution

<!-- Describe how the problem is fixed in detail -->

To fix this issue, the placeholder logic on line 388 of components/_class/select-view.tsx needs to improve the boundary condition check: `... && renderedValue && ...` -> `... && (!!renderedValue || renderedValue === 0) && ...`.

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

Currently no unit test covered this scenario. But after this patch, we got this:

<img width="264" height="162" alt="image" src="https://github.com/user-attachments/assets/a872fa96-befb-485f-8fff-467d10028211" />

The original value `0`.

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
| Select | 修复 Select 组件在单选模式下启用 `allowSearch` 时，选中数字 0 后的 placeholder 行为与选中其他值的不一致的问题 | Fixed the bug that when `allowSearch` is enabled in the Select component in single select mode, the placeholder behavior after selecting the number 0 is inconsistent with that of other selected values | N/A |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->
## Checklist:

- [x] Test suite passes (`npm run test`)
- [x] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [x] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
