### PR TITLE
fix(Table): Fix the issue in the Table component where, when merging cells in the first column, even if borderCell is set to false, some internal borders are still exposed.

### DIFF
--- a/components/ConfigProvider/__test__/__snapshots__/demo.test.ts.snap
+++ b/components/ConfigProvider/__test__/__snapshots__/demo.test.ts.snap
@@ -977,7 +977,7 @@ exports[`renders ConfigProvider/demo/component-config.md correctly 1`] = `
                       class="arco-table-tr"
                     >
                       <th
-                        class="arco-table-th"
+                        class="arco-table-th arco-table-col-first"
                       >
                         <div
                           class="arco-table-th-item"
@@ -1035,7 +1035,7 @@ exports[`renders ConfigProvider/demo/component-config.md correctly 1`] = `
                       class="arco-table-tr arco-table-empty-row"
                     >
                       <td
-                        class="arco-table-td"
+                        class="arco-table-td arco-table-col-first"
                         colspan="4"
                       >
                         <div
@@ -1517,7 +1517,7 @@ Array [
                     class="arco-table-tr"
                   >
                     <th
-                      class="arco-table-th"
+                      class="arco-table-th arco-table-col-first"
                     >
                       <div
                         class="arco-table-th-item"
@@ -1549,7 +1549,7 @@ Array [
                     class="arco-table-tr arco-table-empty-row"
                   >
                     <td
-                      class="arco-table-td"
+                      class="arco-table-td arco-table-col-first"
                       colspan="2"
                     >
                       <div
@@ -2199,7 +2199,7 @@ Array [
                     class="arco-table-tr"
                   >
                     <th
-                      class="arco-table-th"
+                      class="arco-table-th arco-table-col-first"
                     >
                       <div
                         class="arco-table-th-item"
@@ -2257,7 +2257,7 @@ Array [
                     class="arco-table-tr"
                   >
                     <td
-                      class="arco-table-td"
+                      class="arco-table-td arco-table-col-first"
                     >
                       <div
                         class="arco-table-cell"
@@ -2313,7 +2313,7 @@ Array [
                     class="arco-table-tr"
                   >
                     <td
-                      class="arco-table-td"
+                      class="arco-table-td arco-table-col-first"
                     >
                       <div
                         class="arco-table-cell"
@@ -2369,7 +2369,7 @@ Array [
                     class="arco-table-tr"
                   >
                     <td
-                      class="arco-table-td"
+                      class="arco-table-td arco-table-col-first"
                     >
                       <div
                         class="arco-table-cell"

--- a/components/Form/__test__/__snapshots__/demo.test.ts.snap
+++ b/components/Form/__test__/__snapshots__/demo.test.ts.snap
@@ -4266,7 +4266,7 @@ exports[`renders Form/demo/form-provider.md correctly 1`] = `
                     class="arco-table-tr"
                   >
                     <th
-                      class="arco-table-th"
+                      class="arco-table-th arco-table-col-first"
                     >
                       <div
                         class="arco-table-th-item"
@@ -4337,7 +4337,7 @@ exports[`renders Form/demo/form-provider.md correctly 1`] = `
                     class="arco-table-tr"
                   >
                     <td
-                      class="arco-table-td"
+                      class="arco-table-td arco-table-col-first"
                     >
                       <div
                         class="arco-table-cell"
@@ -4406,7 +4406,7 @@ exports[`renders Form/demo/form-provider.md correctly 1`] = `
                     class="arco-table-tr"
                   >
                     <td
-                      class="arco-table-td"
+                      class="arco-table-td arco-table-col-first"
                     >
                       <div
                         class="arco-table-cell"
@@ -4475,7 +4475,7 @@ exports[`renders Form/demo/form-provider.md correctly 1`] = `
                     class="arco-table-tr"
                   >
                     <td
-                      class="arco-table-td"
+                      class="arco-table-td arco-table-col-first"
                     >
                       <div
                         class="arco-table-cell"
@@ -4544,7 +4544,7 @@ exports[`renders Form/demo/form-provider.md correctly 1`] = `
                     class="arco-table-tr"
                   >
                     <td
-                      class="arco-table-td"
+                      class="arco-table-td arco-table-col-first"
                     >
                       <div
                         class="arco-table-cell"
@@ -4613,7 +4613,7 @@ exports[`renders Form/demo/form-provider.md correctly 1`] = `
                     class="arco-table-tr"
                   >
                     <td
-                      class="arco-table-td"
+                      class="arco-table-td arco-table-col-first"
                     >
                       <div
                         class="arco-table-cell"

--- a/components/Table/__test__/__snapshots__/demo.test.ts.snap
+++ b/components/Table/__test__/__snapshots__/demo.test.ts.snap
@@ -705,7 +705,7 @@ exports[`renders Table/demo/attribution.md correctly 1`] = `
                       class="arco-table-tr"
                     >
                       <td
-                        class="arco-table-td arco-table-operation arco-table-checkbox"
+                        class="arco-table-td arco-table-operation arco-table-checkbox arco-table-col-first arco-table-col-first"
                       >
                         <label
                           class="arco-checkbox"
@@ -795,7 +795,7 @@ exports[`renders Table/demo/attribution.md correctly 1`] = `
                       class="arco-table-tr"
                     >
                       <td
-                        class="arco-table-td arco-table-operation arco-table-checkbox"
+                        class="arco-table-td arco-table-operation arco-table-checkbox arco-table-col-first arco-table-col-first"
                       >
                         <label
                           class="arco-checkbox"
@@ -885,7 +885,7 @@ exports[`renders Table/demo/attribution.md correctly 1`] = `
                       class="arco-table-tr"
                     >
                       <td
-                        class="arco-table-td arco-table-operation arco-table-checkbox"
+                        class="arco-table-td arco-table-operation arco-table-checkbox arco-table-col-first arco-table-col-first"
                       >
                         <label
                           class="arco-checkbox"
@@ -975,7 +975,7 @@ exports[`renders Table/demo/attribution.md correctly 1`] = `
                       class="arco-table-tr"
                     >
                       <td
-                        class="arco-table-td arco-table-operation arco-table-checkbox"
+                        class="arco-table-td arco-table-operation arco-table-checkbox arco-table-col-first arco-table-col-first"
                       >
                         <label
                           class="arco-checkbox"
@@ -1065,7 +1065,7 @@ exports[`renders Table/demo/attribution.md correctly 1`] = `
                       class="arco-table-tr"
                     >
                       <td
-                        class="arco-table-td arco-table-operation arco-table-checkbox"
+                        class="arco-table-td arco-table-operation arco-table-checkbox arco-table-col-first arco-table-col-first"
                       >
                         <label
                           class="arco-checkbox"
@@ -1252,7 +1252,7 @@ exports[`renders Table/demo/basic.md correctly 1`] = `
                   class="arco-table-tr"
                 >
                   <th
-                    class="arco-table-th"
+                    class="arco-table-th arco-table-col-first"
                   >
                     <div
                       class="arco-table-th-item"
@@ -1310,7 +1310,7 @@ exports[`renders Table/demo/basic.md correctly 1`] = `
                   class="arco-table-tr"
                 >
                   <td
-                    class="arco-table-td"
+                    class="arco-table-td arco-table-col-first"
                   >
                     <div
                       class="arco-table-cell"
@@ -1366,7 +1366,7 @@ exports[`renders Table/demo/basic.md correctly 1`] = `
                   class="arco-table-tr"
                 >
                   <td
-                    class="arco-table-td"
+                    class="arco-table-td arco-table-col-first"
                   >
                     <div
                       class="arco-table-cell"
@@ -1422,7 +1422,7 @@ exports[`renders Table/demo/basic.md correctly 1`] = `
                   class="arco-table-tr"
                 >
                   <td
-                    class="arco-table-td"
+                    class="arco-table-td arco-table-col-first"
                   >
                     <div
                       class="arco-table-cell"
@@ -1478,7 +1478,7 @@ exports[`renders Table/demo/basic.md correctly 1`] = `
                   class="arco-table-tr"
                 >
                   <td
-                    class="arco-table-td"
+                    class="arco-table-td arco-table-col-first"
                   >
                     <div
                       class="arco-table-cell"
@@ -1534,7 +1534,7 @@ exports[`renders Table/demo/basic.md correctly 1`] = `
                   class="arco-table-tr"
                 >
                   <td
-                    class="arco-table-td"
+                    class="arco-table-td arco-table-col-first"
                   >
                     <div
                       class="arco-table-cell"
@@ -1810,7 +1810,7 @@ exports[`renders Table/demo/data-children.md correctly 1`] = `
                     class="arco-table-tr"
                   >
                     <td
-                      class="arco-table-td arco-table-operation arco-table-checkbox"
+                      class="arco-table-td arco-table-operation arco-table-checkbox arco-table-col-first arco-table-col-first"
                     >
                       <label
                         class="arco-checkbox"
@@ -1921,7 +1921,7 @@ exports[`renders Table/demo/data-children.md correctly 1`] = `
                     class="arco-table-tr"
                   >
                     <td
-                      class="arco-table-td arco-table-operation arco-table-checkbox"
+                      class="arco-table-td arco-table-operation arco-table-checkbox arco-table-col-first arco-table-col-first"
                     >
                       <label
                         class="arco-checkbox"
@@ -2032,7 +2032,7 @@ exports[`renders Table/demo/data-children.md correctly 1`] = `
                     class="arco-table-tr"
                   >
                     <td
-                      class="arco-table-td arco-table-operation arco-table-checkbox"
+                      class="arco-table-td arco-table-operation arco-table-checkbox arco-table-col-first arco-table-col-first"
                     >
                       <label
                         class="arco-checkbox"
@@ -2222,7 +2222,7 @@ exports[`renders Table/demo/drag.md correctly 1`] = `
                   class="arco-table-tr"
                 >
                   <th
-                    class="arco-table-th"
+                    class="arco-table-th arco-table-col-first"
                   >
                     <div
                       class="arco-table-th-item"
@@ -2281,7 +2281,7 @@ exports[`renders Table/demo/drag.md correctly 1`] = `
                   style="cursor:move"
                 >
                   <td
-                    class="arco-table-td"
+                    class="arco-table-td arco-table-col-first"
                   >
                     <div
                       class="arco-table-cell"
@@ -2338,7 +2338,7 @@ exports[`renders Table/demo/drag.md correctly 1`] = `
                   style="cursor:move"
                 >
                   <td
-                    class="arco-table-td"
+                    class="arco-table-td arco-table-col-first"
                   >
                     <div
                       class="arco-table-cell"
@@ -2395,7 +2395,7 @@ exports[`renders Table/demo/drag.md correctly 1`] = `
                   style="cursor:move"
                 >
                   <td
-                    class="arco-table-td"
+                    class="arco-table-td arco-table-col-first"
                   >
                     <div
                       class="arco-table-cell"
@@ -2452,7 +2452,7 @@ exports[`renders Table/demo/drag.md correctly 1`] = `
                   style="cursor:move"
                 >
                   <td
-                    class="arco-table-td"
+                    class="arco-table-td arco-table-col-first"
                   >
                     <div
                       class="arco-table-cell"
@@ -2509,7 +2509,7 @@ exports[`renders Table/demo/drag.md correctly 1`] = `
                   style="cursor:move"
                 >
                   <td
-                    class="arco-table-td"
+                    class="arco-table-td arco-table-col-first"
                   >
                     <div
                       class="arco-table-cell"
@@ -2766,7 +2766,7 @@ exports[`renders Table/demo/drag-handle.md correctly 1`] = `
                   class="arco-table-tr"
                 >
                   <td
-                    class="arco-table-td arco-table-operation"
+                    class="arco-table-td arco-table-operation arco-table-col-first"
                     style="width:40px;min-width:40px"
                   >
                     <div
@@ -2794,7 +2794,7 @@ exports[`renders Table/demo/drag-handle.md correctly 1`] = `
                     </div>
                   </td>
                   <td
-                    class="arco-table-td arco-table-operation arco-table-checkbox"
+                    class="arco-table-td arco-table-operation arco-table-checkbox arco-table-col-first"
                   >
                     <label
                       class="arco-checkbox"
@@ -2884,7 +2884,7 @@ exports[`renders Table/demo/drag-handle.md correctly 1`] = `
                   class="arco-table-tr"
                 >
                   <td
-                    class="arco-table-td arco-table-operation"
+                    class="arco-table-td arco-table-operation arco-table-col-first"
                     style="width:40px;min-width:40px"
                   >
                     <div
@@ -2912,7 +2912,7 @@ exports[`renders Table/demo/drag-handle.md correctly 1`] = `
                     </div>
                   </td>
                   <td
-                    class="arco-table-td arco-table-operation arco-table-checkbox"
+                    class="arco-table-td arco-table-operation arco-table-checkbox arco-table-col-first"
                   >
                     <label
                       class="arco-checkbox"
@@ -3002,7 +3002,7 @@ exports[`renders Table/demo/drag-handle.md correctly 1`] = `
                   class="arco-table-tr"
                 >
                   <td
-                    class="arco-table-td arco-table-operation"
+                    class="arco-table-td arco-table-operation arco-table-col-first"
                     style="width:40px;min-width:40px"
                   >
                     <div
@@ -3030,7 +3030,7 @@ exports[`renders Table/demo/drag-handle.md correctly 1`] = `
                     </div>
                   </td>
                   <td
-                    class="arco-table-td arco-table-operation arco-table-checkbox"
+                    class="arco-table-td arco-table-operation arco-table-checkbox arco-table-col-first"
                   >
                     <label
                       class="arco-checkbox"
@@ -3120,7 +3120,7 @@ exports[`renders Table/demo/drag-handle.md correctly 1`] = `
                   class="arco-table-tr"
                 >
                   <td
-                    class="arco-table-td arco-table-operation"
+                    class="arco-table-td arco-table-operation arco-table-col-first"
                     style="width:40px;min-width:40px"
                   >
                     <div
@@ -3148,7 +3148,7 @@ exports[`renders Table/demo/drag-handle.md correctly 1`] = `
                     </div>
                   </td>
                   <td
-                    class="arco-table-td arco-table-operation arco-table-checkbox"
+                    class="arco-table-td arco-table-operation arco-table-checkbox arco-table-col-first"
                   >
                     <label
                       class="arco-checkbox"
@@ -3238,7 +3238,7 @@ exports[`renders Table/demo/drag-handle.md correctly 1`] = `
                   class="arco-table-tr"
                 >
                   <td
-                    class="arco-table-td arco-table-operation"
+                    class="arco-table-td arco-table-operation arco-table-col-first"
                     style="width:40px;min-width:40px"
                   >
                     <div
@@ -3266,7 +3266,7 @@ exports[`renders Table/demo/drag-handle.md correctly 1`] = `
                     </div>
                   </td>
                   <td
-                    class="arco-table-td arco-table-operation arco-table-checkbox"
+                    class="arco-table-td arco-table-operation arco-table-checkbox arco-table-col-first"
                   >
                     <label
                       class="arco-checkbox"
@@ -3515,7 +3515,7 @@ exports[`renders Table/demo/expand-sub-table.md correctly 1`] = `
                   class="arco-table-tr"
                 >
                   <td
-                    class="arco-table-td arco-table-operation arco-table-expand-icon-cell"
+                    class="arco-table-td arco-table-operation arco-table-expand-icon-cell arco-table-col-first arco-table-col-first"
                   >
                     <button
                       type="button"
@@ -3592,7 +3592,7 @@ exports[`renders Table/demo/expand-sub-table.md correctly 1`] = `
                   class="arco-table-tr"
                 >
                   <td
-                    class="arco-table-td arco-table-operation arco-table-expand-icon-cell"
+                    class="arco-table-td arco-table-operation arco-table-expand-icon-cell arco-table-col-first arco-table-col-first"
                   >
                     <button
                       type="button"
@@ -3669,7 +3669,7 @@ exports[`renders Table/demo/expand-sub-table.md correctly 1`] = `
                   class="arco-table-tr"
                 >
                   <td
-                    class="arco-table-td arco-table-operation arco-table-expand-icon-cell"
+                    class="arco-table-td arco-table-operation arco-table-expand-icon-cell arco-table-col-first arco-table-col-first"
                   >
                     <button
                       type="button"
@@ -3746,7 +3746,7 @@ exports[`renders Table/demo/expand-sub-table.md correctly 1`] = `
                   class="arco-table-tr"
                 >
                   <td
-                    class="arco-table-td arco-table-operation arco-table-expand-icon-cell"
+                    class="arco-table-td arco-table-operation arco-table-expand-icon-cell arco-table-col-first arco-table-col-first"
                   >
                     <button
                       type="button"
@@ -3823,7 +3823,7 @@ exports[`renders Table/demo/expand-sub-table.md correctly 1`] = `
                   class="arco-table-tr"
                 >
                   <td
-                    class="arco-table-td arco-table-operation arco-table-expand-icon-cell"
+                    class="arco-table-td arco-table-operation arco-table-expand-icon-cell arco-table-col-first arco-table-col-first"
                   >
                     <button
                       type="button"
@@ -4059,7 +4059,7 @@ exports[`renders Table/demo/expandable.md correctly 1`] = `
                   class="arco-table-tr"
                 >
                   <td
-                    class="arco-table-td arco-table-operation arco-table-expand-icon-cell"
+                    class="arco-table-td arco-table-operation arco-table-expand-icon-cell arco-table-col-first arco-table-col-first"
                   >
                     <button
                       type="button"
@@ -4136,7 +4136,7 @@ exports[`renders Table/demo/expandable.md correctly 1`] = `
                   class="arco-table-tr"
                 >
                   <td
-                    class="arco-table-td arco-table-operation arco-table-expand-icon-cell"
+                    class="arco-table-td arco-table-operation arco-table-expand-icon-cell arco-table-col-first arco-table-col-first"
                   >
                     <button
                       type="button"
@@ -4213,7 +4213,7 @@ exports[`renders Table/demo/expandable.md correctly 1`] = `
                   class="arco-table-tr"
                 >
                   <td
-                    class="arco-table-td arco-table-operation arco-table-expand-icon-cell"
+                    class="arco-table-td arco-table-operation arco-table-expand-icon-cell arco-table-col-first arco-table-col-first"
                   >
                     <button
                       type="button"
@@ -4290,7 +4290,7 @@ exports[`renders Table/demo/expandable.md correctly 1`] = `
                   class="arco-table-tr"
                 >
                   <td
-                    class="arco-table-td arco-table-operation arco-table-expand-icon-cell"
+                    class="arco-table-td arco-table-operation arco-table-expand-icon-cell arco-table-col-first arco-table-col-first"
                   />
                   <td
                     class="arco-table-td"
@@ -4349,7 +4349,7 @@ exports[`renders Table/demo/expandable.md correctly 1`] = `
                   class="arco-table-tr"
                 >
                   <td
-                    class="arco-table-td arco-table-operation arco-table-expand-icon-cell"
+                    class="arco-table-td arco-table-operation arco-table-expand-icon-cell arco-table-col-first arco-table-col-first"
                   >
                     <button
                       type="button"
@@ -4593,7 +4593,7 @@ exports[`renders Table/demo/expandprops.md correctly 1`] = `
                   class="arco-table-tr"
                 >
                   <td
-                    class="arco-table-td arco-table-operation arco-table-expand-icon-cell"
+                    class="arco-table-td arco-table-operation arco-table-expand-icon-cell arco-table-col-first arco-table-col-first"
                     style="width:60px;min-width:60px"
                   >
                     <button>
@@ -4669,7 +4669,7 @@ exports[`renders Table/demo/expandprops.md correctly 1`] = `
                   class="arco-table-tr"
                 >
                   <td
-                    class="arco-table-td arco-table-operation arco-table-expand-icon-cell"
+                    class="arco-table-td arco-table-operation arco-table-expand-icon-cell arco-table-col-first arco-table-col-first"
                     style="width:60px;min-width:60px"
                   >
                     <button>
@@ -4745,7 +4745,7 @@ exports[`renders Table/demo/expandprops.md correctly 1`] = `
                   class="arco-table-tr"
                 >
                   <td
-                    class="arco-table-td arco-table-operation arco-table-expand-icon-cell"
+                    class="arco-table-td arco-table-operation arco-table-expand-icon-cell arco-table-col-first arco-table-col-first"
                     style="width:60px;min-width:60px"
                   >
                     <button>
@@ -4821,7 +4821,7 @@ exports[`renders Table/demo/expandprops.md correctly 1`] = `
                   class="arco-table-tr"
                 >
                   <td
-                    class="arco-table-td arco-table-operation arco-table-expand-icon-cell"
+                    class="arco-table-td arco-table-operation arco-table-expand-icon-cell arco-table-col-first arco-table-col-first"
                     style="width:60px;min-width:60px"
                   />
                   <td
@@ -4881,7 +4881,7 @@ exports[`renders Table/demo/expandprops.md correctly 1`] = `
                   class="arco-table-tr"
                 >
                   <td
-                    class="arco-table-td arco-table-operation arco-table-expand-icon-cell"
+                    class="arco-table-td arco-table-operation arco-table-expand-icon-cell arco-table-col-first arco-table-col-first"
                     style="width:60px;min-width:60px"
                   >
                     <button>
@@ -5052,7 +5052,7 @@ exports[`renders Table/demo/filter-dropdown.md correctly 1`] = `
                   class="arco-table-tr"
                 >
                   <th
-                    class="arco-table-th"
+                    class="arco-table-th arco-table-col-first"
                   >
                     <div
                       class="arco-table-th-item arco-table-col-has-filter"
@@ -5127,7 +5127,7 @@ exports[`renders Table/demo/filter-dropdown.md correctly 1`] = `
                   class="arco-table-tr"
                 >
                   <td
-                    class="arco-table-td"
+                    class="arco-table-td arco-table-col-first"
                   >
                     <div
                       class="arco-table-cell"
@@ -5183,7 +5183,7 @@ exports[`renders Table/demo/filter-dropdown.md correctly 1`] = `
                   class="arco-table-tr"
                 >
                   <td
-                    class="arco-table-td"
+                    class="arco-table-td arco-table-col-first"
                   >
                     <div
                       class="arco-table-cell"
@@ -5239,7 +5239,7 @@ exports[`renders Table/demo/filter-dropdown.md correctly 1`] = `
                   class="arco-table-tr"
                 >
                   <td
-                    class="arco-table-td"
+                    class="arco-table-td arco-table-col-first"
                   >
                     <div
                       class="arco-table-cell"
@@ -5295,7 +5295,7 @@ exports[`renders Table/demo/filter-dropdown.md correctly 1`] = `
                   class="arco-table-tr"
                 >
                   <td
-                    class="arco-table-td"
+                    class="arco-table-td arco-table-col-first"
                   >
                     <div
                       class="arco-table-cell"
@@ -5351,7 +5351,7 @@ exports[`renders Table/demo/filter-dropdown.md correctly 1`] = `
                   class="arco-table-tr"
                 >
                   <td
-                    class="arco-table-td"
+                    class="arco-table-td arco-table-col-first"
                   >
                     <div
                       class="arco-table-cell"
@@ -5690,7 +5690,7 @@ exports[`renders Table/demo/fixed-column.md correctly 1`] = `
                     class="arco-table-tr"
                   >
                     <td
-                      class="arco-table-td arco-table-operation arco-table-expand-icon-cell arco-table-col-fixed-left"
+                      class="arco-table-td arco-table-operation arco-table-expand-icon-cell arco-table-col-first arco-table-col-fixed-left arco-table-col-first"
                       style="left:0"
                     >
                       <button
@@ -5844,7 +5844,7 @@ exports[`renders Table/demo/fixed-column.md correctly 1`] = `
                     class="arco-table-tr"
                   >
                     <td
-                      class="arco-table-td arco-table-operation arco-table-expand-icon-cell arco-table-col-fixed-left"
+                      class="arco-table-td arco-table-operation arco-table-expand-icon-cell arco-table-col-first arco-table-col-fixed-left arco-table-col-first"
                       style="left:0"
                     >
                       <button
@@ -5998,7 +5998,7 @@ exports[`renders Table/demo/fixed-column.md correctly 1`] = `
                     class="arco-table-tr"
                   >
                     <td
-                      class="arco-table-td arco-table-operation arco-table-expand-icon-cell arco-table-col-fixed-left"
+                      class="arco-table-td arco-table-operation arco-table-expand-icon-cell arco-table-col-first arco-table-col-fixed-left arco-table-col-first"
                       style="left:0"
                     >
                       <button
@@ -6152,7 +6152,7 @@ exports[`renders Table/demo/fixed-column.md correctly 1`] = `
                     class="arco-table-tr"
                   >
                     <td
-                      class="arco-table-td arco-table-operation arco-table-expand-icon-cell arco-table-col-fixed-left"
+                      class="arco-table-td arco-table-operation arco-table-expand-icon-cell arco-table-col-first arco-table-col-fixed-left arco-table-col-first"
                       style="left:0"
                     >
                       <button
@@ -6306,7 +6306,7 @@ exports[`renders Table/demo/fixed-column.md correctly 1`] = `
                     class="arco-table-tr"
                   >
                     <td
-                      class="arco-table-td arco-table-operation arco-table-expand-icon-cell arco-table-col-fixed-left"
+                      class="arco-table-td arco-table-operation arco-table-expand-icon-cell arco-table-col-first arco-table-col-fixed-left arco-table-col-first"
                       style="left:0"
                     >
                       <button
@@ -6569,7 +6569,7 @@ exports[`renders Table/demo/group-columns.md correctly 1`] = `
                   class="arco-table-tr"
                 >
                   <th
-                    class="arco-table-th arco-table-col-fixed-left arco-table-col-fixed-left-last"
+                    class="arco-table-th arco-table-col-first arco-table-col-fixed-left arco-table-col-fixed-left-last"
                     rowspan="3"
                     style="left:0"
                   >
@@ -6646,7 +6646,7 @@ exports[`renders Table/demo/group-columns.md correctly 1`] = `
                   class="arco-table-tr"
                 >
                   <th
-                    class="arco-table-th"
+                    class="arco-table-th arco-table-col-first"
                     rowspan="2"
                   >
                     <div
@@ -6706,7 +6706,7 @@ exports[`renders Table/demo/group-columns.md correctly 1`] = `
                   class="arco-table-tr"
                 >
                   <th
-                    class="arco-table-th"
+                    class="arco-table-th arco-table-col-first"
                   >
                     <div
                       class="arco-table-th-item"
@@ -6751,7 +6751,7 @@ exports[`renders Table/demo/group-columns.md correctly 1`] = `
                   class="arco-table-tr"
                 >
                   <td
-                    class="arco-table-td arco-table-col-fixed-left arco-table-col-fixed-left-last"
+                    class="arco-table-td arco-table-col-fixed-left arco-table-col-fixed-left-last arco-table-col-first"
                     style="left:0"
                   >
                     <div
@@ -6875,7 +6875,7 @@ exports[`renders Table/demo/group-columns.md correctly 1`] = `
                   class="arco-table-tr"
                 >
                   <td
-                    class="arco-table-td arco-table-col-fixed-left arco-table-col-fixed-left-last"
+                    class="arco-table-td arco-table-col-fixed-left arco-table-col-fixed-left-last arco-table-col-first"
                     style="left:0"
                   >
                     <div
@@ -6999,7 +6999,7 @@ exports[`renders Table/demo/group-columns.md correctly 1`] = `
                   class="arco-table-tr"
                 >
                   <td
-                    class="arco-table-td arco-table-col-fixed-left arco-table-col-fixed-left-last"
+                    class="arco-table-td arco-table-col-fixed-left arco-table-col-fixed-left-last arco-table-col-first"
                     style="left:0"
                   >
                     <div
@@ -7123,7 +7123,7 @@ exports[`renders Table/demo/group-columns.md correctly 1`] = `
                   class="arco-table-tr"
                 >
                   <td
-                    class="arco-table-td arco-table-col-fixed-left arco-table-col-fixed-left-last"
+                    class="arco-table-td arco-table-col-fixed-left arco-table-col-fixed-left-last arco-table-col-first"
                     style="left:0"
                   >
                     <div
@@ -7247,7 +7247,7 @@ exports[`renders Table/demo/group-columns.md correctly 1`] = `
                   class="arco-table-tr"
                 >
                   <td
-                    class="arco-table-td arco-table-col-fixed-left arco-table-col-fixed-left-last"
+                    class="arco-table-td arco-table-col-fixed-left arco-table-col-fixed-left-last arco-table-col-first"
                     style="left:0"
                   >
                     <div
@@ -7472,7 +7472,7 @@ exports[`renders Table/demo/header-sticky.md correctly 1`] = `
                         class="arco-table-tr"
                       >
                         <th
-                          class="arco-table-th"
+                          class="arco-table-th arco-table-col-first"
                         >
                           <div
                             class="arco-table-th-item"
@@ -7543,7 +7543,7 @@ exports[`renders Table/demo/header-sticky.md correctly 1`] = `
                       class="arco-table-tr"
                     >
                       <td
-                        class="arco-table-td"
+                        class="arco-table-td arco-table-col-first"
                       >
                         <div
                           class="arco-table-cell"
@@ -7599,7 +7599,7 @@ exports[`renders Table/demo/header-sticky.md correctly 1`] = `
                       class="arco-table-tr"
                     >
                       <td
-                        class="arco-table-td"
+                        class="arco-table-td arco-table-col-first"
                       >
                         <div
                           class="arco-table-cell"
@@ -7655,7 +7655,7 @@ exports[`renders Table/demo/header-sticky.md correctly 1`] = `
                       class="arco-table-tr"
                     >
                       <td
-                        class="arco-table-td"
+                        class="arco-table-td arco-table-col-first"
                       >
                         <div
                           class="arco-table-cell"
@@ -7711,7 +7711,7 @@ exports[`renders Table/demo/header-sticky.md correctly 1`] = `
                       class="arco-table-tr"
                     >
                       <td
-                        class="arco-table-td"
+                        class="arco-table-td arco-table-col-first"
                       >
                         <div
                           class="arco-table-cell"
@@ -7767,7 +7767,7 @@ exports[`renders Table/demo/header-sticky.md correctly 1`] = `
                       class="arco-table-tr"
                     >
                       <td
-                        class="arco-table-td"
+                        class="arco-table-td arco-table-col-first"
                       >
                         <div
                           class="arco-table-cell"
@@ -7921,7 +7921,7 @@ exports[`renders Table/demo/multiple-sorter.md correctly 1`] = `
                   class="arco-table-tr"
                 >
                   <th
-                    class="arco-table-th"
+                    class="arco-table-th arco-table-col-first"
                   >
                     <div
                       class="arco-table-th-item arco-table-col-has-sorter"
@@ -8222,7 +8222,7 @@ exports[`renders Table/demo/multiple-sorter.md correctly 1`] = `
                   class="arco-table-tr"
                 >
                   <td
-                    class="arco-table-td"
+                    class="arco-table-td arco-table-col-first"
                   >
                     <div
                       class="arco-table-cell"
@@ -8291,7 +8291,7 @@ exports[`renders Table/demo/multiple-sorter.md correctly 1`] = `
                   class="arco-table-tr"
                 >
                   <td
-                    class="arco-table-td"
+                    class="arco-table-td arco-table-col-first"
                   >
                     <div
                       class="arco-table-cell"
@@ -8360,7 +8360,7 @@ exports[`renders Table/demo/multiple-sorter.md correctly 1`] = `
                   class="arco-table-tr"
                 >
                   <td
-                    class="arco-table-td"
+                    class="arco-table-td arco-table-col-first"
                   >
                     <div
                       class="arco-table-cell"
@@ -8429,7 +8429,7 @@ exports[`renders Table/demo/multiple-sorter.md correctly 1`] = `
                   class="arco-table-tr"
                 >
                   <td
-                    class="arco-table-td"
+                    class="arco-table-td arco-table-col-first"
                   >
                     <div
                       class="arco-table-cell"
@@ -8498,7 +8498,7 @@ exports[`renders Table/demo/multiple-sorter.md correctly 1`] = `
                   class="arco-table-tr"
                 >
                   <td
-                    class="arco-table-td"
+                    class="arco-table-td arco-table-col-first"
                   >
                     <div
                       class="arco-table-cell"
@@ -8787,7 +8787,7 @@ exports[`renders Table/demo/operations.md correctly 1`] = `
                   class="arco-table-tr"
                 >
                   <td
-                    class="arco-table-td arco-table-operation arco-table-col-fixed-left"
+                    class="arco-table-td arco-table-operation arco-table-col-fixed-left arco-table-col-first"
                     style="left:0;width:40px;min-width:40px"
                   >
                     1
@@ -8829,7 +8829,7 @@ exports[`renders Table/demo/operations.md correctly 1`] = `
                     </label>
                   </td>
                   <td
-                    class="arco-table-td arco-table-operation arco-table-expand-icon-cell arco-table-col-fixed-left"
+                    class="arco-table-td arco-table-operation arco-table-expand-icon-cell arco-table-col-first arco-table-col-fixed-left"
                     style="left:80px"
                   >
                     <button
@@ -8908,7 +8908,7 @@ exports[`renders Table/demo/operations.md correctly 1`] = `
                   class="arco-table-tr"
                 >
                   <td
-                    class="arco-table-td arco-table-operation arco-table-col-fixed-left"
+                    class="arco-table-td arco-table-operation arco-table-col-fixed-left arco-table-col-first"
                     style="left:0;width:40px;min-width:40px"
                   >
                     2
@@ -8950,7 +8950,7 @@ exports[`renders Table/demo/operations.md correctly 1`] = `
                     </label>
                   </td>
                   <td
-                    class="arco-table-td arco-table-operation arco-table-expand-icon-cell arco-table-col-fixed-left"
+                    class="arco-table-td arco-table-operation arco-table-expand-icon-cell arco-table-col-first arco-table-col-fixed-left"
                     style="left:80px"
                   >
                     <button
@@ -9029,7 +9029,7 @@ exports[`renders Table/demo/operations.md correctly 1`] = `
                   class="arco-table-tr"
                 >
                   <td
-                    class="arco-table-td arco-table-operation arco-table-col-fixed-left"
+                    class="arco-table-td arco-table-operation arco-table-col-fixed-left arco-table-col-first"
                     style="left:0;width:40px;min-width:40px"
                   >
                     3
@@ -9071,7 +9071,7 @@ exports[`renders Table/demo/operations.md correctly 1`] = `
                     </label>
                   </td>
                   <td
-                    class="arco-table-td arco-table-operation arco-table-expand-icon-cell arco-table-col-fixed-left"
+                    class="arco-table-td arco-table-operation arco-table-expand-icon-cell arco-table-col-first arco-table-col-fixed-left"
                     style="left:80px"
                   >
                     <button
@@ -9150,7 +9150,7 @@ exports[`renders Table/demo/operations.md correctly 1`] = `
                   class="arco-table-tr arco-table-row-checked"
                 >
                   <td
-                    class="arco-table-td arco-table-operation arco-table-col-fixed-left"
+                    class="arco-table-td arco-table-operation arco-table-col-fixed-left arco-table-col-first"
                     style="left:0;width:40px;min-width:40px"
                   >
                     4
@@ -9194,7 +9194,7 @@ exports[`renders Table/demo/operations.md correctly 1`] = `
                     </label>
                   </td>
                   <td
-                    class="arco-table-td arco-table-operation arco-table-expand-icon-cell arco-table-col-fixed-left"
+                    class="arco-table-td arco-table-operation arco-table-expand-icon-cell arco-table-col-first arco-table-col-fixed-left"
                     style="left:80px"
                   />
                   <td
@@ -9255,7 +9255,7 @@ exports[`renders Table/demo/operations.md correctly 1`] = `
                   class="arco-table-tr"
                 >
                   <td
-                    class="arco-table-td arco-table-operation arco-table-col-fixed-left"
+                    class="arco-table-td arco-table-operation arco-table-col-fixed-left arco-table-col-first"
                     style="left:0;width:40px;min-width:40px"
                   >
                     5
@@ -9297,7 +9297,7 @@ exports[`renders Table/demo/operations.md correctly 1`] = `
                     </label>
                   </td>
                   <td
-                    class="arco-table-td arco-table-operation arco-table-expand-icon-cell arco-table-col-fixed-left"
+                    class="arco-table-td arco-table-operation arco-table-expand-icon-cell arco-table-col-first arco-table-col-fixed-left"
                     style="left:80px"
                   >
                     <button
@@ -9570,7 +9570,7 @@ exports[`renders Table/demo/pagination.md correctly 1`] = `
                   class="arco-table-tr"
                 >
                   <td
-                    class="arco-table-td arco-table-operation arco-table-checkbox"
+                    class="arco-table-td arco-table-operation arco-table-checkbox arco-table-col-first arco-table-col-first"
                   >
                     <label
                       class="arco-checkbox"
@@ -9660,7 +9660,7 @@ exports[`renders Table/demo/pagination.md correctly 1`] = `
                   class="arco-table-tr"
                 >
                   <td
-                    class="arco-table-td arco-table-operation arco-table-checkbox"
+                    class="arco-table-td arco-table-operation arco-table-checkbox arco-table-col-first arco-table-col-first"
                   >
                     <label
                       class="arco-checkbox"
@@ -9750,7 +9750,7 @@ exports[`renders Table/demo/pagination.md correctly 1`] = `
                   class="arco-table-tr"
                 >
                   <td
-                    class="arco-table-td arco-table-operation arco-table-checkbox"
+                    class="arco-table-td arco-table-operation arco-table-checkbox arco-table-col-first arco-table-col-first"
                   >
                     <label
                       class="arco-checkbox"
@@ -9840,7 +9840,7 @@ exports[`renders Table/demo/pagination.md correctly 1`] = `
                   class="arco-table-tr"
                 >
                   <td
-                    class="arco-table-td arco-table-operation arco-table-checkbox"
+                    class="arco-table-td arco-table-operation arco-table-checkbox arco-table-col-first arco-table-col-first"
                   >
                     <label
                       class="arco-checkbox"
@@ -9930,7 +9930,7 @@ exports[`renders Table/demo/pagination.md correctly 1`] = `
                   class="arco-table-tr"
                 >
                   <td
-                    class="arco-table-td arco-table-operation arco-table-checkbox"
+                    class="arco-table-td arco-table-operation arco-table-checkbox arco-table-col-first arco-table-col-first"
                   >
                     <label
                       class="arco-checkbox"
@@ -10020,7 +10020,7 @@ exports[`renders Table/demo/pagination.md correctly 1`] = `
                   class="arco-table-tr"
                 >
                   <td
-                    class="arco-table-td arco-table-operation arco-table-checkbox"
+                    class="arco-table-td arco-table-operation arco-table-checkbox arco-table-col-first arco-table-col-first"
                   >
                     <label
                       class="arco-checkbox"
@@ -10110,7 +10110,7 @@ exports[`renders Table/demo/pagination.md correctly 1`] = `
                   class="arco-table-tr"
                 >
                   <td
-                    class="arco-table-td arco-table-operation arco-table-checkbox"
+                    class="arco-table-td arco-table-operation arco-table-checkbox arco-table-col-first arco-table-col-first"
                   >
                     <label
                       class="arco-checkbox"
@@ -10200,7 +10200,7 @@ exports[`renders Table/demo/pagination.md correctly 1`] = `
                   class="arco-table-tr"
                 >
                   <td
-                    class="arco-table-td arco-table-operation arco-table-checkbox"
+                    class="arco-table-td arco-table-operation arco-table-checkbox arco-table-col-first arco-table-col-first"
                   >
                     <label
                       class="arco-checkbox"
@@ -10290,7 +10290,7 @@ exports[`renders Table/demo/pagination.md correctly 1`] = `
                   class="arco-table-tr"
                 >
                   <td
-                    class="arco-table-td arco-table-operation arco-table-checkbox"
+                    class="arco-table-td arco-table-operation arco-table-checkbox arco-table-col-first arco-table-col-first"
                   >
                     <label
                       class="arco-checkbox"
@@ -10380,7 +10380,7 @@ exports[`renders Table/demo/pagination.md correctly 1`] = `
                   class="arco-table-tr"
                 >
                   <td
-                    class="arco-table-td arco-table-operation arco-table-checkbox"
+                    class="arco-table-td arco-table-operation arco-table-checkbox arco-table-col-first arco-table-col-first"
                   >
                     <label
                       class="arco-checkbox"
@@ -10723,7 +10723,7 @@ exports[`renders Table/demo/render.md correctly 1`] = `
                   class="arco-table-tr"
                 >
                   <th
-                    class="arco-table-th"
+                    class="arco-table-th arco-table-col-first"
                   >
                     <div
                       class="arco-table-th-item"
@@ -10781,7 +10781,7 @@ exports[`renders Table/demo/render.md correctly 1`] = `
                   class="arco-table-tr"
                 >
                   <td
-                    class="arco-table-td"
+                    class="arco-table-td arco-table-col-first"
                   >
                     <div
                       class="arco-table-cell"
@@ -10844,7 +10844,7 @@ exports[`renders Table/demo/render.md correctly 1`] = `
                   class="arco-table-tr"
                 >
                   <td
-                    class="arco-table-td"
+                    class="arco-table-td arco-table-col-first"
                   >
                     <div
                       class="arco-table-cell"
@@ -10907,7 +10907,7 @@ exports[`renders Table/demo/render.md correctly 1`] = `
                   class="arco-table-tr"
                 >
                   <td
-                    class="arco-table-td"
+                    class="arco-table-td arco-table-col-first"
                   >
                     <div
                       class="arco-table-cell"
@@ -10970,7 +10970,7 @@ exports[`renders Table/demo/render.md correctly 1`] = `
                   class="arco-table-tr"
                 >
                   <td
-                    class="arco-table-td"
+                    class="arco-table-td arco-table-col-first"
                   >
                     <div
                       class="arco-table-cell"
@@ -11033,7 +11033,7 @@ exports[`renders Table/demo/render.md correctly 1`] = `
                   class="arco-table-tr"
                 >
                   <td
-                    class="arco-table-td"
+                    class="arco-table-td arco-table-col-first"
                   >
                     <div
                       class="arco-table-cell"
@@ -11199,7 +11199,7 @@ exports[`renders Table/demo/resizable.md correctly 1`] = `
                   class="arco-table-tr"
                 >
                   <th
-                    class="arco-table-th arco-table-col-fixed-left arco-table-col-fixed-left-last react-resizable"
+                    class="arco-table-th arco-table-col-first arco-table-col-fixed-left arco-table-col-fixed-left-last react-resizable"
                     style="left:0"
                   >
                     <div
@@ -11267,7 +11267,7 @@ exports[`renders Table/demo/resizable.md correctly 1`] = `
                   class="arco-table-tr"
                 >
                   <td
-                    class="arco-table-td arco-table-col-fixed-left arco-table-col-fixed-left-last"
+                    class="arco-table-td arco-table-col-fixed-left arco-table-col-fixed-left-last arco-table-col-first"
                     style="left:0"
                   >
                     <div
@@ -11324,7 +11324,7 @@ exports[`renders Table/demo/resizable.md correctly 1`] = `
                   class="arco-table-tr"
                 >
                   <td
-                    class="arco-table-td arco-table-col-fixed-left arco-table-col-fixed-left-last"
+                    class="arco-table-td arco-table-col-fixed-left arco-table-col-fixed-left-last arco-table-col-first"
                     style="left:0"
                   >
                     <div
@@ -11381,7 +11381,7 @@ exports[`renders Table/demo/resizable.md correctly 1`] = `
                   class="arco-table-tr"
                 >
                   <td
-                    class="arco-table-td arco-table-col-fixed-left arco-table-col-fixed-left-last"
+                    class="arco-table-td arco-table-col-fixed-left arco-table-col-fixed-left-last arco-table-col-first"
                     style="left:0"
                   >
                     <div
@@ -11438,7 +11438,7 @@ exports[`renders Table/demo/resizable.md correctly 1`] = `
                   class="arco-table-tr"
                 >
                   <td
-                    class="arco-table-td arco-table-col-fixed-left arco-table-col-fixed-left-last"
+                    class="arco-table-td arco-table-col-fixed-left arco-table-col-fixed-left-last arco-table-col-first"
                     style="left:0"
                   >
                     <div
@@ -11495,7 +11495,7 @@ exports[`renders Table/demo/resizable.md correctly 1`] = `
                   class="arco-table-tr"
                 >
                   <td
-                    class="arco-table-td arco-table-col-fixed-left arco-table-col-fixed-left-last"
+                    class="arco-table-td arco-table-col-fixed-left arco-table-col-fixed-left-last arco-table-col-first"
                     style="left:0"
                   >
                     <div
@@ -11647,7 +11647,7 @@ exports[`renders Table/demo/rowspan.md correctly 1`] = `
                   class="arco-table-tr"
                 >
                   <th
-                    class="arco-table-th"
+                    class="arco-table-th arco-table-col-first"
                   >
                     <div
                       class="arco-table-th-item"
@@ -11693,7 +11693,7 @@ exports[`renders Table/demo/rowspan.md correctly 1`] = `
                   class="arco-table-tr"
                 >
                   <td
-                    class="arco-table-td"
+                    class="arco-table-td arco-table-col-first"
                   >
                     <div
                       class="arco-table-cell"
@@ -11750,7 +11750,7 @@ exports[`renders Table/demo/rowspan.md correctly 1`] = `
                   class="arco-table-tr"
                 >
                   <td
-                    class="arco-table-td"
+                    class="arco-table-td arco-table-col-first"
                   >
                     <div
                       class="arco-table-cell"
@@ -11793,7 +11793,7 @@ exports[`renders Table/demo/rowspan.md correctly 1`] = `
                   class="arco-table-tr"
                 >
                   <td
-                    class="arco-table-td"
+                    class="arco-table-td arco-table-col-first"
                   >
                     <div
                       class="arco-table-cell"
@@ -11836,7 +11836,7 @@ exports[`renders Table/demo/rowspan.md correctly 1`] = `
                   class="arco-table-tr"
                 >
                   <td
-                    class="arco-table-td"
+                    class="arco-table-td arco-table-col-first"
                   >
                     <div
                       class="arco-table-cell"
@@ -11892,7 +11892,7 @@ exports[`renders Table/demo/rowspan.md correctly 1`] = `
                   class="arco-table-tr"
                 >
                   <td
-                    class="arco-table-td"
+                    class="arco-table-td arco-table-col-first"
                     colspan="2"
                   >
                     <div
@@ -12164,7 +12164,7 @@ exports[`renders Table/demo/selection.md correctly 1`] = `
                     class="arco-table-tr"
                   >
                     <td
-                      class="arco-table-td arco-table-operation arco-table-checkbox"
+                      class="arco-table-td arco-table-operation arco-table-checkbox arco-table-col-first arco-table-col-first"
                     >
                       <label
                         aria-disabled="false"
@@ -12255,7 +12255,7 @@ exports[`renders Table/demo/selection.md correctly 1`] = `
                     class="arco-table-tr"
                   >
                     <td
-                      class="arco-table-td arco-table-operation arco-table-checkbox"
+                      class="arco-table-td arco-table-operation arco-table-checkbox arco-table-col-first arco-table-col-first"
                     >
                       <label
                         aria-disabled="false"
@@ -12346,7 +12346,7 @@ exports[`renders Table/demo/selection.md correctly 1`] = `
                     class="arco-table-tr"
                   >
                     <td
-                      class="arco-table-td arco-table-operation arco-table-checkbox"
+                      class="arco-table-td arco-table-operation arco-table-checkbox arco-table-col-first arco-table-col-first"
                     >
                       <label
                         aria-disabled="false"
@@ -12437,7 +12437,7 @@ exports[`renders Table/demo/selection.md correctly 1`] = `
                     class="arco-table-tr arco-table-row-checked"
                   >
                     <td
-                      class="arco-table-td arco-table-operation arco-table-checkbox"
+                      class="arco-table-td arco-table-operation arco-table-checkbox arco-table-col-first arco-table-col-first"
                     >
                       <label
                         aria-disabled="true"
@@ -12531,7 +12531,7 @@ exports[`renders Table/demo/selection.md correctly 1`] = `
                     class="arco-table-tr"
                   >
                     <td
-                      class="arco-table-td arco-table-operation arco-table-checkbox"
+                      class="arco-table-td arco-table-operation arco-table-checkbox arco-table-col-first arco-table-col-first"
                     >
                       <label
                         aria-disabled="false"
@@ -12718,7 +12718,7 @@ exports[`renders Table/demo/sorter.md correctly 1`] = `
                   class="arco-table-tr"
                 >
                   <th
-                    class="arco-table-th"
+                    class="arco-table-th arco-table-col-first"
                   >
                     <div
                       class="arco-table-th-item arco-table-col-has-sorter"
@@ -12929,7 +12929,7 @@ exports[`renders Table/demo/sorter.md correctly 1`] = `
                   class="arco-table-tr"
                 >
                   <td
-                    class="arco-table-td"
+                    class="arco-table-td arco-table-col-first"
                   >
                     <div
                       class="arco-table-cell"
@@ -12985,7 +12985,7 @@ exports[`renders Table/demo/sorter.md correctly 1`] = `
                   class="arco-table-tr"
                 >
                   <td
-                    class="arco-table-td"
+                    class="arco-table-td arco-table-col-first"
                   >
                     <div
                       class="arco-table-cell"
@@ -13041,7 +13041,7 @@ exports[`renders Table/demo/sorter.md correctly 1`] = `
                   class="arco-table-tr"
                 >
                   <td
-                    class="arco-table-td"
+                    class="arco-table-td arco-table-col-first"
                   >
                     <div
                       class="arco-table-cell"
@@ -13097,7 +13097,7 @@ exports[`renders Table/demo/sorter.md correctly 1`] = `
                   class="arco-table-tr"
                 >
                   <td
-                    class="arco-table-td"
+                    class="arco-table-td arco-table-col-first"
                   >
                     <div
                       class="arco-table-cell"
@@ -13248,7 +13248,7 @@ exports[`renders Table/demo/style.md correctly 1`] = `
                   class="arco-table-tr"
                 >
                   <th
-                    class="arco-table-th"
+                    class="arco-table-th arco-table-col-first"
                     style="background-color:var(--color-bg-2)"
                   >
                     <div
@@ -13310,7 +13310,7 @@ exports[`renders Table/demo/style.md correctly 1`] = `
                   class="arco-table-tr"
                 >
                   <td
-                    class="arco-table-td"
+                    class="arco-table-td arco-table-col-first"
                   >
                     <div
                       class="arco-table-cell"
@@ -13366,7 +13366,7 @@ exports[`renders Table/demo/style.md correctly 1`] = `
                   class="arco-table-tr"
                 >
                   <td
-                    class="arco-table-td"
+                    class="arco-table-td arco-table-col-first"
                   >
                     <div
                       class="arco-table-cell"
@@ -13422,7 +13422,7 @@ exports[`renders Table/demo/style.md correctly 1`] = `
                   class="arco-table-tr"
                 >
                   <td
-                    class="arco-table-td"
+                    class="arco-table-td arco-table-col-first"
                   >
                     <div
                       class="arco-table-cell"
@@ -13478,7 +13478,7 @@ exports[`renders Table/demo/style.md correctly 1`] = `
                   class="arco-table-tr"
                 >
                   <td
-                    class="arco-table-td"
+                    class="arco-table-td arco-table-col-first"
                   >
                     <div
                       class="arco-table-cell"
@@ -13534,7 +13534,7 @@ exports[`renders Table/demo/style.md correctly 1`] = `
                   class="arco-table-tr"
                 >
                   <td
-                    class="arco-table-td"
+                    class="arco-table-td arco-table-col-first"
                   >
                     <div
                       class="arco-table-cell"
@@ -13688,7 +13688,7 @@ exports[`renders Table/demo/summary.md correctly 1`] = `
                     class="arco-table-tr"
                   >
                     <th
-                      class="arco-table-th arco-table-col-fixed-left arco-table-col-fixed-left-last"
+                      class="arco-table-th arco-table-col-first arco-table-col-fixed-left arco-table-col-fixed-left-last"
                       style="left:0"
                     >
                       <div
@@ -13747,7 +13747,7 @@ exports[`renders Table/demo/summary.md correctly 1`] = `
                     class="arco-table-tr"
                   >
                     <td
-                      class="arco-table-td arco-table-col-fixed-left arco-table-col-fixed-left-last"
+                      class="arco-table-td arco-table-col-fixed-left arco-table-col-fixed-left-last arco-table-col-first"
                       style="left:0"
                     >
                       <div
@@ -13804,7 +13804,7 @@ exports[`renders Table/demo/summary.md correctly 1`] = `
                     class="arco-table-tr"
                   >
                     <td
-                      class="arco-table-td arco-table-col-fixed-left arco-table-col-fixed-left-last"
+                      class="arco-table-td arco-table-col-fixed-left arco-table-col-fixed-left-last arco-table-col-first"
                       style="left:0"
                     >
                       <div
@@ -13861,7 +13861,7 @@ exports[`renders Table/demo/summary.md correctly 1`] = `
                     class="arco-table-tr"
                   >
                     <td
-                      class="arco-table-td arco-table-col-fixed-left arco-table-col-fixed-left-last"
+                      class="arco-table-td arco-table-col-fixed-left arco-table-col-fixed-left-last arco-table-col-first"
                       style="left:0"
                     >
                       <div
@@ -13918,7 +13918,7 @@ exports[`renders Table/demo/summary.md correctly 1`] = `
                     class="arco-table-tr"
                   >
                     <td
-                      class="arco-table-td arco-table-col-fixed-left arco-table-col-fixed-left-last"
+                      class="arco-table-td arco-table-col-fixed-left arco-table-col-fixed-left-last arco-table-col-first"
                       style="left:0"
                     >
                       <div
@@ -13975,7 +13975,7 @@ exports[`renders Table/demo/summary.md correctly 1`] = `
                     class="arco-table-tr"
                   >
                     <td
-                      class="arco-table-td arco-table-col-fixed-left arco-table-col-fixed-left-last"
+                      class="arco-table-td arco-table-col-fixed-left arco-table-col-fixed-left-last arco-table-col-first"
                       style="left:0"
                     >
                       <div
@@ -14166,7 +14166,7 @@ exports[`renders Table/demo/summary.md correctly 1`] = `
                     class="arco-table-tr"
                   >
                     <th
-                      class="arco-table-th arco-table-col-fixed-left arco-table-col-fixed-left-last"
+                      class="arco-table-th arco-table-col-first arco-table-col-fixed-left arco-table-col-fixed-left-last"
                       style="left:0"
                     >
                       <div
@@ -14239,7 +14239,7 @@ exports[`renders Table/demo/summary.md correctly 1`] = `
                     class="arco-table-tr"
                   >
                     <td
-                      class="arco-table-td arco-table-col-fixed-left arco-table-col-fixed-left-last"
+                      class="arco-table-td arco-table-col-fixed-left arco-table-col-fixed-left-last arco-table-col-first"
                       style="left:0"
                     >
                       <div
@@ -14317,7 +14317,7 @@ exports[`renders Table/demo/summary.md correctly 1`] = `
                     class="arco-table-tr"
                   >
                     <td
-                      class="arco-table-td arco-table-col-fixed-left arco-table-col-fixed-left-last"
+                      class="arco-table-td arco-table-col-fixed-left arco-table-col-fixed-left-last arco-table-col-first"
                       style="left:0"
                     >
                       <div
@@ -14395,7 +14395,7 @@ exports[`renders Table/demo/summary.md correctly 1`] = `
                     class="arco-table-tr"
                   >
                     <td
-                      class="arco-table-td arco-table-col-fixed-left arco-table-col-fixed-left-last"
+                      class="arco-table-td arco-table-col-fixed-left arco-table-col-fixed-left-last arco-table-col-first"
                       style="left:0"
                     >
                       <div
@@ -14473,7 +14473,7 @@ exports[`renders Table/demo/summary.md correctly 1`] = `
                     class="arco-table-tr"
                   >
                     <td
-                      class="arco-table-td arco-table-col-fixed-left arco-table-col-fixed-left-last"
+                      class="arco-table-td arco-table-col-fixed-left arco-table-col-fixed-left-last arco-table-col-first"
                       style="left:0"
                     >
                       <div
@@ -14551,7 +14551,7 @@ exports[`renders Table/demo/summary.md correctly 1`] = `
                     class="arco-table-tr"
                   >
                     <td
-                      class="arco-table-td arco-table-col-fixed-left arco-table-col-fixed-left-last"
+                      class="arco-table-td arco-table-col-fixed-left arco-table-col-fixed-left-last arco-table-col-first"
                       style="left:0"
                     >
                       <div
@@ -14786,7 +14786,7 @@ exports[`renders Table/demo/summary.md correctly 1`] = `
                       class="arco-table-tr"
                     >
                       <th
-                        class="arco-table-th arco-table-col-fixed-left arco-table-col-fixed-left-last"
+                        class="arco-table-th arco-table-col-first arco-table-col-fixed-left arco-table-col-fixed-left-last"
                         style="left:0"
                       >
                         <div
@@ -14862,7 +14862,7 @@ exports[`renders Table/demo/summary.md correctly 1`] = `
                       class="arco-table-tr"
                     >
                       <td
-                        class="arco-table-td arco-table-col-fixed-left arco-table-col-fixed-left-last"
+                        class="arco-table-td arco-table-col-fixed-left arco-table-col-fixed-left-last arco-table-col-first"
                         style="left:0"
                       >
                         <div
@@ -14919,7 +14919,7 @@ exports[`renders Table/demo/summary.md correctly 1`] = `
                       class="arco-table-tr"
                     >
                       <td
-                        class="arco-table-td arco-table-col-fixed-left arco-table-col-fixed-left-last"
+                        class="arco-table-td arco-table-col-fixed-left arco-table-col-fixed-left-last arco-table-col-first"
                         style="left:0"
                       >
                         <div
@@ -14976,7 +14976,7 @@ exports[`renders Table/demo/summary.md correctly 1`] = `
                       class="arco-table-tr"
                     >
                       <td
-                        class="arco-table-td arco-table-col-fixed-left arco-table-col-fixed-left-last"
+                        class="arco-table-td arco-table-col-fixed-left arco-table-col-fixed-left-last arco-table-col-first"
                         style="left:0"
                       >
                         <div
@@ -15033,7 +15033,7 @@ exports[`renders Table/demo/summary.md correctly 1`] = `
                       class="arco-table-tr"
                     >
                       <td
-                        class="arco-table-td arco-table-col-fixed-left arco-table-col-fixed-left-last"
+                        class="arco-table-td arco-table-col-fixed-left arco-table-col-fixed-left-last arco-table-col-first"
                         style="left:0"
                       >
                         <div
@@ -15090,7 +15090,7 @@ exports[`renders Table/demo/summary.md correctly 1`] = `
                       class="arco-table-tr"
                     >
                       <td
-                        class="arco-table-td arco-table-col-fixed-left arco-table-col-fixed-left-last"
+                        class="arco-table-td arco-table-col-fixed-left arco-table-col-fixed-left-last arco-table-col-first"
                         style="left:0"
                       >
                         <div
@@ -15305,7 +15305,7 @@ Array [
                     class="arco-table-tr"
                   >
                     <th
-                      class="arco-table-th"
+                      class="arco-table-th arco-table-col-first"
                     >
                       <div
                         class="arco-table-th-item"
@@ -15378,7 +15378,7 @@ Array [
                     style="display:table-row"
                   >
                     <td
-                      class="arco-table-td"
+                      class="arco-table-td arco-table-col-first"
                     >
                       <div
                         class="arco-table-cell"
@@ -15456,7 +15456,7 @@ Array [
                     style="display:table-row"
                   >
                     <td
-                      class="arco-table-td"
+                      class="arco-table-td arco-table-col-first"
                     >
                       <div
                         class="arco-table-cell"
@@ -15534,7 +15534,7 @@ Array [
                     style="display:table-row"
                   >
                     <td
-                      class="arco-table-td"
+                      class="arco-table-td arco-table-col-first"
                     >
                       <div
                         class="arco-table-cell"
@@ -15612,7 +15612,7 @@ Array [
                     style="display:table-row"
                   >
                     <td
-                      class="arco-table-td"
+                      class="arco-table-td arco-table-col-first"
                     >
                       <div
                         class="arco-table-cell"
@@ -15690,7 +15690,7 @@ Array [
                     style="display:table-row"
                   >
                     <td
-                      class="arco-table-td"
+                      class="arco-table-td arco-table-col-first"
                     >
                       <div
                         class="arco-table-cell"
@@ -15993,7 +15993,7 @@ exports[`renders Table/demo/virtualized.md correctly 1`] = `
                       class="arco-table-tr"
                     >
                       <div
-                        class="arco-table-td arco-table-operation arco-table-checkbox arco-table-selection-col arco-table-col-fixed-left"
+                        class="arco-table-td arco-table-operation arco-table-checkbox arco-table-selection-col arco-table-col-first arco-table-col-fixed-left arco-table-col-first"
                         style="left:0"
                       >
                         <label

--- a/components/Table/__test__/__snapshots__/index.test.tsx.snap
+++ b/components/Table/__test__/__snapshots__/index.test.tsx.snap
@@ -28,7 +28,7 @@ exports[`ConfigProvider componentConfig.Table default 1`] = `
                   class="arco-table-tr"
                 >
                   <th
-                    class="arco-table-th"
+                    class="arco-table-th arco-table-col-first"
                   >
                     <div
                       class="arco-table-th-item"
@@ -45,7 +45,7 @@ exports[`ConfigProvider componentConfig.Table default 1`] = `
                   class="arco-table-tr arco-table-empty-row"
                 >
                   <td
-                    class="arco-table-td"
+                    class="arco-table-td arco-table-col-first"
                     colspan="1"
                   >
                     <div
@@ -122,7 +122,7 @@ exports[`ConfigProvider componentConfig.Table set className globally 1`] = `
                   class="arco-table-tr"
                 >
                   <th
-                    class="arco-table-th"
+                    class="arco-table-th arco-table-col-first"
                   >
                     <div
                       class="arco-table-th-item"
@@ -139,7 +139,7 @@ exports[`ConfigProvider componentConfig.Table set className globally 1`] = `
                   class="arco-table-tr arco-table-empty-row"
                 >
                   <td
-                    class="arco-table-td"
+                    class="arco-table-td arco-table-col-first"
                     colspan="1"
                   >
                     <div
@@ -216,7 +216,7 @@ exports[`ConfigProvider componentConfig.Table set className globally and compone
                   class="arco-table-tr"
                 >
                   <th
-                    class="arco-table-th"
+                    class="arco-table-th arco-table-col-first"
                   >
                     <div
                       class="arco-table-th-item"
@@ -233,7 +233,7 @@ exports[`ConfigProvider componentConfig.Table set className globally and compone
                   class="arco-table-tr arco-table-empty-row"
                 >
                   <td
-                    class="arco-table-td"
+                    class="arco-table-td arco-table-col-first"
                     colspan="1"
                   >
                     <div

--- a/components/Table/__test__/components.test.tsx
+++ b/components/Table/__test__/components.test.tsx
@@ -143,7 +143,7 @@ describe('Table components', () => {
     jest.runAllTimers();
 
     expect(component.find('tbody .arco-table-checkbox').item(0).className).toBe(
-      'arco-table-td arco-table-operation arco-table-checkbox arco-tooltip-open'
+      'arco-table-td arco-table-operation arco-table-checkbox arco-table-col-first arco-tooltip-open'
     );
   });
 

--- a/components/Table/__test__/fixed-columns.test.tsx
+++ b/components/Table/__test__/fixed-columns.test.tsx
@@ -35,21 +35,21 @@ describe('Table fixed columns', () => {
       component.find('td.arco-table-col-fixed-right.arco-table-col-fixed-right-first')
     ).toHaveLength(5);
 
-    function getHeadCell(i) {
+    function getHeadCell(i: number) {
       return headTr.querySelectorAll('th').item(i);
     }
 
-    function getBodyCell(i) {
+    function getBodyCell(i: number) {
       return bodyTr.querySelectorAll('td').item(i);
     }
 
     expect(getHeadCell(0).className).toBe(
-      'arco-table-th arco-table-col-fixed-left arco-table-col-fixed-left-last'
+      'arco-table-th arco-table-col-first arco-table-col-fixed-left arco-table-col-fixed-left-last'
     );
     expect(getHeadCell(0).getAttribute('style')).toEqual('left: 0px;');
 
     expect(getBodyCell(0).className).toBe(
-      'arco-table-td arco-table-col-fixed-left arco-table-col-fixed-left-last'
+      'arco-table-td arco-table-col-fixed-left arco-table-col-fixed-left-last arco-table-col-first'
     );
     expect(getBodyCell(0).getAttribute('style')).toEqual('left: 0px;');
   });
@@ -78,11 +78,11 @@ describe('Table fixed columns', () => {
     const headTr = component.find('thead tr').item(0);
     const bodyTr = component.find('tbody tr').item(0);
 
-    function getHeadCell(i) {
+    function getHeadCell(i: number) {
       return headTr.querySelectorAll('th').item(i);
     }
 
-    function getBodyCell(i) {
+    function getBodyCell(i: number) {
       return bodyTr.querySelectorAll('td').item(i);
     }
 
@@ -97,7 +97,7 @@ describe('Table fixed columns', () => {
     expect(getHeadCell(1).getAttribute('style')).toEqual('left: 40px;');
 
     expect(getBodyCell(0).className).toBe(
-      'arco-table-td arco-table-operation arco-table-expand-icon-cell arco-table-col-fixed-left'
+      'arco-table-td arco-table-operation arco-table-expand-icon-cell arco-table-col-first arco-table-col-fixed-left arco-table-col-first'
     );
     expect(getBodyCell(0).getAttribute('style')).toEqual('left: 0px;');
 
@@ -127,20 +127,20 @@ describe('Table fixed columns', () => {
       <Table scroll={{ x: 600, y: 200 }} columns={fixedColumns} data={data} />
     );
 
-    function getHeadCell(component, i) {
-      return component.find('thead tr')[0].querySelectorAll('th').item(i);
+    function getHeadCell(component: any, i: number) {
+      return component.find('thead tr').item(0).querySelectorAll('th').item(i);
     }
 
-    function getBodyCell(component, i) {
-      return component.find('tbody tr')[0].querySelectorAll('td').item(i);
+    function getBodyCell(component: any, i: number) {
+      return component.find('tbody tr').item(0).querySelectorAll('td').item(i);
     }
 
-    expect(getHeadCell(component, 0).className).toBe('arco-table-th');
+    expect(getHeadCell(component, 0).className).toBe('arco-table-th arco-table-col-first');
     expect(getHeadCell(component, 0).getAttribute('style')).toEqual(null);
     expect(getHeadCell(component, 1).className).toBe('arco-table-th');
     expect(getHeadCell(component, 1).getAttribute('style')).toEqual(null);
 
-    expect(getBodyCell(component, 0).className).toBe('arco-table-td');
+    expect(getBodyCell(component, 0).className).toBe('arco-table-td arco-table-col-first');
     expect(getBodyCell(component, 0).getAttribute('style')).toEqual(null);
     expect(getBodyCell(component, 1).className).toBe('arco-table-td');
     expect(getBodyCell(component, 1).getAttribute('style')).toEqual(null);
@@ -158,14 +158,18 @@ describe('Table fixed columns', () => {
       />
     );
 
-    expect(getHeadCell(component, 0).className).toBe('arco-table-th arco-table-col-fixed-left');
+    expect(getHeadCell(component, 0).className).toBe(
+      'arco-table-th arco-table-col-first arco-table-col-fixed-left'
+    );
     expect(getHeadCell(component, 0).getAttribute('style')).toEqual('left: 0px;');
     expect(getHeadCell(component, 1).className).toBe(
       'arco-table-th arco-table-col-fixed-left arco-table-col-fixed-left-last'
     );
     expect(getHeadCell(component, 1).getAttribute('style')).toEqual('left: 100px;');
 
-    expect(getBodyCell(component, 0).className).toBe('arco-table-td arco-table-col-fixed-left');
+    expect(getBodyCell(component, 0).className).toBe(
+      'arco-table-td arco-table-col-fixed-left arco-table-col-first'
+    );
     expect(getBodyCell(component, 0).getAttribute('style')).toEqual('left: 0px;');
     expect(getBodyCell(component, 1).className).toBe(
       'arco-table-td arco-table-col-fixed-left arco-table-col-fixed-left-last'
@@ -202,11 +206,11 @@ describe('Table fixed columns', () => {
     const headTr = component.find('thead tr').item(0);
     const bodyTr = component.find('tbody tr').item(0);
 
-    function getHeadCell(i) {
+    function getHeadCell(i: number) {
       return headTr.querySelectorAll('th').item(i);
     }
 
-    function getBodyCell(i) {
+    function getBodyCell(i: number) {
       return bodyTr.querySelectorAll('td').item(i);
     }
 

--- a/components/Table/style/index.less
+++ b/components/Table/style/index.less
@@ -613,8 +613,8 @@
       }
     }
 
-    .@{table-cls-th}:first-child,
-    .@{table-cls-td}:first-child {
+    .@{table-cls-th}.@{table-prefix-cls}-col-first,
+    .@{table-cls-td}.@{table-prefix-cls}-col-first {
       border-left: @table-border-width @table-border-style @table-color-border;
     }
 
@@ -656,8 +656,8 @@
   }
 
   &-border-cell:not(&-border) {
-    .@{table-cls-th}:first-child,
-    .@{table-cls-td}:first-child {
+    .@{table-cls-th}.@{table-prefix-cls}-col-first,
+    .@{table-cls-td}.@{table-prefix-cls}-col-first {
       border-left: 0;
     }
   }
@@ -855,8 +855,8 @@
   }
 
   &-rtl&-border-cell:not(&-border) {
-    .@{table-cls-th}:first-child,
-    .@{table-cls-td}:first-child {
+    .@{table-cls-th}.@{table-prefix-cls}-col-first,
+    .@{table-cls-td}.@{table-prefix-cls}-col-first {
       border-right: 0;
     }
   }

--- a/components/Table/tbody/index.tsx
+++ b/components/Table/tbody/index.tsx
@@ -121,7 +121,7 @@ const DataRecordRenderer = forwardRef(function (
           className={cs(`${prefixCls}-tr`, `${prefixCls}-expand-content`)}
         >
           <TDTagName
-            className={cs(`${prefixCls}-td`)}
+            className={cs(`${prefixCls}-td`, `${prefixCls}-col-first`)}
             style={{ paddingLeft: indentSize }}
             colSpan={columns.length}
           >
@@ -185,7 +185,7 @@ function TBody<T>(props: TbodyProps<T>) {
 
   const noDataTr = (
     <tr className={cs(`${prefixCls}-tr`, `${prefixCls}-empty-row`)}>
-      <td className={`${prefixCls}-td`} colSpan={columns.length}>
+      <td className={cs(`${prefixCls}-td`, `${prefixCls}-col-first`)} colSpan={columns.length}>
         <div {...noElementProps}>{noDataElement}</div>
       </td>
     </tr>

--- a/components/Table/tbody/td.tsx
+++ b/components/Table/tbody/td.tsx
@@ -63,6 +63,7 @@ function Td(props: TdType) {
     {
       [`${prefixCls}-col-sorted`]:
         currentSorter && currentSorter.direction && currentSorter.field === column.dataIndex,
+      [`${prefixCls}-col-first`]: columnIndex === 0,
     },
     column.className
   );

--- a/components/Table/tbody/tr.tsx
+++ b/components/Table/tbody/tr.tsx
@@ -75,10 +75,11 @@ function Tr<T>(props: TrType<T>, ref) {
       ? rowSelection.checkboxProps(originRecord)
       : {};
   const operationClassName = cs(`${prefixCls}-td`, `${prefixCls}-operation`);
-  const getPrefixColClassName = (name) => {
+  const getPrefixColClassName = (name, index) => {
     return cs(operationClassName, `${prefixCls}-${name}`, {
       [`${prefixCls}-selection-col`]: (virtualized && type === 'checkbox') || type === 'radio',
       [`${prefixCls}-expand-icon-col`]: virtualized && expandedRowRender,
+      [`${prefixCls}-col-first`]: index === 0,
     });
   };
 
@@ -145,7 +146,7 @@ function Tr<T>(props: TrType<T>, ref) {
   }
 
   const expandNode = expandedRowRender && (
-    <InnerComponentTd className={getPrefixColClassName('expand-icon-cell')}>
+    <InnerComponentTd className={getPrefixColClassName('expand-icon-cell', 0)}>
       {shouldRenderExpandRow && renderExpandIcon(record, rowK)}
     </InnerComponentTd>
   );
@@ -174,7 +175,7 @@ function Tr<T>(props: TrType<T>, ref) {
 
   if (type === 'checkbox') {
     selectionNode = (
-      <InnerComponentTd className={getPrefixColClassName('checkbox')}>
+      <InnerComponentTd className={getPrefixColClassName('checkbox', expandNode ? 1 : 0)}>
         {renderSelectionCell
           ? renderSelectionCell(checkboxNode, checked, originRecord)
           : checkboxNode}
@@ -183,7 +184,7 @@ function Tr<T>(props: TrType<T>, ref) {
   }
   if (type === 'radio') {
     selectionNode = (
-      <InnerComponentTd className={getPrefixColClassName('radio')}>
+      <InnerComponentTd className={getPrefixColClassName('radio', expandNode ? 1 : 0)}>
         {renderSelectionCell ? renderSelectionCell(radioNode, checked, originRecord) : radioNode}
       </InnerComponentTd>
     );
@@ -219,7 +220,10 @@ function Tr<T>(props: TrType<T>, ref) {
             className: cs(
               isExtraOperation ? operationClassName : '',
               operationNode?.props?.className,
-              stickyClassName
+              stickyClassName,
+              {
+                [`${prefixCls}-col-first`]: colIndex === 0,
+              }
             ),
             style: {
               ...operationNode?.props?.style,

--- a/components/Table/thead/column.tsx
+++ b/components/Table/thead/column.tsx
@@ -326,6 +326,7 @@ function Column<T>({
           {
             [`${prefixCls}-col-sorted`]:
               currentSorter && currentSorter.direction && currentSorter.field === innerDataIndex,
+            [`${prefixCls}-col-first`]: index === 0,
           },
           className
         )}

--- a/components/Transfer/__test__/__snapshots__/demo.test.ts.snap
+++ b/components/Transfer/__test__/__snapshots__/demo.test.ts.snap
@@ -5199,7 +5199,7 @@ exports[`renders Transfer/demo/with-table.md correctly 1`] = `
                         class="arco-table-tr"
                       >
                         <td
-                          class="arco-table-td arco-table-operation arco-table-checkbox"
+                          class="arco-table-td arco-table-operation arco-table-checkbox arco-table-col-first arco-table-col-first"
                         >
                           <label
                             class="arco-checkbox"
@@ -5276,7 +5276,7 @@ exports[`renders Transfer/demo/with-table.md correctly 1`] = `
                         class="arco-table-tr"
                       >
                         <td
-                          class="arco-table-td arco-table-operation arco-table-checkbox"
+                          class="arco-table-td arco-table-operation arco-table-checkbox arco-table-col-first arco-table-col-first"
                         >
                           <label
                             class="arco-checkbox"
@@ -5353,7 +5353,7 @@ exports[`renders Transfer/demo/with-table.md correctly 1`] = `
                         class="arco-table-tr"
                       >
                         <td
-                          class="arco-table-td arco-table-operation arco-table-checkbox"
+                          class="arco-table-td arco-table-operation arco-table-checkbox arco-table-col-first arco-table-col-first"
                         >
                           <label
                             class="arco-checkbox"
@@ -5430,7 +5430,7 @@ exports[`renders Transfer/demo/with-table.md correctly 1`] = `
                         class="arco-table-tr"
                       >
                         <td
-                          class="arco-table-td arco-table-operation arco-table-checkbox"
+                          class="arco-table-td arco-table-operation arco-table-checkbox arco-table-col-first arco-table-col-first"
                         >
                           <label
                             class="arco-checkbox"
@@ -5822,7 +5822,7 @@ exports[`renders Transfer/demo/with-table.md correctly 1`] = `
                         class="arco-table-tr arco-table-empty-row"
                       >
                         <td
-                          class="arco-table-td"
+                          class="arco-table-td arco-table-col-first"
                           colspan="4"
                         >
                           <div


### PR DESCRIPTION
Fix the issue in the Table component where, when merging cells in the first column, even if borderCell is set to false, some internal borders are still exposed.

<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context

<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->
Arco Table中， 在补齐表格最左侧的外边框时，CSS 原本依赖 :first-child 伪类选择器为每一行的第一个单元格添加 border-left，但在 单元格合并 (rowSpan > 1) 场景下：
1. 被合并行（后续行）的首列单元格在 DOM 中是 缺失 的（逻辑返回 null）。
2. 浏览器会将该行原本的 第二列 识别为物理上的 :first-child。
3. 这导致第二列被错误地应用了左边框，从而在表格内部产生了一条多余的垂直线（y 轴边框未隐藏）。

## Solution

<!-- Describe how the problem is fixed in detail -->
核心方案是将边框控制逻辑从 “物理 CSS 伪类” 转变为 “逻辑类名标识”，并实现布局与业务逻辑的解耦：
1. 引入物理首列标识 (arco-table-col-first)：在渲染层（td.tsx、column.tsx、tr.tsx）中，直接根据渲染索引 index === 0 或 columnIndex === 0 为真正的物理第一列添加类名。
2. 样式重构：修改 style/index.less，将所有针对 :first-child 的边框定义（补齐外边框、关闭 borderCell 时隐藏内部线）全部替换为基于 .arco-table-col-first 的定义。

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
| Table          | 修复 `Table` 组件第一列在合并单元格时，即便将borderCell设置为false，内部仍有部分边框外露的问题              |               Fix the issue in the `Table` component where, when merging cells in the first column, even if borderCell is set to false, some internal borders are still exposed.  |                |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->
## Checklist:

- [ ] Test suite passes (`npm run test`)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
