### PR TITLE
fix(Table):  Fix the issue that, after enabling virtual scrolling in the Table component, when there is an instance of empty data, the table header and the table body no longer scroll horizontally in sync.

### DIFF
--- a/components/Table/table.tsx
+++ b/components/Table/table.tsx
@@ -185,8 +185,14 @@ function Table<T extends unknown>(baseProps: TableProps<T>, ref: React.Ref<Table
       if (column.filteredValue) {
         currentFilters[innerDataIndex] = column.filteredValue;
       }
-      const hasDefaultSortOrder = 'defaultSortOrder' in column && typeof column.defaultSortOrder !== 'undefined' && column.defaultSortOrder !== null;
-      const hasSortOrder = 'sortOrder' in column && typeof column.sortOrder !== 'undefined' && column.sortOrder !== null;
+      const hasDefaultSortOrder =
+        'defaultSortOrder' in column &&
+        typeof column.defaultSortOrder !== 'undefined' &&
+        column.defaultSortOrder !== null;
+      const hasSortOrder =
+        'sortOrder' in column &&
+        typeof column.sortOrder !== 'undefined' &&
+        column.sortOrder !== null;
       if (hasDefaultSortOrder || hasSortOrder) {
         const priority = getSorterPriority(column.sorter);
         const direction = hasSortOrder ? column.sortOrder : column.defaultSortOrder;
@@ -273,7 +279,11 @@ function Table<T extends unknown>(baseProps: TableProps<T>, ref: React.Ref<Table
     return (a, b) => {
       for (let i = 0, l = sorters.length; i < l; i++) {
         const { sorterFn, direction } = sorters[i];
-        if (typeof sorterFn !== 'function' || typeof direction === 'undefined' || direction === null) {
+        if (
+          typeof sorterFn !== 'function' ||
+          typeof direction === 'undefined' ||
+          direction === null
+        ) {
           continue;
         }
         const result = compare(sorterFn, direction)(a, b);
@@ -509,7 +519,16 @@ function Table<T extends unknown>(baseProps: TableProps<T>, ref: React.Ref<Table
         off(tableFoot, 'scroll', tableScrollHandler);
       }
     };
-  }, [hasFixedColumnLeft, hasFixedColumnRight, scroll?.x, scroll?.y, flattenColumns.length, data]);
+  }, [
+    hasFixedColumnLeft,
+    hasFixedColumnRight,
+    scroll?.x,
+    scroll?.y,
+    flattenColumns.length,
+    data,
+    virtualized,
+    pageData.length === 0,
+  ]);
 
   useUpdate(() => {
     const { total, pageSize } = getPaginationProps(data);
@@ -836,7 +855,12 @@ function Table<T extends unknown>(baseProps: TableProps<T>, ref: React.Ref<Table
   const tbodyNode = (
     <Tbody<T>
       {...props}
-      saveRef={(node) => (refTBody.current = node)}
+      saveRef={(node) => {
+        refTBody.current = node;
+        if (virtualized && pageData.length === 0) {
+          refTableBody.current = node;
+        }
+      }}
       selectedRowKeys={selectedRowKeys}
       indeterminateKeys={indeterminateKeys}
       expandedRowKeys={expandedRowKeys}


### PR DESCRIPTION
Fix the issue that, after enabling virtual scrolling in the Table component, when there is an instance of empty data, the table header and the table body no longer scroll horizontally in sync.

<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context

<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->
当开启虚拟滚动时，Table 组件使用 VirtualList 作为滚动容器。正常有数据情况下，refTableBody 会被设置为指向 VirtualList 的 DOM 节点。当过滤结果为空时，Tbody 组件不再渲染 VirtualList，而是渲染一个包含“暂无数据”提示的普通 div 容器。Table 在 useIsomorphicLayoutEffect 中对 refTableBody.current 绑定滚动事件。由于空数据时容器发生了变化，且该 Effect 的依赖项未能在数据重置回有数据状态时正确触发重新绑定（或者在空数据时未能正确获取到临时的滚动容器），导致数据恢复后，refTableBody 指向了新的 VirtualList 节点，但其上的滚动事件监听器（tableScrollHandler）并未重新挂载

## Solution

<!-- Describe how the problem is fixed in detail -->

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|  Table         |  修复 `Table` 组件开启虚拟滚动后，在出现一次空数据的情况下，表头与表身不再同步横向滚动的问题             |  Fix the issue that, after enabling virtual scrolling in the `Table` component, when there is an instance of empty data, the table header and the table body no longer scroll horizontally in sync.             |                |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->
## Checklist:

- [ ] Test suite passes (`npm run test`)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
