### PR TITLE
fix(Message) : Fix the issue that when closing the previous message messageA and displaying a new message messageB in the Message component, the new message messageB fails to display properly.

### DIFF
--- a/components/_class/notification.tsx
+++ b/components/_class/notification.tsx
@@ -48,20 +48,25 @@ class BaseNotice extends Component<any, BaseNoticeState> {
   };
 
   update = (newNotice) => {
-    const updatedNotices = this.state.notices.map((oldNotice) =>
-      newNotice.id === oldNotice.id ? newNotice : oldNotice
-    );
-
     this.setState(
-      {
-        notices: updatedNotices,
+      (prevState) => {
+        const updatedNotices = prevState.notices.map((oldNotice) =>
+          newNotice.id === oldNotice.id ? newNotice : oldNotice
+        );
+        return {
+          notices: updatedNotices,
+        };
       },
       () => {
-        const notices = updatedNotices.map((notice) => {
-          if (newNotice.id === notice.id) delete notice.update;
-          return notice;
+        this.setState((prevState) => {
+          const notices = prevState.notices.map((notice) => {
+            if (newNotice.id === notice.id && notice.update) {
+              delete notice.update;
+            }
+            return notice;
+          });
+          return { notices };
         });
-        this.setState({ notices });
       }
     );
   };


### PR DESCRIPTION
Fix the issue that when closing the previous message messageA and displaying a new message messageB in the Message component, the new message messageB fails to display properly.

<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context
```javascript
import { Message, Button } from "@arco-design/web-react";

const delaySuccess = () => {
  return new Promise((resolve) => {
    setTimeout(() => {
      resolve("success");
    }, 3000);
  });
};
const App = () => {
  return (
    <Button
      onClick={async () => {
        const close = Message.info("Loading...");
        const resp = await delaySuccess();
        close();
        Message.success("智能分集完成，请确认是否符合创作预期");
      }}
      type="primary"
    >
      Open Message
    </Button>
  );
};

export default App;
```
对于以上case，`Message.success("智能分集完成，请确认是否符合创作预期")`无法正常显示

### 问题原因
接着 close() 调用 Message.success() 时，React 状态更新会发生冲突，导致新的消息未能正确挂载:
1. close() 触发 update：
当调用 close() 时，它会调用 Message 实例的 update 方法来设置 opacity: 0。这个方法定义在 components/_class/notification.tsx 中：
```javascript
update = (newNotice) => {
  // 1. 这里计算了当前时刻的 notices 数组（包含旧的 Loading 消息）
  const updatedNotices = this.state.notices.map(...) 

  this.setState(
    { notices: updatedNotices }, // 2. 调度第一个状态更新
    () => {
      // 4. 回调函数执行！
      // 注意：这里的 updatedNotices 是步骤 1 中闭包捕获的变量
      const notices = updatedNotices.map(...) 
      this.setState({ notices }); // 5. 再次更新状态，将 notices 设回旧数组
    }
  );
};
```

2. Message.success() 触发 add：
紧接着 close()，同步调用了 Message.success()。它会调用 add 方法（components/_class/notification.tsx）：
```javascript
add = (noticeProps) => {
  this.setState((prevState) => {
    return {
      notices: prevState.notices.concat(...) // 3. 调度第二个状态更新，添加 Success 消息
    };
  });
};
```
React 批处理与冲突：
由于这两个调用发生在同一个事件循环 Tick 中，React 会进行批处理（Batching）：

首先，执行 update 的第一个 setState 和 add 的 setState。此时状态短暂地变为了 [Loading(渐隐中), Success]。
关键点：update 方法自带了一个 setState 回调函数。在 React 完成上述批处理渲染后，这个回调函数会立即执行。
在回调函数中，它使用了闭包捕获的 updatedNotices（这个数组只包含 Loading，不包含刚添加的 Success）。
回调函数执行 this.setState({ notices })，直接用不包含 Success 的旧数组覆盖了当前状态。
总结：为什么会消失？
虽然 Message.success 成功把消息放进了队列，但紧随其后的 update 回调函数带着“过时的快照”横冲直撞，把刚刚排好队的新消息给抹除了。
<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

## Solution
消除闭包陷阱：原有的 update 方法在 setState 的回调函数中使用了外部作用域捕获的 updatedNotices 变量。当多个通知（如 close() 和 Message.success()）在极短时间内连续触发时，这个回调函数会带着过时的状态快照覆盖最新的状态。修复方案改为在回调函数内部使用 函数式 setState (prevState => ...)，确保操作的是最新的状态树。
<!-- Describe how the problem is fixed in detail -->

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|  Message         |  修复 Message 组件在close上一个消息 messageA 的同时显示新的消息 messageB 时，新的消息 messageB 无法正常显示的问题             |  Fix the issue that when closing the previous message messageA and displaying a new message messageB in the Message component, the new message messageB fails to display properly.             |                |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->
## Checklist:

- [ ] Test suite passes (`npm run test`)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
