### PR TITLE
fix(Notification): Fix the issue that the Message component and Notification component reset the locale to Chinese after being triggered.

### DIFF
--- a/components/Drawer/index.tsx
+++ b/components/Drawer/index.tsx
@@ -317,7 +317,12 @@ function Drawer(baseProps: DrawerProps, ref) {
             )}
           >
             <div className={`${prefixCls}-inner`}>
-              <ConfigProvider {...context} zIndex={popupZIndex || 1050}>
+              <ConfigProvider
+                {...context}
+                effectGlobalModal={false}
+                effectGlobalNotice={false}
+                zIndex={popupZIndex || 1050}
+              >
                 {dom}
               </ConfigProvider>
             </div>

--- a/components/Modal/modal.tsx
+++ b/components/Modal/modal.tsx
@@ -246,6 +246,8 @@ function Modal(baseProps: PropsWithChildren<ModalProps>, ref) {
   const element = (
     <ConfigProvider
       {...context}
+      effectGlobalModal={false}
+      effectGlobalNotice={false}
       prefixCls={props.prefixCls || context.prefixCls}
       locale={locale}
       zIndex={popupZIndex || 1050}

--- a/components/_class/notice.tsx
+++ b/components/_class/notice.tsx
@@ -188,7 +188,7 @@ class Notice extends Component<NoticeProps, {}> {
     if (noticeType === 'message') {
       _closable = closable;
       return (
-        <ConfigProvider {...configContext}>
+        <ConfigProvider {...configContext} effectGlobalModal={false} effectGlobalNotice={false}>
           <div
             style={{ textAlign: 'center' }}
             onMouseEnter={this.onMouseEnter}
@@ -220,7 +220,7 @@ class Notice extends Component<NoticeProps, {}> {
 
     if (noticeType === 'notification') {
       return (
-        <ConfigProvider {...configContext}>
+        <ConfigProvider {...configContext} effectGlobalModal={false} effectGlobalNotice={false}>
           <div
             ref={this.rootDOMRef}
             onMouseEnter={this.onMouseEnter}


### PR DESCRIPTION
Fix the issue that the Message component and Notification component reset the locale to Chinese after being triggered.

<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context
```javascript
import enUs from "@arco-design/web-react/es/locale/en-US";
import {
  Button,
  ConfigProvider,
  Modal,
  Notification,
} from "@arco-design/web-react";

export default function App() {
  return (
    <ConfigProvider locale={enUs}>
      <div className="App">
        <Button
          onClick={() => {
            Modal.confirm({
              title: "按钮是英文",
            });
          }}
        >
          step 1 点我弹出 Modal
        </Button>
        &emsp;
        <Button
          onClick={() => {
            Notification.error({ content: "错误通知" });
          }}
        >
          step 2 点我弹出通知
        </Button>
        &emsp;
        <Button
          onClick={() => {
            Modal.confirm({
              title: "按钮是中文了?",
            });
          }}
        >
          step 3 再弹出 Modal
        </Button>
      </div>
    </ConfigProvider>
  );
}
```
对于如上代码，配置的locale未enUS，点击第一个按钮弹出Modal是，取消和确定按钮显示的是英文，点击第二个按钮弹出Notification后，再点击第三个按钮弹出Modal是，取消和确定按钮显示的是中文了

### 问题原因
原因在于 Arco Design 的 ConfigProvider 组件在渲染时，默认会通过 useEffect 将当前的 locale、prefixCls 等配置同步到一个全局变量中，以便给 Modal.confirm、Message、Notification 等命令式调用的组件使用。

故障链条分析：
Step 1：App 中的 <ConfigProvider locale={enUs}> 挂载，触发 useEffect，全局配置被设为 en-US。此时弹出 Modal.confirm，按钮显示英文，符合预期。
Step 2：调用 Notification.error。Notification 内部会渲染 Notice 组件，而 Notice 组件内部为了保证其子组件（如关闭按钮、图标等）能正确获取 context，也嵌套了一个 <ConfigProvider>。
副作用发生：Notice 内部的 ConfigProvider 接收的是 Notification 实例创建时的 context（通常是默认配置，即中文 zh-CN）。当这个内部 ConfigProvider 挂载时，它也触发了 useEffect，执行了 setConfigProviderProps({ locale: 'zh-CN', ... })。
结果覆盖：这一步直接将全局配置覆盖成了中文。
Step 3：再次点击 Modal.confirm，它从已被“污染”的全局配置中读取 locale，因此显示为中文。
<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

## Solution
在组件库内部，针对那些仅用于“透传 Context”而嵌套的 ConfigProvider，显式设置 effectGlobalModal={false} 和 effectGlobalNotice={false}，以防止它们干扰全局配置。
<!-- Describe how the problem is fixed in detail -->

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|  Notification         | 修复 `Message` 组件和 `Notification` 组件触发后将 locale 重置为中文的问题              |  Fix the issue that the `Message` component and `Notification` component reset the locale to Chinese after being triggered.             |                |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->
## Checklist:

- [ ] Test suite passes (`npm run test`)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
