### PR TITLE
fix(Table): Fix the issue that when the data of the Table component is fetched asynchronously, the setting of defaultExpandAllRows fails.

### DIFF
--- a/components/Table/hooks/useExpand.tsx
+++ b/components/Table/hooks/useExpand.tsx
@@ -1,4 +1,4 @@
-import { useState, Key } from 'react';
+import { useState, Key, useEffect, useRef } from 'react';
 import { TableProps, GetRowKeyType } from '../interface';
 import { isChildrenNotEmpty, getOriginData } from '../utils';
 
@@ -18,6 +18,17 @@ export default function useExpand<T>(
   } = props;
   const [expandedRowKeys, setExpandedRowKeys] = useState<Key[]>(getDefaultExpandedRowKeys());
   const mergedExpandedRowKeys = props.expandedRowKeys || expandedRowKeys;
+  const isFirstRender = useRef(true);
+
+  useEffect(() => {
+    if (isFirstRender.current) {
+      isFirstRender.current = false;
+      return;
+    }
+    if (defaultExpandAllRows && flattenData && flattenData.length > 0) {
+      setExpandedRowKeys(getDefaultExpandedRowKeys());
+    }
+  }, [flattenData?.length, defaultExpandAllRows]);
 
   function getDefaultExpandedRowKeys() {
     let rows: React.Key[] = [];


### PR DESCRIPTION
Fix the issue that when the data of the Table component is fetched asynchronously, the setting of defaultExpandAllRows fails.

<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context
[Table](vscode-webview://1jatc9fo8ap905g650rt7rm7jmnhd48f9k5n4i13euqs62qcjifo/components/Table/table.tsx) 组件的展开逻辑由 [useExpand](vscode-webview://1jatc9fo8ap905g650rt7rm7jmnhd48f9k5n4i13euqs62qcjifo/components/Table/hooks/useExpand.tsx) hook 管理。该 hook 使用 useState 初始化 expandedRowKeys，而初始值是通过 getDefaultExpandedRowKeys() 计算的。

### 根本原因

初始化时机： useState 的初始值计算只在组件挂载（Mount）时执行一次。
异步数据滞后： 当数据是异步加载时，初始挂载时 data 为空数组，此时 flattenData 也是空，导致 getDefaultExpandedRowKeys() 返回空数组。
缺乏副作用监听： 当异步数据返回并更新 flattenData 时，useExpand 内部没有监听数据变化来重新触发出发默认展开逻辑。
<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

## Solution
在 useExpand 中增加一个 useEffect，监听 flattenData 和 defaultExpandAllRows 的变化。当数据从无到有加载完成，且设置了 defaultExpandAllRows 时，重新计算并设置默认展开的行
<!-- Describe how the problem is fixed in detail -->

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|  Table         |  修复 `Table` 组件在 data 数据异步拉取时，设置 defaultExpandAllRows 后失效的问题  |   Fix the issue that when the data of the `Table` component is fetched asynchronously, the setting of defaultExpandAllRows fails.              |                |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->
## Checklist:

- [ ] Test suite passes (`npm run test`)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
