### PR TITLE
fix(Table): [Genius AI] 修复Table 在Table header 和Table body 分离模式下（设置Scroll y属性），调用原生横向 smooth scroll 时，滚动几乎不生效且出现轻微抖动问题

### DIFF
--- a/components/Table/table.tsx
+++ b/components/Table/table.tsx
@@ -138,6 +138,7 @@ function Table<T extends unknown>(baseProps: TableProps<T>, ref: React.Ref<Table
   // Not fixed header
   const refTableNF = useRef<HTMLTableElement | null>(null);
   const lastScrollLeft = useRef<number>(0);
+  const syncingScrollTargets = useRef<HTMLElement[]>([]);
 
   const scrollbarChanged = useRef<boolean>(false);
   const [groupColumns, flattenColumns] = useColumns<T>(props);
@@ -722,19 +723,29 @@ function Table<T extends unknown>(baseProps: TableProps<T>, ref: React.Ref<Table
     const theadScrollContainer =
       refTableHead.current && (refTableHead.current.parentNode as HTMLElement);
     const tfoot = refTableFoot.current;
-    if (target.scrollLeft !== lastScrollLeft.current) {
-      if (theadScrollContainer) {
-        theadScrollContainer.scrollLeft = target.scrollLeft;
-      }
-      if (tbody) {
-        tbody.scrollLeft = target.scrollLeft;
-      }
-      if (tfoot) {
-        tfoot.scrollLeft = target.scrollLeft;
-      }
+    const scrollTarget = target as HTMLElement;
+
+    if (syncingScrollTargets.current.includes(scrollTarget)) {
+      syncingScrollTargets.current = syncingScrollTargets.current.filter(
+        (item) => item !== scrollTarget
+      );
+      lastScrollLeft.current = scrollTarget.scrollLeft;
+      return;
+    }
+
+    if (scrollTarget.scrollLeft !== lastScrollLeft.current) {
+      const syncTargets = [theadScrollContainer, tbody, tfoot].filter(
+        (node): node is HTMLElement => !!node && node !== scrollTarget
+      );
+
+      syncingScrollTargets.current = syncTargets;
+      syncTargets.forEach((node) => {
+        node.scrollLeft = scrollTarget.scrollLeft;
+      });
       setFixedColumnClassNames();
     }
-    lastScrollLeft.current = e.target.scrollLeft;
+
+    lastScrollLeft.current = scrollTarget.scrollLeft;
   }
 
   // isFixedHeader = false


### PR DESCRIPTION

<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an x in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the Type column in the Changelog. -->

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context


<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

## Solution
### 缺陷摘要

- **问题现象**：`Table` 在 fixed header 模式下调用原生横向 smooth scroll 时，滚动几乎不生效且出现抖动。
- **预期结果**：执行复现 Demo 的 `scrollFixed` 后，表格横向平滑滚动到目标列。

### 复现与验证路径

- fixed header 模式下
    1. 渲染 `scroll={{ x: COLUMN_COUNT * 120, y: TABLE_BODY_HEIGHT }}` 的 `Table`
    2. 查询 `.arco-table-body` 并执行 `scrollTo({ left: targetLeft, behavior: 'smooth' })`
    3. **验证点**：表体滚动到目标列，表头与表尾保持同步，过程无 0.5 ~ 1px 抖动

### 问题诊断

- **根因分析**：`tableScrollHandler()` 对联动容器持续回写 `scrollLeft`，打断浏览器的多帧 smooth scroll 动画。
- **详细诊断**：
    * `components/Table/table.tsx` 中：`useIsomorphicLayoutEffect` 给 `refTableBody`、表头滚动容器、`refTableFoot` 绑定同一个 `tableScrollHandler`
    * `components/Table/table.tsx` 中：`tableScrollHandler` 在任一容器触发 scroll 时同时写回 body、head、foot 的 `scrollLeft`
    * `components/Table/table.tsx` 中：`lastScrollLeft` 只避免相同值重复分支，无法避免 smooth scroll 每帧触发的互相回写

### 修复方案

- **解决思路**：区分滚动源与同步目标，联动时跳过事件源自身写回，并在同步阶段屏蔽由程序写入触发的二次 scroll。
- **代码变更**：
    1. `components/Table/table.tsx`
        - 新增滚动同步保护状态：记录当前程序写入的容器或同步批次
        - 修改 `tableScrollHandler`：仅把事件源的 `scrollLeft` 同步到其他容器，跳过 source 自写回
        - 为程序同步触发的 scroll 增加短路逻辑，避免 head/body/foot 连续互相回写
        - 保留 `setFixedColumnClassNames` 调用，滚动定位样式继续按最新 `scrollLeft` 更新

<!-- Describe how the problem is fixed in detail -->

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
| Table          | 修复`Table` 在Table header 和Table body 分离模式下（设置Scroll y属性），调用原生横向 smooth scroll 时，滚动几乎不生效且出现轻微抖动问题              | Fixed the issue where when using native horizontal smooth scrolling in `Table` with separated Table header and Table body mode (by setting the scroll-y property), the horizontal scrolling barely took effect and exhibited slight jitter.              |                |

<!-- If there are multiple types, you can add the Type column in the Changelog, the value of the column is the same as Types of changes -->
## Checklist:

- [ ] Test suite passes (npm run test)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to feature branch and others should be submitted to main branch)

## Other information
- isFromGitlab: true
- gitlabMRId: 894
- createdBy: lingyunsong

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
