### PR TITLE
fix(DatePicker): [Genius AI] 修复DatePicker 传入字符串 value 且 format="YYYY/MM/DD hh:mm:ss A" 时显示为 12:00:00 凌晨，时间信息丢失问题

### DIFF
--- a/components/DatePicker/__test__/format.test.tsx
+++ b/components/DatePicker/__test__/format.test.tsx
@@ -111,6 +111,16 @@ describe('Picker Format', () => {
     );
   });
 
+  it('showTime format with meridiem and string value', () => {
+    const component = render(
+      <DatePicker showTime format="YYYY/MM/DD hh:mm:ss A" value="2025-08-12 09:24:09" />
+    );
+
+    expect(component.find('.arco-picker-input input')[0].getAttribute('value')).toBe(
+      '2025/08/12 09:24:09 上午'
+    );
+  });
+
   it('RangePicker format array', () => {
     const component = render(
       <RangePicker

--- a/components/_util/dayjs.ts
+++ b/components/_util/dayjs.ts
@@ -50,6 +50,8 @@ originDayjs.extend(timezone);
 
 export const dayjs = originDayjs;
 
+const defaultStringFormats = ['YYYY-MM-DD HH:mm:ss', 'YYYY-MM-DD'];
+
 function startOfWeekTimestamp(date, weekStart: number) {
   // 计算 date 与前一个 weekStart 日期的间隔
   const diff = (date.day() - weekStart + 7) % 7;
@@ -249,8 +251,19 @@ export function getDayjsValue(
     }
     if (typeof value === 'string') {
       const dv = dayjs(value, isArray(format) ? format[i] : format);
+      if (dv.isValid()) {
+        return dv;
+      }
 
-      return dv.isValid() ? dv : dayjs(value, 'YYYY-MM-DD');
+      for (let index = 0; index < defaultStringFormats.length; index += 1) {
+        const fallbackValue = dayjs(value, defaultStringFormats[index]);
+
+        if (fallbackValue.isValid()) {
+          return fallbackValue;
+        }
+      }
+
+      return dv;
     }
     return dayjs(value);
   };


### PR DESCRIPTION

<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an x in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the Type column in the Changelog. -->

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context


<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

## Solution

### 缺陷摘要

- **问题现象**：`DatePicker` 传入字符串 `value` 且 `format="YYYY/MM/DD hh:mm:ss A"` 时显示为 `12:00:00 凌晨`，时间信息丢失。
- **预期结果**：`DatePicker` 应显示 `2025/08/12 09:24:09 上午`。
- **影响范围**：`components/DatePicker` 字符串值解析与展示。

### 复现与验证路径

渲染 `DatePicker`，设置 `showTime`、`format="YYYY/MM/DD hh:mm:ss A"`，传入 `value="2025-08-12 09:24:09"`。
1. 打开页面并渲染组件。
2. 观察输入框展示值。
3. **验证点**：显示值为 `2025/08/12 09:24:09 上午`。

### 问题诊断

- **根因分析**：字符串值首轮按展示格式解析失败后仅回退到 `YYYY-MM-DD`，导致时间字段被重置，再按含 `A` 的格式展示时输出错误时间。
- **详细诊断**：
    * `components/_util/dayjs.ts` 中：`getDayjsValue` 对字符串仅回退 `dayjs(value, 'YYYY-MM-DD')`，未覆盖 `showTime` 默认字符串格式 `YYYY-MM-DD HH:mm:ss`。
    * `components/DatePicker/picker.tsx` 中：`value`、`defaultValue`、输入校验都依赖 `getDayjsValue` 与 `format`，解析结果异常会直接反映到输入框显示。

### 修复方案

- **解决思路**：扩展字符串解析兜底顺序，优先保留原始时间信息，再补充含 `A` 场景回归用例。
- **代码变更**：
    1. `components/_util/dayjs.ts`
        - 字符串 fallback：`YYYY-MM-DD` → `YYYY-MM-DD HH:mm:ss`、`YYYY-MM-DD` 按序尝试。
        - 保持 `format` 命中优先，fallback 仅在 `dv.isValid()` 失败时生效。
    2. `components/DatePicker/__test__/format.test.tsx`
        - 新增 `showTime + A` 字符串值用例。
        - 断言输入框显示 `2025/08/12 09:24:09 上午`。


<!-- Describe how the problem is fixed in detail -->

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
| DatePicker          | 修复 `DatePicker` 传入字符串 value 且 format="YYYY/MM/DD hh:mm:ss A" 时显示为 12:00:00 凌晨，时间信息丢失问题              | Fixed the issue where the time information was lost and displayed as 12:00:00 AM when passing a string value to `DatePicker` with format="YYYY/MM/DD hh:mm:ss A".              |                |

<!-- If there are multiple types, you can add the Type column in the Changelog, the value of the column is the same as Types of changes -->
## Checklist:

- [ ] Test suite passes (npm run test)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to feature branch and others should be submitted to main branch)

## Other information
- isFromGitlab: true
- gitlabMRId: 898
- createdBy: lingyunsong

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
