### PR TITLE
fix(Tree): 修复Tree组件的Tree.Node内添加Input组件后,在Input组件内输入中文,光标会跳动的问题

### DIFF
--- a/components/Tree/__test__/index.test.tsx
+++ b/components/Tree/__test__/index.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { render, fireEvent, act } from '../../../tests/util';
 import mountTest from '../../../tests/mountTest';
 import Tree from '..';
+import Input from '../../Input';
 import { IconHeartFill } from '../../../icon';
 import componentConfigTest from '../../../tests/componentConfigTest';
 
@@ -109,6 +110,57 @@ describe('Tree', () => {
     const summaryNodeLength = getTreeNodesLength(data);
     expect(wrapper.find(`${prefixCls}-node`)).toHaveLength(summaryNodeLength);
   });
+
+  it('should keep caret position for controlled input rendered in title', () => {
+    function Demo() {
+      const [value, setValue] = React.useState('abc');
+
+      return (
+        <Tree defaultExpandedKeys={['0-0']}>
+          <TreeNode title="Trunk" key="0-0">
+            <TreeNode key="0-0-0" title={<Input value={value} onChange={setValue} />} />
+          </TreeNode>
+        </Tree>
+      );
+    }
+
+    const wrapper = render(<Demo />);
+    const innerInput = wrapper.querySelectorAll('input')[0] as HTMLInputElement;
+
+    act(() => {
+      innerInput.focus();
+      innerInput.setSelectionRange(2, 2);
+    });
+
+    fireEvent.compositionStart(innerInput);
+    fireEvent.compositionUpdate(innerInput, {
+      target: {
+        value: 'ab中c',
+      },
+    });
+    fireEvent.change(innerInput, {
+      target: {
+        value: 'ab中c',
+      },
+    });
+
+    act(() => {
+      innerInput.setSelectionRange(3, 3);
+    });
+
+    fireEvent.compositionEnd(innerInput, {
+      target: {
+        value: 'ab中c',
+      },
+    });
+
+    const updatedInput = wrapper.querySelectorAll('input')[0] as HTMLInputElement;
+    expect(updatedInput.value).toBe('ab中c');
+    expect(document.activeElement).toBe(updatedInput);
+    expect(updatedInput.selectionStart).toBe(3);
+    expect(updatedInput.selectionEnd).toBe(3);
+  });
+
   it('tree render treedata', () => {
     const wrapper = render(<Tree treeData={data} />);
     const wrapper2 = render(<Tree>{generatorTreeNodes(data)}</Tree>);

--- a/components/Tree/index.tsx
+++ b/components/Tree/index.tsx
@@ -158,16 +158,21 @@ class Tree extends Component<TreeProps, TreeState> {
 
     if (prevProps !== this.props || !isEqualWith(prevMergedProps, mergedProps)) {
       const newState: Partial<TreeState> = {};
-      if (
-        this.needUpdateTreeData(
-          { ...prevMergedProps, ...prevProps },
-          { ...mergedProps, ...this.props }
-        )
-      ) {
+      const shouldUsePropsNodeList = !('treeData' in this.props);
+      let latestTreeData = this.state.treeData;
+      const treeDataChanged = this.needUpdateTreeData(
+        { ...prevMergedProps, ...prevProps },
+        { ...mergedProps, ...this.props }
+      );
+      if (treeDataChanged) {
         const treeData = this.getTreeData();
-        const nodeList = this.getNodeList(treeData);
-        newState.treeData = treeData;
-        newState.nodeList = nodeList;
+        latestTreeData = treeData;
+
+        if (!shouldUsePropsNodeList) {
+          const nodeList = this.getNodeList(treeData);
+          newState.treeData = treeData;
+          newState.nodeList = nodeList;
+        }
 
         if ('expandedKeys' in this.props) {
           const derivedExpandedKeys = this.getInitExpandedKeys(this.props.expandedKeys || []);
@@ -197,7 +202,7 @@ class Tree extends Component<TreeProps, TreeState> {
       }
 
       if (
-        newState.treeData ||
+        treeDataChanged ||
         ('checkedKeys' in this.props && !isEqualWith(prevProps.checkedKeys, this.props.checkedKeys))
       ) {
         // 说明treeData变了，需要比较下内部checkedKeys
@@ -252,9 +257,9 @@ class Tree extends Component<TreeProps, TreeState> {
               });
       }
       const currentExpandKeys = newState.currentExpandKeys || this.state.currentExpandKeys;
-      if (newState.treeData && currentExpandKeys) {
+      if (treeDataChanged && currentExpandKeys) {
         newState.currentExpandKeys = currentExpandKeys.filter((key) => {
-          const item = newState.treeData.find((node) => node.key === key);
+          const item = latestTreeData?.find((node) => node.key === key);
           return item && item.children && item.children.length;
         });
       }
@@ -812,6 +817,8 @@ class Tree extends Component<TreeProps, TreeState> {
     const { getPrefixCls, rtl } = this.context;
 
     const prefixCls = getPrefixCls('tree');
+    const nodeList =
+      'treeData' in this.props ? this.state.nodeList : this.getNodeList(this.getTreeData());
 
     return (
       <TreeContext.Provider
@@ -860,7 +867,7 @@ class Tree extends Component<TreeProps, TreeState> {
           currentExpandKeys={this.state.currentExpandKeys}
           getNodeProps={this.getNodeProps}
           getDataSet={this.getDataSet}
-          nodeList={this.state.nodeList}
+          nodeList={nodeList}
           onMouseDown={this.props.onMouseDown}
           ariaProps={{
             role: 'tree',


### PR DESCRIPTION

<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an x in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the Type column in the Changelog. -->

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context


<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

## Solution

### 问题描述

Tree.Node 的 title 中嵌入受控 Input 时，在输入框已有内容中间使用中文输入法输入，输入完成后光标会跳到文本末尾；英文输入则正常，普通场景下的 Input 也正常。

以示例为例，title={<Input value={state} onChange={setState} />} 初始值为 abc，当光标放在 ab|c 之间输入中文，预期结果应为中文插入到当前位置且光标保持在插入点后，但实际会跳到末尾 ab中文c|。外层普通 Input 不会出现这个问题。

### 复现路径及验证方式

#### 复现路径：

渲染一个 Tree。
在 Tree.Node 的 title 中放入受控 Input。
给该 Input 一个初始值，比如 abc。
将光标移动到文本中间，比如 ab|c。
使用中文输入法输入中文并上屏。
#### 复现示例：
``` tsx
const App = () => {
  const [state, setState] = useState<string>('abc');
  const [inputState, setInputState] = useState<string>('abcef');

  return (
    <div>
      <Input value={inputState} onChange={setInputState} />
      <Tree>
        <Tree.Node title="Trunk" key="0-0">
          <Tree.Node title={<Input value={state} onChange={setState} />} />
        </Tree.Node>
      </Tree>
    </div>
  );
};
```
#### 验证方式：

手动验证。
在 Tree.Node 内部 Input 中间输入中文，确认中文插入后光标仍停留在正确位置。
对比外层普通 Input，确认行为一致。
对比英文输入，确认行为一致。
执行回归测试：
yarn test:client components/Tree/__test__/index.test.tsx --runInBand
这次也补充了自动化测试，覆盖 Tree.Node title 中受控 Input 在中文组合输入结束后 caret 不应跳到末尾的场景。

### 问题原因

根因不在 Input 本身，而在 Tree 的节点数据更新链路。

Tree 在 children 模式下会先根据 Tree.Node children 构造内部 nodeList。当 title 中的受控 Input 输入中文时，value 更新会触发父组件重新渲染；随后 Tree 又会在 componentDidUpdate 中基于最新 children 再补一次 nodeList 的 setState 更新。

这意味着 Tree.Node 里的 Input 在中文输入法组合输入结束附近，会经历一次额外的补渲染。该额外更新不会在普通外层 Input 场景出现，但会让嵌套在 Tree.Node title 中的受控 Input 更容易丢失当前 selection/caret，最终表现为光标跳到末尾。

英文输入之所以不容易触发，是因为中文输入法的 composition 流程对受控组件的更新时机更敏感。

### 修复方案

修复思路是减少 children 模式下不必要的二次补渲染。

具体做法：

保持 treeData 模式的现有更新方式不变。
对 children 模式，不再依赖 componentDidUpdate -> setState 去补更新 nodeList。
改为在当前 render 阶段同步计算 nodeList，让节点数据在本次渲染中直接稳定下来。
这样可以避免中文组合输入结束时，Tree.Node title 内部的 Input 因为额外一次补渲染而丢失光标位置。
对应修改文件：

components/Tree/index.tsx (line 153)
components/Tree/test/index.test.tsx (line 114)



<!-- Describe how the problem is fixed in detail -->

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
| Tree          | 修复`Tree` 组件的Tree.Node内添加Input组件后,在Input组件内输入中文,光标会跳动的问题  | Fixed the issue where the cursor jumps when typing Chinese in the Input component added inside Tree.Node of the `Tree` component.              |            |

<!-- If there are multiple types, you can add the Type column in the Changelog, the value of the column is the same as Types of changes -->
## Checklist:

- [ ] Test suite passes (npm run test)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to feature branch and others should be submitted to main branch)

## Other information
- isFromGitlab: true
- gitlabMRId: 900
- createdBy: lingyunsong

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
