### PR TITLE
feat(Input): fix(Input): 为 Input.TextArea 新增字数统计位置配置能力，支持将 showWordLimit 的统计文案显示在输入框下方，解决业务场景下统计文案与输入内容重叠、不易满足预期展示的问题

### DIFF
--- a/components/Input/README.en-US.md
+++ b/components/Input/README.en-US.md
@@ -61,6 +61,7 @@ The basic form components have been expanded on the basis of native controls and
 |maxLength|The max content length；After setting `errorOnly` to `true`, if `maxLength` is exceeded, the `error` status will be displayed, and user input will not be restricted.|number \| { length: number; errorOnly?: boolean } |`-`|`errorOnly` in 2.23.0|
 |style|Additional style|CSSProperties |`-`|-|
 |wrapperStyle|With `showWordLimit`, a `div` will be outside the `textarea` tag, and `wrapperStyle` is used to configure the style of it.|CSSProperties |`-`|-|
+|wordLimitPosition|The position of the word count|`'inside' \| 'outside'` |`inside`| 2.66.14 |  
 |onChange|Callback when user input|(value: string, e) => void |`-`|-|
 |onClear|Callback when click clear button|() => void |`-`|2.2.0|
 |onPressEnter|Callback when press enter key|(e) => void |`-`|-|

--- a/components/Input/README.zh-CN.md
+++ b/components/Input/README.zh-CN.md
@@ -61,6 +61,7 @@
 |maxLength|输入框最大输入的长度；设置 `errorOnly`为 `true` 后，超过 `maxLength` 会展示 `error` 状态，并不限制用户输入。|number \| { length: number; errorOnly?: boolean } |`-`|`errorOnly` in 2.23.0|
 |style|节点样式|CSSProperties |`-`|-|
 |wrapperStyle|开启字数统计之后，会在 `textarea` 标签外包一层 `div`，`wrapperStyle` 用来配置这个 `div` 的样式。|CSSProperties |`-`|-|
+|wordLimitPosition|字数统计的位置|`'inside' \| 'outside'` |`inside`| 2.66.14 |
 |onChange|输入时的回调|(value: string, e) => void |`-`|-|
 |onClear|点击清除按钮的回调|() => void |`-`|2.2.0|
 |onPressEnter|按下回车键的回调|(e) => void |`-`|-|

--- a/components/Input/__demo__/max-length.md
+++ b/components/Input/__demo__/max-length.md
@@ -56,6 +56,14 @@ function App() {
           wrapperStyle={{ width: 300 }}
         />
       </Space>
+
+      <Input.TextArea
+        maxLength={50}
+        showWordLimit
+        wordLimitPosition="outside"
+        placeholder="Word count below the textarea"
+        wrapperStyle={{ width: 300 }}
+      />
     </Space>
   );
 }

--- a/components/Input/__test__/__snapshots__/demo.test.ts.snap
+++ b/components/Input/__test__/__snapshots__/demo.test.ts.snap
@@ -734,6 +734,7 @@ exports[`renders Input/demo/max-length.md correctly 1`] = `
   </div>
   <div
     class="arco-space-item"
+    style="margin-bottom:8px"
   >
     <div
       class="arco-space arco-space-horizontal arco-space-align-start"
@@ -788,6 +789,25 @@ exports[`renders Input/demo/max-length.md correctly 1`] = `
           </span>
         </div>
       </div>
+    </div>
+  </div>
+  <div
+    class="arco-space-item"
+  >
+    <div
+      class="arco-textarea-wrapper arco-textarea-wrapper-word-limit-outside"
+      style="width:300px"
+    >
+      <textarea
+        class="arco-textarea"
+        maxlength="50"
+        placeholder="Word count below the textarea"
+      />
+      <span
+        class="arco-textarea-word-limit arco-textarea-word-limit-outside"
+      >
+        0/50
+      </span>
     </div>
   </div>
 </div>

--- a/components/Input/__test__/index.test.tsx
+++ b/components/Input/__test__/index.test.tsx
@@ -294,6 +294,23 @@ describe('Test Textarea', () => {
     expect(inputLimitElement()).toHaveLength(0);
   });
 
+  it('test TextArea wordLimitPosition', () => {
+    const textarea = render(
+      <Input.TextArea
+        maxLength={50}
+        defaultValue={getLengthString(20)}
+        showWordLimit
+        wordLimitPosition="outside"
+      />
+    );
+    const textareaWrapperElement = () => textarea.container.querySelector('.arco-textarea-wrapper');
+    const textareaLimitElement = () =>
+      textarea.container.querySelector('.arco-textarea-word-limit');
+    expect(textareaWrapperElement()).toHaveClass('arco-textarea-wrapper-word-limit-outside');
+    expect(textareaLimitElement()).toHaveClass('arco-textarea-word-limit-outside');
+    expect(textareaLimitElement()?.textContent).toEqual('20/50');
+  });
+
   it('test maxLength.errorOnly', () => {
     const input = render(
       <Input

--- a/components/Input/interface.tsx
+++ b/components/Input/interface.tsx
@@ -223,6 +223,11 @@ export interface TextAreaProps
   maxLength?: number | { length: number; errorOnly?: boolean };
   showWordLimit?: boolean;
   /**
+   * @zh 字数统计的位置
+   * @en The position of the word count
+   */
+  wordLimitPosition?: 'inside' | 'outside';
+  /**
    * @zh 允许清空输入框
    * @en Whether allow clear the content
    * @version 2.2.0

--- a/components/Input/style/rtl.less
+++ b/components/Input/style/rtl.less
@@ -138,4 +138,10 @@
       left: @textarea-layout-tip-right;
     }
   }
+
+  &.@{textarea-prefix-cls}-wrapper-word-limit-outside {
+    .@{textarea-prefix-cls}-word-limit {
+      align-self: flex-start;
+    }
+  }
 }

--- a/components/Input/style/textarea.less
+++ b/components/Input/style/textarea.less
@@ -6,6 +6,20 @@
   width: 100%;
 }
 
+.@{textarea-prefix-cls}-wrapper-word-limit-outside {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: stretch;
+  vertical-align: top;
+
+  .@{textarea-prefix-cls}-word-limit {
+    position: static;
+    align-self: flex-end;
+    margin-top: @spacing-2;
+    line-height: @line-height-base;
+  }
+}
+
 .@{textarea-prefix-cls}-clear-wrapper {
   &:hover {
     .@{textarea-prefix-cls}-clear-icon {

--- a/components/Input/textarea.tsx
+++ b/components/Input/textarea.tsx
@@ -39,6 +39,7 @@ const TextArea = (baseProps: TextAreaProps, ref) => {
     onPressEnter,
     status,
     clearIcon,
+    wordLimitPosition = 'inside',
     ...rest
   } = props;
 
@@ -128,7 +129,13 @@ const TextArea = (baseProps: TextAreaProps, ref) => {
   );
 
   const valueLength = value ? value.length : 0;
-  const withWrapper = (wordLimitMaxLength && showWordLimit) || allowClear;
+  const withWordLimit = !!(wordLimitMaxLength && showWordLimit);
+  const withWrapper = withWordLimit || allowClear;
+  const wordLimitOutside = withWordLimit && wordLimitPosition === 'outside';
+  const [leftWord, rightWord] = rtl
+    ? [wordLimitMaxLength, valueLength]
+    : [valueLength, wordLimitMaxLength];
+  const wordLimitText = withWordLimit ? `${leftWord}/${rightWord}` : '';
 
   const lengthError = useMemo(() => {
     if (!maxLength && wordLimitMaxLength) {
@@ -170,13 +177,11 @@ const TextArea = (baseProps: TextAreaProps, ref) => {
 
   if (withWrapper) {
     const showClearIcon = !disabled && allowClear && value;
-    const [leftWord, rightWord] = rtl
-      ? [wordLimitMaxLength, valueLength]
-      : [valueLength, wordLimitMaxLength];
     return (
       <div
         className={cs(`${prefixCls}-wrapper`, {
           [`${prefixCls}-clear-wrapper`]: allowClear,
+          [`${prefixCls}-wrapper-word-limit-outside`]: wordLimitOutside,
           [`${prefixCls}-wrapper-rtl`]: rtl,
         })}
         style={wrapperStyle}
@@ -205,13 +210,14 @@ const TextArea = (baseProps: TextAreaProps, ref) => {
             </IconHover>
           )
         ) : null}
-        {wordLimitMaxLength && showWordLimit && (
+        {withWordLimit && (
           <span
             className={cs(`${prefixCls}-word-limit`, {
+              [`${prefixCls}-word-limit-outside`]: wordLimitOutside,
               [`${prefixCls}-word-limit-error`]: lengthError,
             })}
           >
-            {leftWord}/{rightWord}
+            {wordLimitText}
           </span>
         )}
       </div>


### PR DESCRIPTION
…入框下方，解决业务场景下统计文案与输入内容重叠、不易满足预期展示的问题

<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [x] New feature
- [ ] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context

<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

## Solution
为 Input.TextArea 新增字数统计位置配置能力，支持将 showWordLimit 的统计文案显示在输入框下方，解决长文本输入场景下统计文案与输入内容重叠、样式难以兼顾的问题。同时保留默认行为不变，确保现有使用方式不受影响。

### 主要改动

为 Input.TextArea 新增参数 wordLimitPosition?: 'inside' | 'outside'
默认值为 inside，保持当前右下角内嵌显示字数统计的行为不变
当传入 wordLimitPosition="outside" 时，字数统计显示在输入框下方
撤回此前围绕“避免重叠”做的样式避让调整，避免影响默认输入区域布局
补充对应样式实现，并兼容 RTL 场景
补充单测、README 文档和 demo 示例
### 解决方式
这次改为提供显式配置项：

默认仍使用原有的输入框内部展示方式，不改变现有行为
当业务侧需要避免重叠时，可通过 wordLimitPosition="outside" 将字数统计移到输入框下方
通过新增独立布局样式处理 outside 场景，而不是继续修改 inside 模式下的内容区域排版逻辑
这样可以把“兼容旧行为”和“支持新展示方式”拆开处理，方案更稳定，也更容易维护。

### 影响面

Input.TextArea 新增一个非破坏性参数，属于向后兼容增强
默认 showWordLimit 展示逻辑不变，现有线上用法无需修改
仅在显式传入 wordLimitPosition="outside" 时，字数统计位置才会发生变化
涉及 TextArea 的样式、接口定义、文档、demo 和测试
RTL 场景下 outside 模式也已适配
不影响 Input 单行输入框的字数统计逻辑
### 使用示例
``` tsx
<Input.TextArea
  maxLength={{ length: 500 }}
  showWordLimit
  wordLimitPosition="outside"
/>
```
<!-- Describe how the problem is fixed in detail -->

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
| Input          | 为 Input.TextArea 新增字数统计位置配置能力，支持将 showWordLimit 的统计文案显示在输入框下方，解决业务场景下统计文案与输入内容重叠、不易满足预期展示的问题              | Add configuration capability for the word count position of Input.TextArea, supporting displaying the count text of showWordLimit below the input box. This resolves issues such as overlapping count text with input content and failure to meet expected display requirements in business scenarios.              |                |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->
## Checklist:

- [ ] Test suite passes (`npm run test`)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
