### PR TITLE
feat(Select): [Genius AI]Select组件内置搜索支持匹配 字符串 label值，减少用户定制成本

### DIFF
--- a/components/Select/__test__/index.test.tsx
+++ b/components/Select/__test__/index.test.tsx
@@ -161,31 +161,41 @@ describe('Select', () => {
   it('showSearch matches string label in options and Option children', async () => {
     wrapper = render(
       <div>
-        <Select showSearch options={[{ label: '中文', value: 'chinese' }]} />
-        <Select showSearch>
+        <Select
+          showSearch
+          dropdownMenuClassName="select-with-options"
+          options={[{ label: '中文', value: 'chinese' }]}
+        />
+        <Select showSearch dropdownMenuClassName="select-with-children">
           <Option value="chinese">中文</Option>
         </Select>
       </div>
     );
 
     const selectList = wrapper.querySelectorAll('.arco-select');
+    const getPopup = (className: string) => {
+      return document.body.querySelector(`.${className}`) as HTMLElement;
+    };
+
     fireEvent.click(selectList[0]);
     await sleep(100);
 
     const inputList = wrapper.querySelectorAll('input');
     fireEvent.change(inputList[0], { target: { value: '中' } });
-    expect(wrapper.find('.arco-select-option')).toHaveLength(1);
-    expect(wrapper.querySelector('.arco-select-option')).toHaveTextContent('中文');
-    expect(wrapper.querySelector('.arco-select-highlight')).toHaveTextContent('中');
+    let popup = getPopup('select-with-options');
+    expect(popup.querySelectorAll('.arco-select-option')).toHaveLength(1);
+    expect(popup.querySelector('.arco-select-option')).toHaveTextContent('中文');
+    expect(popup.querySelector('.arco-select-highlight')).toHaveTextContent('中');
 
     fireEvent.change(inputList[0], { target: { value: '' } });
     fireEvent.click(selectList[1]);
     await sleep(100);
 
     fireEvent.change(inputList[1], { target: { value: '中' } });
-    expect(wrapper.find('.arco-select-option')).toHaveLength(1);
-    expect(wrapper.querySelector('.arco-select-option')).toHaveTextContent('中文');
-    expect(wrapper.querySelector('.arco-select-highlight')).toHaveTextContent('中');
+    popup = getPopup('select-with-children');
+    expect(popup.querySelectorAll('.arco-select-option')).toHaveLength(1);
+    expect(popup.querySelector('.arco-select-option')).toHaveTextContent('中文');
+    expect(popup.querySelector('.arco-select-highlight')).toHaveTextContent('中');
   });
 
   it('showSearch async correctly', async () => {

--- a/components/Select/__test__/index.test.tsx
+++ b/components/Select/__test__/index.test.tsx
@@ -158,6 +158,36 @@ describe('Select', () => {
     expect(wrapper.find('.arco-select-option')).toHaveLength(0);
   });
 
+  it('showSearch matches string label in options and Option children', async () => {
+    wrapper = render(
+      <div>
+        <Select showSearch options={[{ label: '中文', value: 'chinese' }]} />
+        <Select showSearch>
+          <Option value="chinese">中文</Option>
+        </Select>
+      </div>
+    );
+
+    const selectList = wrapper.querySelectorAll('.arco-select');
+    fireEvent.click(selectList[0]);
+    await sleep(100);
+
+    const inputList = wrapper.querySelectorAll('input');
+    fireEvent.change(inputList[0], { target: { value: '中' } });
+    expect(wrapper.find('.arco-select-option')).toHaveLength(1);
+    expect(wrapper.querySelector('.arco-select-option')).toHaveTextContent('中文');
+    expect(wrapper.querySelector('.arco-select-highlight')).toHaveTextContent('中');
+
+    fireEvent.change(inputList[0], { target: { value: '' } });
+    fireEvent.click(selectList[1]);
+    await sleep(100);
+
+    fireEvent.change(inputList[1], { target: { value: '中' } });
+    expect(wrapper.find('.arco-select-option')).toHaveLength(1);
+    expect(wrapper.querySelector('.arco-select-option')).toHaveTextContent('中文');
+    expect(wrapper.querySelector('.arco-select-highlight')).toHaveTextContent('中');
+  });
+
   it('showSearch async correctly', async () => {
     const onSearch = jest.fn();
     wrapper = render(

--- a/components/Select/utils.tsx
+++ b/components/Select/utils.tsx
@@ -110,12 +110,16 @@ function flatChildren(
 
   const handleOption = (child: ReactElement, origin: OptionInfo['_origin']) => {
     const optionValue = getChildValue(child);
+    const optionLabel = get(child, 'props.children');
+    const searchValue = inputValue.toLowerCase();
 
     let isValidOption = true;
     if (filterOption === true) {
-      isValidOption =
-        optionValue !== undefined &&
-        String(optionValue).toLowerCase().indexOf(inputValue.toLowerCase()) !== -1;
+      const isValueMatched =
+        optionValue !== undefined && String(optionValue).toLowerCase().indexOf(searchValue) !== -1;
+      const isLabelMatched =
+        typeof optionLabel === 'string' && optionLabel.toLowerCase().indexOf(searchValue) !== -1;
+      isValidOption = !inputValue || isValueMatched || isLabelMatched;
     } else if (typeof filterOption === 'function') {
       isValidOption = !inputValue || filterOption(inputValue, child);
     }

--- a/components/Select/utils.tsx
+++ b/components/Select/utils.tsx
@@ -112,6 +112,7 @@ function flatChildren(
     const optionValue = getChildValue(child);
     const optionLabel = get(child, 'props.children');
     const searchValue = inputValue.toLowerCase();
+    const hasExplicitValue = get(child, 'props.value') !== undefined;
 
     let isValidOption = true;
     if (filterOption === true) {
@@ -119,7 +120,7 @@ function flatChildren(
         optionValue !== undefined && String(optionValue).toLowerCase().indexOf(searchValue) !== -1;
       const isLabelMatched =
         typeof optionLabel === 'string' && optionLabel.toLowerCase().indexOf(searchValue) !== -1;
-      isValidOption = !inputValue || isValueMatched || isLabelMatched;
+      isValidOption = hasExplicitValue && (!inputValue || isValueMatched || isLabelMatched);
     } else if (typeof filterOption === 'function') {
       isValidOption = !inputValue || filterOption(inputValue, child);
     }


### PR DESCRIPTION

<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an x in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the Type column in the Changelog. -->

- [x] New feature
- [ ] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context


<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

## Solution

### 缺陷摘要

- **问题现象**：Select 默认静态搜索仅匹配 `value`，`options` 中字符串 `label` 无法被命中，需额外编写 `filterOption`。
- **预期结果**：`filterOption=true` 时同时匹配 `value` 与字符串 `label`，如 `{ label: '中文', value: 'chinese' }` 可被「中」命中。
- **影响范围**：`components/Select` 默认搜索行为

### 复现与验证路径

- 路径一：正常使用 `showSearch` 或默认搜索场景
    1. 渲染 `Select`，传入 `options={[{ label: '中文', value: 'chinese' }]}`。
    2. 打开下拉框并输入「中」。
    3. **验证点**：下拉列表保留该选项，输入高亮覆盖字符串 `label`。
- 路径二：使用 JSX `Option` 场景
    1. 渲染 `<Select showSearch><Select.Option value="chinese">中文</Select.Option></Select>`。
    2. 打开下拉框并输入「中」。
    3. **验证点**：下拉列表保留该选项，原有按 `value` 搜索能力不变。

### 问题诊断

- **根因分析**：`flatChildren` 的默认筛选分支仅比较 `optionValue`，未纳入字符串 `children`。
- **详细诊断**：
    * `components/Select/utils.tsx` 中：`handleOption` 在 `filterOption === true` 时仅执行 `String(optionValue)` 匹配，`options.label` 转成的 `children` 未参与判断。
    * `components/Select/__test__/index.test.tsx` 中：现有 `showSearch` 用例只覆盖按 `value` 搜索，缺少字符串 `label` 命中回归用例。

### 修复方案

- **解决思路**：扩展默认筛选条件 → 保留 `value` 匹配，同时在 `children` 为字符串时追加 `label` 匹配。
- **代码变更**：
    1. `components/Select/utils.tsx`
        - 提取 `child.props.children` 字符串值参与默认搜索。
        - `filterOption === true` 分支改为 `value` 命中或字符串 `label` 命中。
    2. `components/Select/__test__/index.test.tsx`
        - 为 `options={[{ label: '中文', value: 'chinese' }]}` 增加搜索「中」命中用例。
        - 为 JSX `Option` 字符串子节点增加搜索「中」命中用例或合并到现有 `showSearch` 用例。


<!-- Describe how the problem is fixed in detail -->

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
| Select          | `Select` 组件内置搜索支持匹配 字符串 label值，减少用户定制成本 | The built-in search of the `Select` component supports matching string label values, reducing user customization costs.              |               |

<!-- If there are multiple types, you can add the Type column in the Changelog, the value of the column is the same as Types of changes -->
## Checklist:

- [ ] Test suite passes (npm run test)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to feature branch and others should be submitted to main branch)

## Other information
- isFromGitlab: true
- gitlabMRId: 903
- createdBy: lingyunsong

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
