### PR TITLE
fix(Select): 修复在Select组件showSearch模式下，如果Option内容被HTML标签（如Tooltip、Popover或div等）包裹，并且设置了retainInputValue: true，在选中选项后再次聚焦下拉框时，输入框内已选中的内容会被清空，不展示已选中内容的问题

### DIFF
--- a/components/Select/__test__/index.test.tsx
+++ b/components/Select/__test__/index.test.tsx
@@ -4,6 +4,7 @@ import { sleep, render } from '../../../tests/util';
 import mountTest from '../../../tests/mountTest';
 import componentConfigTest from '../../../tests/componentConfigTest';
 import Button from '../../Button';
+import Tooltip from '../../Tooltip';
 import Select from '../select';
 import { Enter, Tab } from '../../_util/keycode';
 import { LabeledValue, SelectProps } from '../interface';
@@ -205,6 +206,42 @@ describe('Select', () => {
     );
     fireEvent.change(wrapper.querySelector('input'), { target: { value: 'A' } });
     expect(onSearch.mock.calls[0][0]).toBe('A');
+  });
+
+  it('retainInputValue works with Tooltip wrapped option children', async () => {
+    wrapper = render(
+      <Select showSearch={{ retainInputValue: true }} defaultValue="1">
+        <Option value="1">
+          <Tooltip content="tooltip content">content1</Tooltip>
+        </Option>
+      </Select>
+    );
+
+    const select = wrapper.querySelector('.arco-select');
+    const input = wrapper.querySelector('input') as HTMLInputElement;
+
+    fireEvent.click(select);
+    await sleep(100);
+    expect(input.value).toBe('content1');
+  });
+
+  it('retainInputValue works with div wrapped option children', async () => {
+    wrapper = render(
+      <Select showSearch={{ retainInputValue: true }} defaultValue="1">
+        <Option value="1">
+          <div>content1</div>
+        </Option>
+      </Select>
+    );
+
+    expect(wrapper.querySelector('.arco-select-view-value')).toHaveTextContent('content1');
+
+    const select = wrapper.querySelector('.arco-select');
+    const input = wrapper.querySelector('input') as HTMLInputElement;
+
+    fireEvent.click(select);
+    await sleep(100);
+    expect(input.value).toBe('content1');
   });
 
   it('popup with correct position', async () => {

--- a/components/Select/select.tsx
+++ b/components/Select/select.tsx
@@ -45,6 +45,22 @@ import useMergeProps from '../_util/hooks/useMergeProps';
 import { SelectOptionProps } from '../index';
 import useId from '../_util/hooks/useId';
 
+const nodeToText = (node: ReactNode): string => {
+  if (typeof node === 'string' || typeof node === 'number') {
+    return String(node);
+  }
+
+  if (Array.isArray(node)) {
+    return node.map((item) => nodeToText(item)).join('');
+  }
+
+  if (React.isValidElement(node)) {
+    return nodeToText(node.props?.children);
+  }
+
+  return '';
+};
+
 // 用户创建中的option的origin标识
 const USER_CREATING_OPTION_ORIGIN = 'userCreatingOption';
 
@@ -838,13 +854,15 @@ function Select(baseProps: SelectProps, ref) {
           onSort={tryUpdateSelectValue}
           renderText={(value) => {
             const option = getOptionInfoByValue(value);
-            let text = value;
+            let text: ReactNode = value;
+            let textInput = String(value);
             if (isFunction(renderFormat)) {
               const paramsForCallback = getValueAndOptionForCallback(value, false);
               text = renderFormat(
                 (paramsForCallback.option as OptionInfo) || null,
                 paramsForCallback.value as ReactText | LabeledValue
               );
+              textInput = nodeToText(text);
             } else {
               let foundLabelFromProps = false;
               if (labelInValue) {
@@ -855,21 +873,25 @@ function Select(baseProps: SelectProps, ref) {
                   );
                   if (targetLabeledValue) {
                     text = targetLabeledValue.label;
+                    textInput = nodeToText(targetLabeledValue.label);
                     foundLabelFromProps = true;
                   }
                 } else if (isObject(propValue)) {
                   text = (propValue as LabeledValue).label;
+                  textInput = nodeToText((propValue as LabeledValue).label);
                   foundLabelFromProps = true;
                 }
               }
 
               if (!foundLabelFromProps && option && 'children' in option) {
                 text = option.children;
+                textInput = nodeToText(option.children);
               }
             }
 
             return {
               text,
+              textInput,
               disabled: option && option.disabled,
             };
           }}

--- a/components/_class/select-view.tsx
+++ b/components/_class/select-view.tsx
@@ -191,7 +191,7 @@ export interface SelectViewProps extends SelectViewCommonProps {
   prefixCls: string;
   rtl?: boolean;
   ariaControls?: string;
-  renderText: (value) => { text; disabled };
+  renderText: (value) => { text; textInput?: string; disabled };
   renderView?: (eleView: ReactElement) => ReactElement;
   onSort?: (value) => void;
   onRemoveCheckedItem?: (item, index: number, e) => void;
@@ -279,9 +279,13 @@ const CoreSelectView = React.forwardRef(
     const mergedFocused = focused || popupVisible;
     const isRetainInputValueSearch = isObject(showSearch) && showSearch.retainInputValue;
     // the formatted text of value.
-    const renderedValue = !isMultiple && value !== undefined ? renderText(value).text : '';
+    const renderedTextResult = !isMultiple && value !== undefined ? renderText(value) : null;
+    const renderedValue = renderedTextResult?.text ?? '';
+    const renderedValueInput = renderedTextResult?.textInput;
     const renderedValuePlain =
-      typeof renderedValue === 'string' || typeof renderedValue === 'number'
+      renderedValueInput !== undefined
+        ? renderedValueInput
+        : typeof renderedValue === 'string' || typeof renderedValue === 'number'
         ? String(renderedValue)
         : nodeToText(renderedValue);
 
@@ -401,7 +405,7 @@ const CoreSelectView = React.forwardRef(
 
       switch (searchStatus) {
         case SearchStatus.BEFORE:
-          _inputValue = inputValue || (isRetainInputValueSearch ? renderedValue : '');
+          _inputValue = inputValue || (isRetainInputValueSearch ? renderedValuePlain : '');
           break;
         case SearchStatus.EDITING:
           _inputValue = inputValue || '';


### PR DESCRIPTION

<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an x in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the Type column in the Changelog. -->

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context


<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

## Solution

### 缺陷摘要

- **问题现象**：Select 单选 `showSearch={{ retainInputValue: true }}` 时，Option children 被标签包裹后再次聚焦会清空输入框，已选内容丢失。
- **预期结果**：聚焦后继续展示已选内容，被标签包裹与纯文本表现一致。

### 复现与验证路径

1. 渲染 `Select` 并设置 `showSearch={{ retainInputValue: true }}`。
2. 渲染 `Option`，其 `children` 用 `Tooltip`、`Popover` 或 `div` 包裹。
3. 选中该选项后再次点击 Select。
4. **验证点**：输入框显示当前已选文本，不变为空字符串。

### 问题诊断

- **根因分析**：单选搜索态保留输入值时依赖可写入 `<input>` 的纯文本，但当前回显链路把复杂 ReactNode 当作选中值文本，聚焦态无法回填。
- **详细诊断**：
    * `components/Select/select.tsx` 中：`renderText` 默认分支直接返回 `option.children`，复杂节点不会转成可回填输入框的文本。
    * `components/_class/select-view.tsx` 中：`retainInputValue` 聚焦态用 `inputValue || renderedValue`，复杂节点会在 `inputTextValue` 阶段变成空字符串，仅占位符保留文本。

### 修复方案

- **解决思路**：统一单选回显文本来源；默认回显继续保留原节点展示，搜索保留态补充纯文本提取值供输入框使用。
- **代码变更**：
    1. `components/Select/select.tsx`
        - 调整 `renderText` 返回结构：补充基于 `option.children` 的纯文本字段，兼容 `renderFormat` 与 `labelInValue`。
        - 单选默认分支区分展示节点与输入文本，复杂 children 递归提取文本后传给视图层。
    2. `components/_class/select-view.tsx`
        - 扩展 `renderText` 返回值类型：新增输入态文本字段，复用现有 `nodeToText` 兜底。
        - `SearchStatus.BEFORE` 下优先使用纯文本字段回填 input，保留 `.arco-select-view-value` 的富文本展示。
    3. `components/Select/__test__/index.test.tsx`
        - 新增单测：`retainInputValue` + `Tooltip` 包裹 children，二次聚焦时断言 input value 为已选文本。
        - 新增单测：`retainInputValue` + `div` 包裹 children，验证纯文本与富文本回显都正常。


<!-- Describe how the problem is fixed in detail -->

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
| Select          | 修复在 `Select` 组件showSearch模式下，如果Option内容被HTML标签（如Tooltip、Popover或div等）包裹，并且设置了retainInputValue: true，在选中选项后再次聚焦下拉框时，输入框内已选中的内容会被清空，不展示已选中内容的问题              | Fix the issue that in the showSearch mode of the `Select` component, when the Option content is wrapped by HTML tags (such as Tooltip, Popover, div, etc.) and retainInputValue: true is configured, the selected content in the input box will be cleared and not displayed when focusing the dropdown box again after selecting an option.              | https://github.com/arco-design/arco-design/issues/3014               |

<!-- If there are multiple types, you can add the Type column in the Changelog, the value of the column is the same as Types of changes -->
## Checklist:

- [ ] Test suite passes (npm run test)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to feature branch and others should be submitted to main branch)

## Other information
- isFromGitlab: true
- gitlabMRId: 904
- createdBy: lingyunsong

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
