### PR TITLE
fix(InputTag):  修复InputTag组件，当开启拖拽排序能力dragToSort后，在输入时，输入部分还未按enter保存为tag时，就可以拖拽为保存为tag的输入，拖拽完成后会报错问题

### DIFF
--- a/components/Cascader/__test__/__snapshots__/demo.test.ts.snap
+++ b/components/Cascader/__test__/__snapshots__/demo.test.ts.snap
@@ -1038,22 +1038,16 @@ exports[`renders Cascader/demo/draggable.md correctly 1`] = `
                 </span>
               </div>
             </li>
-            <li
-              class="arco-draggable-item"
-              draggable="true"
-              style="display:inline-block"
-            >
-              <input
-                autocomplete="off"
-                class="arco-input-tag-input arco-input-tag-input-size-default arco-input-tag-input-autowidth"
-                placeholder=""
-                value=""
-              />
-              <span
-                class="arco-input-tag-input-mirror"
-              />
-            </li>
           </div>
+          <input
+            autocomplete="off"
+            class="arco-input-tag-input arco-input-tag-input-size-default arco-input-tag-input-autowidth"
+            placeholder=""
+            value=""
+          />
+          <span
+            class="arco-input-tag-input-mirror"
+          />
         </div>
       </div>
     </div>

--- a/components/InputTag/__test__/__snapshots__/demo.test.ts.snap
+++ b/components/InputTag/__test__/__snapshots__/demo.test.ts.snap
@@ -323,22 +323,16 @@ exports[`renders InputTag/demo/draggable.md correctly 1`] = `
             </span>
           </div>
         </li>
-        <li
-          class="arco-draggable-item"
-          draggable="true"
-          style="display:inline-block"
-        >
-          <input
-            autocomplete="off"
-            class="arco-input-tag-input arco-input-tag-input-size-default arco-input-tag-input-autowidth"
-            placeholder=""
-            value=""
-          />
-          <span
-            class="arco-input-tag-input-mirror"
-          />
-        </li>
       </div>
+      <input
+        autocomplete="off"
+        class="arco-input-tag-input arco-input-tag-input-size-default arco-input-tag-input-autowidth"
+        placeholder=""
+        value=""
+      />
+      <span
+        class="arco-input-tag-input-mirror"
+      />
     </div>
     <div
       class="arco-input-tag-suffix"

--- a/components/InputTag/__test__/index.test.tsx
+++ b/components/InputTag/__test__/index.test.tsx
@@ -153,4 +153,14 @@ describe('InputTag', () => {
     expect(wrapper.querySelectorAll('.arco-tag')).toHaveLength(3);
     expect(wrapper.querySelector('input').getAttribute('value')).toBe('');
   });
+
+  it('should not make input area draggable when dragToSort is enabled', async () => {
+    const wrapper = render(<InputTag dragToSort defaultValue={['a', 'b', 'c', 'd']} />);
+    const eleInput = wrapper.querySelector('input') as HTMLElement;
+
+    fireEvent.change(eleInput, { target: { value: 'draft' } });
+    await sleep(10);
+
+    expect(wrapper.querySelectorAll('[draggable="true"]')).toHaveLength(4);
+  });
 });

--- a/components/InputTag/input-tag.tsx
+++ b/components/InputTag/input-tag.tsx
@@ -529,11 +529,20 @@ function InputTag(baseProps: InputTagProps<string | ObjectValueType>, ref) {
                   arr.splice(isMoveLeft ? toIndex : toIndex - 1, 0, item);
                   return arr;
                 };
+                if (
+                  prevIndex < 0 ||
+                  index < 0 ||
+                  prevIndex >= value.length ||
+                  index > value.length
+                ) {
+                  return;
+                }
                 valueChangeHandler(moveItem(value, prevIndex, index), 'sort');
               }}
             >
-              {childrenTagWithAnimation.concat(suffixInput)}
+              {childrenTagWithAnimation}
             </Draggable>
+            {suffixInput}
           </UsedTransitionGroup>
         ) : (
           <UsedTransitionGroup

--- a/components/Select/__test__/__snapshots__/demo.test.ts.snap
+++ b/components/Select/__test__/__snapshots__/demo.test.ts.snap
@@ -1484,22 +1484,16 @@ exports[`renders Select/demo/darggable.md correctly 1`] = `
                 </span>
               </div>
             </li>
-            <li
-              class="arco-draggable-item"
-              draggable="true"
-              style="display:inline-block"
-            >
-              <input
-                autocomplete="off"
-                class="arco-input-tag-input arco-input-tag-input-size-default arco-input-tag-input-autowidth"
-                placeholder=""
-                value=""
-              />
-              <span
-                class="arco-input-tag-input-mirror"
-              />
-            </li>
           </div>
+          <input
+            autocomplete="off"
+            class="arco-input-tag-input arco-input-tag-input-size-default arco-input-tag-input-autowidth"
+            placeholder=""
+            value=""
+          />
+          <span
+            class="arco-input-tag-input-mirror"
+          />
         </div>
       </div>
     </div>

--- a/components/TreeSelect/__test__/__snapshots__/demo.test.ts.snap
+++ b/components/TreeSelect/__test__/__snapshots__/demo.test.ts.snap
@@ -641,27 +641,20 @@ exports[`renders TreeSelect/demo/draggable.md correctly 1`] = `
         >
           <div
             class="arco-draggable"
+          />
+          <input
+            autocomplete="off"
+            class="arco-input-tag-input arco-input-tag-input-size-default arco-input-tag-input-autowidth"
+            placeholder="请选择..."
+            style="order:-1"
+            value=""
+          />
+          <span
+            class="arco-input-tag-input-mirror"
+            style="order:-1"
           >
-            <li
-              class="arco-draggable-item"
-              draggable="true"
-              style="display:inline-block"
-            >
-              <input
-                autocomplete="off"
-                class="arco-input-tag-input arco-input-tag-input-size-default arco-input-tag-input-autowidth"
-                placeholder="请选择..."
-                style="order:-1"
-                value=""
-              />
-              <span
-                class="arco-input-tag-input-mirror"
-                style="order:-1"
-              >
-                请选择...
-              </span>
-            </li>
-          </div>
+            请选择...
+          </span>
         </div>
       </div>
     </div>


### PR DESCRIPTION

<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an x in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the Type column in the Changelog. -->

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context


<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

## Solution

### 缺陷摘要

- **问题现象**：`dragToSort` 开启后，未提交的输入区可被拖拽，拖拽结束触发排序报错。
- **预期结果**：未按 Enter 保存的输入区不可拖拽，排序仅作用于已存在 tag。

### 复现与验证路径

配置 `dragToSort` 的 `InputTag`
1. 渲染 `defaultValue={['a', 'b', 'c', 'd']}` 且 `dragToSort` 开启的 `InputTag`。
2. 在输入框输入内容且不按 Enter。
3. 拖拽未保存文本区域。
4. **验证点**：输入区不进入拖拽态，组件不报错，已保存 tag 仍可排序。

### 问题诊断

- **根因分析**：`InputTag` 把输入框节点一并交给 `Draggable`，排序回调却按 `value` 数组索引移动，输入项索引越界后产生异常状态。
- **详细诊断**：
    * `components/InputTag/input-tag.tsx` 中：`childrenTagWithAnimation.concat(suffixInput)` 全量传给 `Draggable`，未排除输入框节点。
    * `components/InputTag/input-tag.tsx` 中：`onIndexChange` 直接对 `value` 执行 `moveItem`，`prevIndex` 或 `index` 指向输入项时会脱离真实 tag 索引。
    * `components/_class/Draggable/item.tsx` 中：每个子项固定 `draggable`，组件层未提供禁用单项拖拽能力。

### 修复方案

- **解决思路**：拖拽列表仅保留已保存 tag，输入框继续作为非拖拽尾项渲染，避免排序索引混入临时输入节点。
- **代码变更**：
    1. `components/InputTag/input-tag.tsx`
        - 拆分 tag 列表与输入框渲染：`Draggable` 仅接收 `childrenTagWithAnimation`。
        - 输入框节点移出 `Draggable` 或以非拖拽方式追加，保持现有布局与动画。
        - `onIndexChange` 增加索引边界保护，非法索引直接返回。
    2. `components/InputTag/__test__/index.test.tsx`
        - 新增 `dragToSort` + 未提交输入场景。
        - 校验渲染的拖拽项数量仅等于已保存 tag 数量。
        - 校验输入后不存在额外可拖拽项，拖拽排序回调不触发异常。


<!-- Describe how the problem is fixed in detail -->

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
| InputTag          | 修复 `InputTag` 组件，当开启拖拽排序能力dragToSort后，在输入时，输入部分还未按enter保存为tag时，就可以拖拽为保存为tag的输入，拖拽完成后会报错问题              | Fix the issue of the `InputTag` component: when the drag-and-drop sorting capability dragToSort is enabled, the unsaved input content (which has not been confirmed as a tag by pressing Enter) can be dragged directly during input. An error will be thrown after the drag operation is completed.             | https://github.com/arco-design/arco-design/issues/3019               |

<!-- If there are multiple types, you can add the Type column in the Changelog, the value of the column is the same as Types of changes -->
## Checklist:

- [ ] Test suite passes (npm run test)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to feature branch and others should be submitted to main branch)

## Other information
- isFromGitlab: true
- gitlabMRId: 905
- createdBy: lingyunsong

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
