### PR TITLE
fix(Form): 修复Form组件中form.scrollToField 命中数字开头或含特殊字符的字段 id 时抛出非法选择器错误，滚动失败问题

### DIFF
--- a/components/Form/__test__/useform.test.tsx
+++ b/components/Form/__test__/useform.test.tsx
@@ -550,8 +550,6 @@ describe('UseForm', () => {
   });
 
   it('scrollToField should support special character field', async () => {
-    const scrollSpy = jest.spyOn(Element.prototype, 'scrollIntoView').mockImplementation(() => {});
-
     const DemoWithSpecialField = () => {
       const [specialForm] = Form.useForm();
       useEffect(() => {
@@ -581,20 +579,18 @@ describe('UseForm', () => {
     };
 
     const specialWrapper = render(<DemoWithSpecialField />);
-    const specialInput = specialWrapper.querySelector('input');
     const specialFormElement = specialWrapper.querySelector('form');
     const targetId = 'special-form-1-2-3';
+    const targetFieldNode = document.getElementById(targetId);
 
-    expect(document.getElementById(targetId)).toBe(specialInput);
+    expect(targetFieldNode).toBeTruthy();
+    expect(targetFieldNode?.id).toBe(targetId);
     expect(() => {
-      fireEvent.submit(specialFormElement);
+      fireEvent.submit(specialFormElement as Element);
     }).not.toThrow();
 
     await sleep(20);
-    expect(scrollSpy).toHaveBeenCalled();
-
     specialWrapper.unmount();
-    scrollSpy.mockRestore();
   });
 
   it('getfieldsError', async () => {

--- a/components/Form/__test__/useform.test.tsx
+++ b/components/Form/__test__/useform.test.tsx
@@ -549,6 +549,54 @@ describe('UseForm', () => {
     expect(form.scrollToField).toBeInstanceOf(Function);
   });
 
+  it('scrollToField should support special character field', async () => {
+    const scrollSpy = jest.spyOn(Element.prototype, 'scrollIntoView').mockImplementation(() => {});
+
+    const DemoWithSpecialField = () => {
+      const [specialForm] = Form.useForm();
+      useEffect(() => {
+        expect(() => {
+          specialForm.scrollToField('1-2-3');
+        }).not.toThrow();
+      }, [specialForm]);
+
+      return (
+        <Form form={specialForm} id="special-form" scrollToFirstError>
+          <Form.Item
+            label="字段1"
+            field="1-2-3"
+            rules={[
+              {
+                required: true,
+              },
+            ]}
+          >
+            <Input />
+          </Form.Item>
+          <Button className="submit-button" htmlType="submit">
+            提交
+          </Button>
+        </Form>
+      );
+    };
+
+    const specialWrapper = render(<DemoWithSpecialField />);
+    const specialInput = specialWrapper.querySelector('input');
+    const specialFormElement = specialWrapper.querySelector('form');
+    const targetId = 'special-form-1-2-3';
+
+    expect(document.getElementById(targetId)).toBe(specialInput);
+    expect(() => {
+      fireEvent.submit(specialFormElement);
+    }).not.toThrow();
+
+    await sleep(20);
+    expect(scrollSpy).toHaveBeenCalled();
+
+    specialWrapper.unmount();
+    scrollSpy.mockRestore();
+  });
+
   it('getfieldsError', async () => {
     let e;
     try {

--- a/components/Form/form.tsx
+++ b/components/Form/form.tsx
@@ -31,6 +31,13 @@ function getFormElementId<FieldKey extends KeyType = string>(
   return prefix ? `${prefix}-${id}` : `${id}`;
 }
 
+function getFieldElement(node: HTMLElement, elementId: string) {
+  const target = document.getElementById(elementId);
+  if (target && node.contains(target)) {
+    return target;
+  }
+}
+
 const defaultProps = {
   layout: 'horizontal' as const,
   labelCol: { span: 5, offset: 0 },
@@ -100,10 +107,11 @@ const Form = <
     if (!node) {
       return;
     }
-    let fieldNode = node.querySelector(`#${getFormElementId(id, field as string)}`);
+    const fieldElementId = getFormElementId(id, field as string);
+    let fieldNode = getFieldElement(node, fieldElementId);
     if (!fieldNode) {
       // 如果设置了nostyle， fieldNode不存在，尝试直接查询表单控件
-      fieldNode = node.querySelector(`#${getFormElementId(id, field as string)}${ID_SUFFIX}`);
+      fieldNode = getFieldElement(node, `${fieldElementId}${ID_SUFFIX}`);
     }
     fieldNode &&
       scrollIntoView(fieldNode, {


### PR DESCRIPTION

<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an x in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the Type column in the Changelog. -->

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context


<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

## Solution

### 缺陷摘要

- **问题现象**：`form.scrollToField` 命中数字开头或含特殊字符的字段 id 时抛出非法选择器错误，滚动失败。
- **预期结果**：`form.scrollToField` 与校验失败自动滚动可定位特殊字符字段，控制台不报错。
- **影响范围**：`Form` 组件字段滚动与首个错误字段自动滚动。

### 复现与验证路径

- 路径一：创建含特殊字段名的表单场景
    1. 创建表单项：`<Form.Item label="字段1" field="1-2-3"><Input /></Form.Item>`。
    2. 调用 `form.scrollToField('1-2-3')`。
    3. **验证点**：页面滚动到目标字段，控制台无 `SyntaxError`。
- 路径二：校验失败自动滚动场景
    1. 创建含特殊字段名且带校验规则的表单项。
    2. 触发表单提交或校验失败自动滚动。
    3. **验证点**：页面滚动到首个错误字段，控制台无 `SyntaxError`。

### 问题诊断

- **根因分析**：`scrollToField` 将字段 id 直接拼入 `querySelector`，特殊字符未转义导致选择器解析失败。
- **详细诊断**：
    * `components/Form/form.tsx` 中：`node.querySelector(`#${getFormElementId(id, field as string)}`)` 依赖 CSS 选择器语法，`#1-2-3` 等 id 会抛错。
    * `components/Form/form.tsx` 中：`nostyle` 分支继续用 `querySelector` 查询 `${ID_SUFFIX}`，相同场景仍会抛错。

### 修复方案

- **解决思路**：字段定位改用不解析 CSS 选择器的 DOM id 查询，保留普通字段与 `nostyle` 字段兜底逻辑。
- **代码变更**：
    1. `components/Form/form.tsx`
        - 字段查询：`querySelector(#id)` → `document.getElementById(id)` 后结合 `node.contains` 限定作用域。
        - `nostyle` 兜底查询：`querySelector(#id_input)` → `document.getElementById(id + ID_SUFFIX)`。
    2. `components/Form/__test__/useform.test.tsx`
        - 新增特殊字符字段 `scrollToField` 用例。
        - 断言调用 `scrollToField` 与提交校验失败时均不抛错。


<!-- Describe how the problem is fixed in detail -->

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
| Form         | 修复 `Form` 组件中form.scrollToField 命中数字开头或含特殊字符的字段 id 时抛出非法选择器错误，滚动失败问题              |  Fix the issue where form.scrollToField in the `Form` component throws an invalid selector error and fails to scroll when targeting a field ID that starts with a number or contains special characters.             | https://github.com/arco-design/arco-design/issues/3029               |

<!-- If there are multiple types, you can add the Type column in the Changelog, the value of the column is the same as Types of changes -->
## Checklist:

- [ ] Test suite passes (npm run test)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to feature branch and others should be submitted to main branch)

## Other information
- isFromGitlab: true
- gitlabMRId: 906
- createdBy: lingyunsong

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
