### PR TITLE
fix(Menu):  修复ResizeObserver 回调内同步测量并更新 Menu 溢出状态，触发连续布局抖动，浏览器上报 loop error问题

### DIFF
--- a/components/Menu/overflow-wrap.tsx
+++ b/components/Menu/overflow-wrap.tsx
@@ -1,4 +1,12 @@
-import React, { useState, useRef, useContext, ReactElement, ReactNode } from 'react';
+import React, {
+  useState,
+  useRef,
+  useContext,
+  ReactElement,
+  ReactNode,
+  useCallback,
+  useEffect,
+} from 'react';
 import SubMenu from './sub-menu';
 import { getStyle } from '../_util/style';
 import MenuContext from './context';
@@ -30,6 +38,7 @@ const OverflowWrap = (props: OverflowWrapProps) => {
   const { prefixCls } = useContext(MenuContext);
 
   const refUl = useRef(null);
+  const resizeFrameRef = useRef<number>(null);
   const [lastVisibleIndex, setLastVisibleIndex] = useState(null);
 
   const overflowSubMenuClass = `${prefixCls}-overflow-sub-menu`;
@@ -48,7 +57,7 @@ const OverflowWrap = (props: OverflowWrapProps) => {
     }
   };
 
-  function computeLastVisibleIndex() {
+  const computeLastVisibleIndex = useCallback(() => {
     if (!refUl.current) {
       return;
     }
@@ -100,7 +109,27 @@ const OverflowWrap = (props: OverflowWrapProps) => {
 
     // 全部可见
     tryUpdateEllipsisStatus(null);
-  }
+  }, [children, lastVisibleIndex]);
+
+  const onResize = useCallback(() => {
+    if (resizeFrameRef.current) {
+      cancelAnimationFrame(resizeFrameRef.current);
+    }
+
+    resizeFrameRef.current = requestAnimationFrame(() => {
+      resizeFrameRef.current = null;
+      computeLastVisibleIndex();
+    });
+  }, [computeLastVisibleIndex]);
+
+  useEffect(() => {
+    return () => {
+      if (resizeFrameRef.current) {
+        cancelAnimationFrame(resizeFrameRef.current);
+        resizeFrameRef.current = null;
+      }
+    };
+  }, []);
 
   const renderOverflowSubMenu = (children, isMirror = false) => {
     return (
@@ -144,7 +173,7 @@ const OverflowWrap = (props: OverflowWrapProps) => {
   };
 
   return (
-    <ResizeObserver onResize={computeLastVisibleIndex} getTargetDOMNode={() => refUl.current}>
+    <ResizeObserver onResize={onResize} delayOnResizeByRaf getTargetDOMNode={() => refUl.current}>
       <div className={`${prefixCls}-overflow-wrap`} ref={refUl}>
         {renderChildren()}
       </div>

--- a/components/Menu/overflow-wrap.tsx
+++ b/components/Menu/overflow-wrap.tsx
@@ -1,12 +1,4 @@
-import React, {
-  useState,
-  useRef,
-  useContext,
-  ReactElement,
-  ReactNode,
-  useCallback,
-  useEffect,
-} from 'react';
+import React, { useState, useRef, useContext, ReactElement, ReactNode, useCallback } from 'react';
 import SubMenu from './sub-menu';
 import { getStyle } from '../_util/style';
 import MenuContext from './context';
@@ -15,6 +7,7 @@ import type { MenuProps } from './interface';
 import cs from '../_util/classNames';
 
 const OVERFLOW_THRESHOLD = 5;
+const WIDTH_CHANGE_THRESHOLD = 1;
 
 function getNodeWidth(node) {
   // getBoundingClientRect will get a result like 20.45
@@ -38,7 +31,7 @@ const OverflowWrap = (props: OverflowWrapProps) => {
   const { prefixCls } = useContext(MenuContext);
 
   const refUl = useRef(null);
-  const resizeFrameRef = useRef<number>(null);
+  const lastMeasuredWidthRef = useRef<number>(0);
   const [lastVisibleIndex, setLastVisibleIndex] = useState(null);
 
   const overflowSubMenuClass = `${prefixCls}-overflow-sub-menu`;
@@ -63,7 +56,18 @@ const OverflowWrap = (props: OverflowWrapProps) => {
     }
 
     const ulElement = refUl.current;
-    const maxWidth = getNodeWidth(ulElement) - OVERFLOW_THRESHOLD;
+    const currentWidth = getNodeWidth(ulElement);
+
+    if (
+      lastMeasuredWidthRef.current &&
+      Math.abs(currentWidth - lastMeasuredWidthRef.current) < WIDTH_CHANGE_THRESHOLD
+    ) {
+      return;
+    }
+
+    lastMeasuredWidthRef.current = currentWidth;
+
+    const maxWidth = currentWidth - OVERFLOW_THRESHOLD;
     const childNodeList = [].slice.call(ulElement.children);
 
     let menuItemIndex = 0;
@@ -111,26 +115,6 @@ const OverflowWrap = (props: OverflowWrapProps) => {
     tryUpdateEllipsisStatus(null);
   }, [children, lastVisibleIndex]);
 
-  const onResize = useCallback(() => {
-    if (resizeFrameRef.current) {
-      cancelAnimationFrame(resizeFrameRef.current);
-    }
-
-    resizeFrameRef.current = requestAnimationFrame(() => {
-      resizeFrameRef.current = null;
-      computeLastVisibleIndex();
-    });
-  }, [computeLastVisibleIndex]);
-
-  useEffect(() => {
-    return () => {
-      if (resizeFrameRef.current) {
-        cancelAnimationFrame(resizeFrameRef.current);
-        resizeFrameRef.current = null;
-      }
-    };
-  }, []);
-
   const renderOverflowSubMenu = (children, isMirror = false) => {
     return (
       <SubMenu
@@ -173,7 +157,11 @@ const OverflowWrap = (props: OverflowWrapProps) => {
   };
 
   return (
-    <ResizeObserver onResize={onResize} delayOnResizeByRaf getTargetDOMNode={() => refUl.current}>
+    <ResizeObserver
+      onResize={computeLastVisibleIndex}
+      delayOnResizeByRaf
+      getTargetDOMNode={() => refUl.current}
+    >
       <div className={`${prefixCls}-overflow-wrap`} ref={refUl}>
         {renderChildren()}
       </div>

--- a/components/_util/resizeObserver.tsx
+++ b/components/_util/resizeObserver.tsx
@@ -9,12 +9,17 @@ export interface ResizeProps {
   onResize?: (entry: ResizeObserverEntry[]) => void;
   children?: React.ReactNode;
   getTargetDOMNode?: () => any;
+  delayOnResizeByRaf?: boolean;
 }
 
 class ResizeObserverComponent extends React.Component<ResizeProps> {
   resizeObserver: ResizeObserver;
 
   rootDOMRef: any;
+
+  resizeFrameId: number;
+
+  latestEntry: ResizeObserverEntry[];
 
   getRootElement = () => {
     const { getTargetDOMNode } = this.props;
@@ -40,13 +45,17 @@ class ResizeObserverComponent extends React.Component<ResizeProps> {
   }
 
   componentWillUnmount = () => {
+    if (this.resizeFrameId) {
+      cancelAnimationFrame(this.resizeFrameId);
+      this.resizeFrameId = null;
+    }
     if (this.resizeObserver) {
       this.destroyResizeObserver();
     }
   };
 
   createResizeObserver = () => {
-    const { throttle = true } = this.props;
+    const { throttle = true, delayOnResizeByRaf = false } = this.props;
     const onResize = (entry) => {
       this.props.onResize?.(entry);
     };
@@ -59,6 +68,18 @@ class ResizeObserverComponent extends React.Component<ResizeProps> {
         firstExec = false;
         onResize(entry);
       }
+
+      if (delayOnResizeByRaf) {
+        this.latestEntry = entry;
+        if (!this.resizeFrameId) {
+          this.resizeFrameId = requestAnimationFrame(() => {
+            this.resizeFrameId = null;
+            resizeHandler(this.latestEntry);
+          });
+        }
+        return;
+      }
+
       resizeHandler(entry);
     });
     const targetNode = this.getRootElement();
@@ -68,6 +89,7 @@ class ResizeObserverComponent extends React.Component<ResizeProps> {
   destroyResizeObserver = () => {
     this.resizeObserver && this.resizeObserver.disconnect();
     this.resizeObserver = null;
+    this.latestEntry = null;
   };
 
   render() {


### PR DESCRIPTION

<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an x in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the Type column in the Changelog. -->

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context


<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

## Solution

### 缺陷摘要

- **问题现象**：Menu 在 `mode="pop"` 下调整窗口或菜单宽度时触发 `ResizeObserver loop completed with undelivered notifications`，ErrorBoundary 拦截后页面崩溃。
- **预期结果**：窗口尺寸或菜单宽度变化时不再触发 ResizeObserver 报错，页面保持可用。

### 复现与验证路径

创建 `mode="pop"` 的 Menu，菜单项数量接近容器宽度临界点。
1. 渲染 `components/Menu/__demo__/pop.md` 同类结构的 Menu。
2. 调整窗口大小或修改 Menu 容器宽度。
3. **验证点**：控制台无 `ResizeObserver loop completed with undelivered notifications`，ErrorBoundary 不触发。

### 问题诊断

- **根因分析**：ResizeObserver 回调内同步测量并更新 Menu 溢出状态，触发连续布局抖动，浏览器上报 loop error。
- **详细诊断**：
    * `components/Menu/overflow-wrap.tsx` 中：`computeLastVisibleIndex` 在 ResizeObserver 回调内同步读取宽度并执行 `setLastVisibleIndex`，宽度临界变化时反复触发重排。
    * `components/_util/resizeObserver.tsx` 中：observer 首次与后续回调都在当前通知周期内执行 `onResize`，未将易触发布局更新的逻辑延后到下一帧。

### 修复方案

- **解决思路**：将 Menu 溢出计算移出当前 ResizeObserver 通知周期，合并连续尺寸变化，避免测量与状态更新在同一轮观察中循环触发。
- **代码变更**：
    1. `components/Menu/overflow-wrap.tsx`
        - `onResize` → 帧级调度函数，使用 `requestAnimationFrame` 延后执行 `computeLastVisibleIndex`。
        - 增加卸载清理逻辑，取消待执行调度，避免销毁后继续更新状态。
    2. `components/_util/resizeObserver.tsx`
        - 增加可选的异步调度开关或帧级包装，供布局敏感场景跳出 ResizeObserver 当前循环。
        - 保持默认行为兼容，仅在 Menu 等指定场景启用延后回调。

<!-- Describe how the problem is fixed in detail -->

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|  Menu         | 修复ResizeObserver 回调内同步测量并更新 `Menu`溢出状态，触发连续布局抖动，浏览器上报 loop error问题              | Fix the issue that synchronously measuring and updating the `Menu` overflow state inside the ResizeObserver callback triggers continuous layout jitter and causes the browser to report a loop error.              | https://github.com/arco-design/arco-design/issues/3044               |

<!-- If there are multiple types, you can add the Type column in the Changelog, the value of the column is the same as Types of changes -->
## Checklist:

- [ ] Test suite passes (npm run test)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to feature branch and others should be submitted to main branch)

## Other information
- isFromGitlab: true
- gitlabMRId: 909
- createdBy: lingyunsong

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
