### PR TITLE
fix(Tree): 修复修复 Tree 在 Modal 中使用虚拟列表时，展开/关闭节点或 loadMore 完成后,由于VirtualList 数据变更后的滚动校准过度、旧虚拟窗口状态未及时重算，以及浏览器焦点/scroll anchoring 对虚拟 DOM 重排产生自动滚动补偿导致的滚动条跳动问题

### DIFF
--- a/components/List/__test__/__snapshots__/demo.test.ts.snap
+++ b/components/List/__test__/__snapshots__/demo.test.ts.snap
@@ -2592,10 +2592,10 @@ Array [
         style="overflow-y:auto;overflow-anchor:none;max-height:560px"
       >
         <div
-          style="height:320000px;position:relative;overflow:hidden;z-index:0"
+          style="height:320000px;position:relative;overflow:hidden;overflow-anchor:none;z-index:0"
         >
           <div
-            style="display:flex;flex-direction:column;transform:translateY(0px);position:absolute;left:0;right:0;top:0"
+            style="display:flex;flex-direction:column;overflow-anchor:none;transform:translateY(0px);position:absolute;left:0;right:0;top:0"
           >
             <div
               class="arco-list-item"

--- a/components/Table/__test__/__snapshots__/demo.test.ts.snap
+++ b/components/Table/__test__/__snapshots__/demo.test.ts.snap
@@ -16095,10 +16095,10 @@ exports[`renders Table/demo/virtualized.md correctly 1`] = `
                 style="overflow-y:auto;overflow-anchor:none;max-height:500px"
               >
                 <div
-                  style="height:3200000px;position:relative;overflow:visible;z-index:0;width:1000px;min-width:100%"
+                  style="height:3200000px;position:relative;overflow:visible;overflow-anchor:none;z-index:0;width:1000px;min-width:100%"
                 >
                   <div
-                    style="display:flex;flex-direction:column;transform:translateY(0px);position:absolute;left:0;right:auto;top:0;min-width:100%"
+                    style="display:flex;flex-direction:column;overflow-anchor:none;transform:translateY(0px);position:absolute;left:0;right:auto;top:0;min-width:100%"
                   >
                     <div
                       class="arco-table-tr"

--- a/components/Tree/__test__/__snapshots__/demo.test.ts.snap
+++ b/components/Tree/__test__/__snapshots__/demo.test.ts.snap
@@ -7592,10 +7592,10 @@ exports[`renders Tree/demo/virtual.md correctly 1`] = `
     tabindex="0"
   >
     <div
-      style="height:35520px;position:relative;overflow:hidden;z-index:0"
+      style="height:35520px;position:relative;overflow:hidden;overflow-anchor:none;z-index:0"
     >
       <div
-        style="display:flex;flex-direction:column;transform:translateY(0px);position:absolute;left:0;right:0;top:0"
+        style="display:flex;flex-direction:column;overflow-anchor:none;transform:translateY(0px);position:absolute;left:0;right:0;top:0"
       >
         <div
           aria-expanded="true"

--- a/components/Tree/__test__/case.test.tsx
+++ b/components/Tree/__test__/case.test.tsx
@@ -69,6 +69,13 @@ describe('Tree case', () => {
     expect(firstNode.textContent).toBe('+');
   });
 
+  it('does not focus switcher when clicking by mouse', () => {
+    const wrapper = render(<Tree treeData={TreeData} />);
+    const firstNode = wrapper.find(`.arco-tree-node-switcher-icon`).item(0);
+
+    expect(fireEvent.mouseDown(firstNode)).toBe(false);
+  });
+
   it('show child correctly', async () => {
     const data = [
       {

--- a/components/Tree/node.tsx
+++ b/components/Tree/node.tsx
@@ -128,6 +128,7 @@ function TreeNode(props: PropsWithChildren<NodeProps>, ref) {
           aria-label={expanded ? 'fold button' : 'expand button'}
           role="button"
           tabIndex={0}
+          onMouseDown={(e) => e.preventDefault()}
           onClick={switchExpandStatus}
         >
           {icon}

--- a/components/_class/VirtualList/Filler.tsx
+++ b/components/_class/VirtualList/Filler.tsx
@@ -25,6 +25,7 @@ const Filler: React.FC<FillerProps> = ({
   let innerStyle: React.CSSProperties = {
     display: 'flex',
     flexDirection: 'column',
+    overflowAnchor: 'none',
   };
 
   if (offset !== undefined) {
@@ -32,6 +33,7 @@ const Filler: React.FC<FillerProps> = ({
       height,
       position: 'relative',
       overflow: 'hidden',
+      overflowAnchor: 'none',
       zIndex: 0,
       ...propsOuterStyle,
     };
@@ -46,7 +48,7 @@ const Filler: React.FC<FillerProps> = ({
       ...propsInnerStyle,
     };
   } else {
-    outerStyle = { ...propsOuterStyle };
+    outerStyle = { overflowAnchor: 'none', ...propsOuterStyle };
     innerStyle = { ...innerStyle, ...propsInnerStyle };
   }
 

--- a/components/_class/VirtualList/__test__/index.test.tsx
+++ b/components/_class/VirtualList/__test__/index.test.tsx
@@ -3,10 +3,57 @@ import { fireEvent } from '@testing-library/dom';
 
 import VirtualList from '../index';
 import { requestAnimationFrameMock } from '../../../../tests/mockRAF';
-import { render, sleep } from '../../../../tests/util';
+import { act, render, sleep } from '../../../../tests/util';
 
 function getData(size: number) {
   return new Array(size).fill(null).map((_, index) => ({ content: `Content ${index}` }));
+}
+
+function getKeyedData(size: number) {
+  return new Array(size).fill(null).map((_, index) => ({
+    key: `item-${index}`,
+    content: `Content ${index}`,
+  }));
+}
+
+function mockElementSize() {
+  const descriptors = {
+    clientHeight: Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'clientHeight'),
+    scrollHeight: Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'scrollHeight'),
+    offsetHeight: Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'offsetHeight'),
+  };
+
+  Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
+    configurable: true,
+    get() {
+      return this.classList?.contains('virtual-list') ? 200 : 20;
+    },
+  });
+  Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+    configurable: true,
+    get() {
+      if (this.classList?.contains('virtual-list')) {
+        return parseInt((this.firstElementChild as HTMLElement)?.style.height, 10) || 0;
+      }
+      return 20;
+    },
+  });
+  Object.defineProperty(HTMLElement.prototype, 'offsetHeight', {
+    configurable: true,
+    get() {
+      return this.classList?.contains('list-item') ? 20 : 0;
+    },
+  });
+
+  return () => {
+    (Object.keys(descriptors) as Array<keyof typeof descriptors>).forEach((prop) => {
+      if (descriptors[prop]) {
+        Object.defineProperty(HTMLElement.prototype, prop, descriptors[prop]);
+      } else {
+        delete (HTMLElement.prototype as any)[prop];
+      }
+    });
+  };
 }
 
 describe('VirtualList', () => {
@@ -102,5 +149,153 @@ describe('VirtualList', () => {
 
     fireEvent.scroll(wrapper.querySelector(`.${className}`));
     expect(onScroll).toBeCalled();
+  });
+
+  it('keeps the visible keyed item stable when items are inserted before viewport', async () => {
+    const restoreElementSize = mockElementSize();
+
+    function Demo() {
+      const refList = useRef<any>(null);
+      const [data, setData] = useState(getKeyedData(200));
+      return (
+        <div>
+          <button
+            className="scroll-to-item"
+            onClick={() => {
+              refList.current?.scrollTo({ index: 84, options: { block: 'start' } });
+            }}
+          />
+          <button
+            className="insert-items"
+            onClick={() => {
+              setData([
+                ...data.slice(0, 20),
+                { key: 'insert-1', content: 'Insert 1' },
+                { key: 'insert-2', content: 'Insert 2' },
+                ...data.slice(20),
+              ]);
+            }}
+          />
+          <VirtualList
+            ref={refList}
+            className="virtual-list"
+            data={data}
+            height={200}
+            itemHeight={20}
+            itemKey="key"
+            isStaticItemHeight={false}
+            threshold={0}
+          >
+            {({ content }) => <div className="list-item">{content}</div>}
+          </VirtualList>
+        </div>
+      );
+    }
+
+    try {
+      const wrapper = render(<Demo />);
+      const list = wrapper.container.querySelector('.virtual-list') as HTMLElement;
+
+      await act(async () => {
+        await sleep(0);
+      });
+
+      act(() => {
+        fireEvent.click(wrapper.container.querySelector('.scroll-to-item'));
+        requestAnimationFrameMock.triggerAllAnimationFrames();
+      });
+      await act(async () => {
+        await sleep(100);
+      });
+
+      expect(wrapper.container.querySelector('.list-item')).toHaveTextContent('Content 83');
+      const prevScrollTop = list.scrollTop;
+
+      act(() => {
+        fireEvent.click(wrapper.container.querySelector('.insert-items'));
+      });
+      await act(async () => {
+        await sleep(0);
+      });
+
+      expect(list.scrollTop).toBeGreaterThan(prevScrollTop);
+      expect(wrapper.container.querySelector('.list-item')).toHaveTextContent('Content 83');
+    } finally {
+      restoreElementSize();
+    }
+  });
+
+  it('does not adjust scrollTop when items are inserted inside viewport', async () => {
+    const restoreElementSize = mockElementSize();
+
+    function Demo() {
+      const refList = useRef<any>(null);
+      const [data, setData] = useState(getKeyedData(200));
+      return (
+        <div>
+          <button
+            className="scroll-to-item"
+            onClick={() => {
+              refList.current?.scrollTo({ index: 84, options: { block: 'start' } });
+            }}
+          />
+          <button
+            className="insert-items"
+            onClick={() => {
+              setData([
+                ...data.slice(0, 85),
+                { key: 'insert-1', content: 'Insert 1' },
+                { key: 'insert-2', content: 'Insert 2' },
+                ...data.slice(85),
+              ]);
+            }}
+          />
+          <VirtualList
+            ref={refList}
+            className="virtual-list"
+            data={data}
+            height={200}
+            itemHeight={20}
+            itemKey="key"
+            isStaticItemHeight={false}
+            threshold={0}
+          >
+            {({ content }) => <div className="list-item">{content}</div>}
+          </VirtualList>
+        </div>
+      );
+    }
+
+    try {
+      const wrapper = render(<Demo />);
+      const list = wrapper.container.querySelector('.virtual-list') as HTMLElement;
+
+      await act(async () => {
+        await sleep(0);
+      });
+
+      act(() => {
+        fireEvent.click(wrapper.container.querySelector('.scroll-to-item'));
+        requestAnimationFrameMock.triggerAllAnimationFrames();
+      });
+      await act(async () => {
+        await sleep(100);
+      });
+
+      expect(wrapper.container.querySelector('.list-item')).toHaveTextContent('Content 83');
+      const prevScrollTop = list.scrollTop;
+
+      act(() => {
+        fireEvent.click(wrapper.container.querySelector('.insert-items'));
+      });
+      await act(async () => {
+        await sleep(0);
+      });
+
+      expect(list.scrollTop).toBe(prevScrollTop);
+      expect(wrapper.container.querySelector('.list-item')).toHaveTextContent('Content 83');
+    } finally {
+      restoreElementSize();
+    }
   });
 });

--- a/components/_class/VirtualList/index.tsx
+++ b/components/_class/VirtualList/index.tsx
@@ -254,6 +254,10 @@ const VirtualList: React.ForwardRefExoticComponent<
     return item !== undefined ? getItemKey(item, index) : null;
   };
 
+  const getItemIndexByKey = (key: Key): number => {
+    return data.findIndex((item, index) => getItemKey(item, index) === key);
+  };
+
   const getCachedItemHeight = (key: Key): number => {
     return refItemHeightMap.current[key] || itemHeight;
   };
@@ -422,6 +426,7 @@ const VirtualList: React.ForwardRefExoticComponent<
     if (!refList.current) return;
 
     let changedItemIndex: number = null;
+    let locatedItemIndex = state.itemIndex;
     const switchTo = refIsVirtual.current !== isVirtual ? (isVirtual ? 'virtual' : 'raw') : '';
 
     refIsVirtual.current = isVirtual;
@@ -431,8 +436,18 @@ const VirtualList: React.ForwardRefExoticComponent<
       changedItemIndex = diff ? diff.index : null;
     }
 
+    const locatedItemKey = getItemKeyByIndex(state.itemIndex, prevData);
+    if (locatedItemKey && locatedItemKey !== GHOST_ITEM_KEY) {
+      const nextIndex = getItemIndexByKey(locatedItemKey);
+      locatedItemIndex = nextIndex > -1 ? nextIndex : Math.min(locatedItemIndex, itemCount - 1);
+    }
+
+    const dataLengthChanged = changedItemIndex !== null;
+    const shouldCorrectScroll =
+      switchTo || (isVirtual && dataLengthChanged && changedItemIndex <= state.startIndex);
+
     // No need to correct the position when the number of elements in the real list changes
-    if (switchTo || (isVirtual && changedItemIndex)) {
+    if (shouldCorrectScroll) {
       const { clientHeight } = refList.current;
       const locatedItemRelativeTop = getItemRelativeTop({
         itemHeight: getCachedItemHeight(getItemKeyByIndex(state.itemIndex, prevData)),
@@ -447,7 +462,7 @@ const VirtualList: React.ForwardRefExoticComponent<
 
       if (switchTo === 'raw') {
         let rawTop = locatedItemRelativeTop;
-        for (let index = 0; index < state.itemIndex; index++) {
+        for (let index = 0; index < locatedItemIndex; index++) {
           rawTop -= getCachedItemHeight(getItemKeyByIndex(index));
         }
 
@@ -458,10 +473,12 @@ const VirtualList: React.ForwardRefExoticComponent<
         });
       } else {
         internalScrollTo({
-          itemIndex: state.itemIndex,
+          itemIndex: locatedItemIndex,
           relativeTop: locatedItemRelativeTop,
         });
       }
+    } else if (isVirtual && dataLengthChanged) {
+      virtualListScrollHandler(null, true);
     }
   }, [data, isVirtual]);
 


### PR DESCRIPTION
…List 数据变更后的滚动校准过度、旧虚拟窗口状态未及时重算，以及浏览器焦点/scroll anchoring 对虚拟 DOM 重排产生自动滚动补偿导致的滚动条跳动问题

<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context

<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

## Solution
## 复现步骤
1. 创建Modal，内部包含Tree组件，开启虚拟滚动 virtualListProps
2. Tree包含多层级节点，节点数量较多，包含loadMore
3. 滚动Tree到任意位置
4. 展开某个节点，等子节点加载完成
5. 继续滚动，观察到滚动条上下跳动，位置不稳定
6. 向下滚动很长距离，展开某个节点，等子节点加载完成，向上可能滚动很短距离就到顶了

## 根因
Tree 虚拟滚动底层使用 `components/_class/VirtualList`。节点展开/收起或 `loadMore` 完成后，Tree 的可见节点列表会发生插入/删除，`VirtualList` 会在 `data.length` 变化时主动校准滚动位置。

原逻辑存在以下问题：

1. 校准条件过宽：只要虚拟列表数据长度变化且 diff index 非空，就会调用 `internalScrollTo` 重新设置 `scrollTop`。Tree 展开当前视口内节点时，首屏内容本身没有跳动，只有列表中部的内部定位项受到插入影响；此时继续校准会额外拨动滚动条，所以表现为“元素位置是对的，但滚动条抽搐”。
2. 视口内数据变化时完全跳过校准会留下旧的虚拟窗口状态，下一次滚动才按新数据总高度重算，容易在滚动过程中出现一次补偿式跳动。
3. 锚点使用旧 index：当数据在视口上方插入/删除时，原先可见的节点在新数组中的 index 会变化。旧逻辑继续用 `state.itemIndex` 作为新列表定位项，可能锚到错误节点；并且 diff index 为 `0` 时会被 falsy 判断跳过校准。
4. 鼠标点击 Tree 展开按钮时，`tabIndex=0` 的 switcher 会获得焦点。虚拟列表滚动重排并移除视口外节点时，浏览器会尝试维护焦点/滚动锚点位置，导致 `scrollTop` 被浏览器回调一次，进一步放大滚动条跳动。

## 修复方案
在 `VirtualList` 的数据变更校准逻辑中：

1. 通过旧数据中的定位项 key 在新数据里重新找到 index，避免插入/删除后锚点漂移。
2. 只有当变化发生在当前渲染窗口起点之前或列表虚拟/普通模式切换时，才主动校准 `scrollTop`。如果变化发生在当前视口内部，保持现有 `scrollTop`，但立即按当前 `scrollTop` 重算虚拟窗口，避免下一次滚动再补偿。
3. 将 `changedItemIndex` 的判断改为显式 `!== null`，确保首项变化也能按需处理。
4. 在虚拟列表 Filler 子树上显式设置 `overflowAnchor: 'none'`，排除浏览器 scroll anchoring 对虚拟 DOM 增删的自动补偿。
5. Tree switcher 的鼠标按下事件调用 `preventDefault`，避免鼠标点击展开按钮时抢占焦点；键盘用户仍可通过 `tabIndex` 聚焦并操作。

## 验证方法
修复后测试：
1. 在Modal中使用Tree虚拟列表，展开/关闭节点后滚动正常，没有跳动
2. 滚动到任意位置展开节点，可视内容保持稳定
3. Modal打开/关闭后Tree滚动功能正常
4. 快速多次展开/关闭节点，不会出现滚动条抽搐，上下滚动，滚动条位置不抽搐
<!-- Describe how the problem is fixed in detail -->

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
| Tree          |  修复修复 `Tree` 在 Modal 中使用虚拟列表时，展开/关闭节点或 loadMore 完成后,由于VirtualList 数据变更后的滚动校准过度、旧虚拟窗口状态未及时重算，以及浏览器焦点/scroll anchoring 对虚拟 DOM 重排产生自动滚动补偿导致的滚动条跳动问题             | Fix the scrollbar jitter issue of `Tree` when using the virtual list inside Modal. After expanding/collapsing nodes or completing loadMore, the problem occurs due to excessive scroll calibration after VirtualList data changes, untimely recalculation of the old virtual viewport state, and automatic scroll compensation caused by browser focus and scroll anchoring affecting virtual DOM reflow.              | https://github.com/arco-design/arco-design/issues/3034               |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->
## Checklist:

- [ ] Test suite passes (`npm run test`)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
