### PR TITLE
fix(Image): 修复Image.Preview 弹出层关闭按钮点击事件冒泡，导致误触发父元素的click事件的问题

### DIFF
--- a/components/Image/__test__/preview.test.tsx
+++ b/components/Image/__test__/preview.test.tsx
@@ -197,6 +197,25 @@ describe('Image', () => {
     expect(mockVisibleChange.mock.calls[0]).toEqual([false, true]);
   });
 
+  it('should not trigger parent click event when click close button', () => {
+    const mockParentClick = jest.fn();
+    const mockVisibleChange = jest.fn();
+    const wrapper = render(
+      <div onClick={mockParentClick}>
+        <Image.Preview src={imgSrc} onVisibleChange={mockVisibleChange} defaultVisible />
+      </div>
+    );
+
+    jest.runAllTimers();
+
+    act(() => {
+      fireEvent.click(wrapper.find('.arco-image-preview-close-btn')[0]);
+    });
+
+    expect(mockVisibleChange.mock.calls[0]).toEqual([false, true]);
+    expect(mockParentClick).toHaveBeenCalledTimes(0);
+  });
+
   it('handle maskClosable prop correctly', () => {
     const mockVisibleChange = jest.fn();
     const wrapper = render(

--- a/components/Image/image-preview.tsx
+++ b/components/Image/image-preview.tsx
@@ -8,6 +8,7 @@ import React, {
   useCallback,
   useMemo,
   WheelEvent,
+  MouseEvent,
 } from 'react';
 import ArcoCSSTransition from '../_util/CSSTransition';
 import { findDOMNode } from '../_util/react-dom';
@@ -255,7 +256,8 @@ function Preview(baseProps: ImagePreviewProps, ref) {
   }
 
   // Close button is clicked.
-  function onCloseClick() {
+  function onCloseClick(e: MouseEvent<HTMLDivElement>) {
+    e.stopPropagation();
     close();
   }
 


### PR DESCRIPTION

<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an x in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the Type column in the Changelog. -->

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context


<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

## Solution

### 缺陷摘要

- **问题现象**：点击 `Image.Preview` 右上角关闭按钮时会冒泡到外层容器，误触发父元素 `onClick`。
- **预期结果**：点击预览关闭按钮只关闭预览，不触发父元素事件。

### 复现与验证路径

1. 点击“查看图片”按钮打开 `Image.Preview`
2. 点击预览右上角关闭按钮
3. **验证点**：预览关闭且控制台不打印父元素点击日志

### 问题诊断

- **根因分析**：关闭按钮点击事件未拦截冒泡，Portal 内点击继续冒泡到触发预览的父节点。
- **详细诊断**：
    * `components/Image/image-preview.tsx` 中：`onCloseClick` 只调用 `close()`，未执行 `stopPropagation`，关闭按钮事件会继续向上冒泡。
    * `components/Image/__test__/preview.test.tsx` 中：现有关闭测试只校验 `onVisibleChange`，未覆盖父元素点击误触发场景。

### 修复方案

- **解决思路**：在关闭按钮点击链路拦截冒泡，并补充回归测试锁定父元素点击场景。
- **代码变更**：
    1. `components/Image/image-preview.tsx`
        - `onCloseClick` 入参增加事件对象
        - 关闭前调用 `e.stopPropagation()` 阻断冒泡
    2. `components/Image/__test__/preview.test.tsx`
        - 新增父容器 `onClick` + `Image.Preview` 组合用例
        - 断言点击 `.arco-image-preview-close-btn` 后只触发关闭，不触发父元素回调


<!-- Describe how the problem is fixed in detail -->

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|  Image         | 修复 `Image.Preview` 弹出层关闭按钮点击事件冒泡，导致误触发父元素的click事件的问题              | Fix the issue where the click event of the close button in the `Image.Preview` popup bubbles up, causing the parent element's click event to be triggered mistakenly.              | https://github.com/arco-design/arco-design/issues/3046               |

<!-- If there are multiple types, you can add the Type column in the Changelog, the value of the column is the same as Types of changes -->
## Checklist:

- [ ] Test suite passes (npm run test)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to feature branch and others should be submitted to main branch)

## Other information
- isFromGitlab: true
- gitlabMRId: 912
- createdBy: lingyunsong

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
